### PR TITLE
Batch 2: företagsspecifika kedjehuvuden

### DIFF
--- a/app/src/main/groovy/se/alipsa/accounting/service/AuditLogService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/AuditLogService.groovy
@@ -104,56 +104,66 @@ final class AuditLogService {
   List<String> validateIntegrity() {
     databaseService.withSql { Sql sql ->
       List<String> problems = []
-      String expectedPreviousHash = null
-      String actualLastHash = null
-      sql.rows('''
-          select id,
-                 event_type as eventType,
-                 voucher_id as voucherId,
-                 attachment_id as attachmentId,
-                 fiscal_year_id as fiscalYearId,
-                 accounting_period_id as accountingPeriodId,
-                 vat_period_id as vatPeriodId,
-                 actor,
-                 summary,
-                 details,
-                 previous_hash as previousHash,
-                 entry_hash as entryHash,
-                 created_at as createdAt
-            from audit_log
-           order by id
-      ''').each { GroovyRowResult row ->
-        AuditLogEntry entry = mapEntry(row)
-        if (entry.previousHash != expectedPreviousHash) {
-          problems << ("Auditlogg ${entry.id} har fel föregående hash." as String)
-        }
-        String calculated = calculateHash(new AuditEntrySeed(
-            eventType: entry.eventType,
-            voucherId: entry.voucherId,
-            attachmentId: entry.attachmentId,
-            fiscalYearId: entry.fiscalYearId,
-            accountingPeriodId: entry.accountingPeriodId,
-            vatPeriodId: entry.vatPeriodId,
-            actor: entry.actor,
-            summary: entry.summary,
-            details: entry.details,
-            previousHash: entry.previousHash,
-            createdAt: entry.createdAt
-        ))
-        if (entry.entryHash != calculated) {
-          problems << ("Auditlogg ${entry.id} har ogiltig hash." as String)
-        }
-        expectedPreviousHash = entry.entryHash
-        actualLastHash = entry.entryHash
-      }
-      AuditChainHead chainHead = loadChainHead(sql)
-      if (chainHead == null) {
-        problems << 'Auditloggkedjans huvud saknas.'
-      } else if (chainHead.lastEntryHash != actualLastHash) {
-        problems << 'Auditloggkedjans huvud pekar inte på sista auditraden.'
+      sql.rows('select distinct company_id as companyId from audit_log').each { GroovyRowResult companyRow ->
+        long companyId = ((Number) companyRow.get('companyId')).longValue()
+        problems.addAll(validateIntegrityForCompany(sql, companyId))
       }
       problems
     }
+  }
+
+  private static List<String> validateIntegrityForCompany(Sql sql, long companyId) {
+    List<String> problems = []
+    String expectedPreviousHash = null
+    String actualLastHash = null
+    sql.rows('''
+        select id,
+               event_type as eventType,
+               voucher_id as voucherId,
+               attachment_id as attachmentId,
+               fiscal_year_id as fiscalYearId,
+               accounting_period_id as accountingPeriodId,
+               vat_period_id as vatPeriodId,
+               actor,
+               summary,
+               details,
+               previous_hash as previousHash,
+               entry_hash as entryHash,
+               created_at as createdAt
+          from audit_log
+         where company_id = ?
+         order by id
+    ''', [companyId]).each { GroovyRowResult row ->
+      AuditLogEntry entry = mapEntry(row)
+      if (entry.previousHash != expectedPreviousHash) {
+        problems << ("Auditlogg ${entry.id} har fel föregående hash." as String)
+      }
+      String calculated = calculateHash(new AuditEntrySeed(
+          eventType: entry.eventType,
+          voucherId: entry.voucherId,
+          attachmentId: entry.attachmentId,
+          fiscalYearId: entry.fiscalYearId,
+          accountingPeriodId: entry.accountingPeriodId,
+          vatPeriodId: entry.vatPeriodId,
+          actor: entry.actor,
+          summary: entry.summary,
+          details: entry.details,
+          previousHash: entry.previousHash,
+          createdAt: entry.createdAt
+      ))
+      if (entry.entryHash != calculated) {
+        problems << ("Auditlogg ${entry.id} har ogiltig hash." as String)
+      }
+      expectedPreviousHash = entry.entryHash
+      actualLastHash = entry.entryHash
+    }
+    AuditChainHead chainHead = loadChainHead(sql, companyId)
+    if (chainHead == null) {
+      problems << 'Auditloggkedjans huvud saknas.'
+    } else if (chainHead.lastEntryHash != actualLastHash) {
+      problems << 'Auditloggkedjans huvud pekar inte på sista auditraden.'
+    }
+    problems
   }
 
   AuditLogEntry logImport(String summary, String details = null) {
@@ -297,7 +307,8 @@ final class AuditLogService {
     String safeEventType = requireText(eventType, 'Audit event type')
     String safeSummary = requireText(summary, 'Audit summary')
     AuditReferences safeReferences = references ?: AuditReferences.EMPTY
-    AuditChainHead chainHead = lockChainHead(sql)
+    long companyId = resolveCompanyId(sql, safeReferences)
+    AuditChainHead chainHead = lockChainHead(sql, companyId)
     AuditEntrySeed seed = new AuditEntrySeed(
         eventType: safeEventType,
         voucherId: safeReferences.voucherId,
@@ -325,8 +336,9 @@ final class AuditLogService {
             details,
             previous_hash,
             entry_hash,
-            created_at
-        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            created_at,
+            company_id
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ''', [
         seed.eventType,
         seed.voucherId,
@@ -339,10 +351,11 @@ final class AuditLogService {
         seed.details,
         seed.previousHash,
         entryHash,
-        Timestamp.valueOf(seed.createdAt)
+        Timestamp.valueOf(seed.createdAt),
+        companyId
     ])
     long id = ((Number) keys.first().first()).longValue()
-    updateChainHead(sql, entryHash)
+    updateChainHead(sql, companyId, entryHash)
     findById(sql, id)
   }
 
@@ -373,35 +386,66 @@ final class AuditLogService {
     row == null ? null : mapEntry(row)
   }
 
-  private static AuditChainHead lockChainHead(Sql sql) {
+  private static Long resolveCompanyId(Sql sql, AuditReferences references) {
+    if (references.voucherId != null) {
+      GroovyRowResult row = sql.firstRow(
+          'select company_id as companyId from voucher where id = ?',
+          [references.voucherId]
+      ) as GroovyRowResult
+      if (row != null) {
+        return ((Number) row.get('companyId')).longValue()
+      }
+    }
+    if (references.fiscalYearId != null) {
+      GroovyRowResult row = sql.firstRow(
+          'select company_id as companyId from fiscal_year where id = ?',
+          [references.fiscalYearId]
+      ) as GroovyRowResult
+      if (row != null) {
+        return ((Number) row.get('companyId')).longValue()
+      }
+    }
+    if (references.attachmentId != null) {
+      GroovyRowResult row = sql.firstRow(
+          'select company_id as companyId from attachment where id = ?',
+          [references.attachmentId]
+      ) as GroovyRowResult
+      if (row != null) {
+        return ((Number) row.get('companyId')).longValue()
+      }
+    }
+    CompanyService.LEGACY_COMPANY_ID
+  }
+
+  private static AuditChainHead lockChainHead(Sql sql, long companyId) {
     GroovyRowResult row = sql.firstRow('''
         select last_entry_hash as lastEntryHash
           from audit_log_chain_head
-         where id = 1
+         where company_id = ?
          for update
-    ''') as GroovyRowResult
+    ''', [companyId]) as GroovyRowResult
     if (row == null) {
       throw new IllegalStateException('Kedjehuvudet för audit-loggen saknas.')
     }
     new AuditChainHead(row.get('lastEntryHash') as String)
   }
 
-  private static AuditChainHead loadChainHead(Sql sql) {
+  private static AuditChainHead loadChainHead(Sql sql, long companyId) {
     GroovyRowResult row = sql.firstRow('''
         select last_entry_hash as lastEntryHash
           from audit_log_chain_head
-         where id = 1
-    ''') as GroovyRowResult
+         where company_id = ?
+    ''', [companyId]) as GroovyRowResult
     row == null ? null : new AuditChainHead(row.get('lastEntryHash') as String)
   }
 
-  private static void updateChainHead(Sql sql, String entryHash) {
+  private static void updateChainHead(Sql sql, long companyId, String entryHash) {
     int updated = sql.executeUpdate('''
         update audit_log_chain_head
            set last_entry_hash = ?,
                updated_at = current_timestamp
-         where id = 1
-    ''', [entryHash])
+         where company_id = ?
+    ''', [entryHash, companyId])
     if (updated != 1) {
       throw new IllegalStateException('Kedjehuvudet för audit-loggen kunde inte uppdateras.')
     }

--- a/app/src/main/groovy/se/alipsa/accounting/service/AuditLogService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/AuditLogService.groovy
@@ -166,20 +166,20 @@ final class AuditLogService {
     problems
   }
 
-  AuditLogEntry logImport(String summary, String details = null) {
-    recordStandaloneEvent(IMPORT, summary, details)
+  AuditLogEntry logImport(String summary, String details = null, long companyId = CompanyService.LEGACY_COMPANY_ID) {
+    recordStandaloneEvent(IMPORT, summary, details, companyId)
   }
 
-  AuditLogEntry logExport(String summary, String details = null) {
-    recordStandaloneEvent(EXPORT, summary, details)
+  AuditLogEntry logExport(String summary, String details = null, long companyId = CompanyService.LEGACY_COMPANY_ID) {
+    recordStandaloneEvent(EXPORT, summary, details, companyId)
   }
 
-  AuditLogEntry logBackup(String summary, String details = null) {
-    recordStandaloneEvent(BACKUP, summary, details)
+  AuditLogEntry logBackup(String summary, String details = null, long companyId = CompanyService.LEGACY_COMPANY_ID) {
+    recordStandaloneEvent(BACKUP, summary, details, companyId)
   }
 
-  AuditLogEntry logRestore(String summary, String details = null) {
-    recordStandaloneEvent(RESTORE, summary, details)
+  AuditLogEntry logRestore(String summary, String details = null, long companyId = CompanyService.LEGACY_COMPANY_ID) {
+    recordStandaloneEvent(RESTORE, summary, details, companyId)
   }
 
   @PackageScope
@@ -302,12 +302,13 @@ final class AuditLogService {
       String eventType,
       AuditReferences references,
       String summary,
-      String details
+      String details,
+      Long explicitCompanyId = null
   ) {
     String safeEventType = requireText(eventType, 'Audit event type')
     String safeSummary = requireText(summary, 'Audit summary')
     AuditReferences safeReferences = references ?: AuditReferences.EMPTY
-    long companyId = resolveCompanyId(sql, safeReferences)
+    long companyId = explicitCompanyId ?: resolveCompanyId(sql, safeReferences)
     AuditChainHead chainHead = lockChainHead(sql, companyId)
     AuditEntrySeed seed = new AuditEntrySeed(
         eventType: safeEventType,
@@ -359,9 +360,9 @@ final class AuditLogService {
     findById(sql, id)
   }
 
-  private AuditLogEntry recordStandaloneEvent(String eventType, String summary, String details) {
+  private AuditLogEntry recordStandaloneEvent(String eventType, String summary, String details, long companyId) {
     databaseService.withTransaction { Sql sql ->
-      recordEvent(sql, eventType, AuditReferences.EMPTY, summary, details)
+      recordEvent(sql, eventType, AuditReferences.EMPTY, summary, details, companyId)
     }
   }
 

--- a/app/src/main/groovy/se/alipsa/accounting/service/BackupService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/BackupService.groovy
@@ -105,7 +105,8 @@ final class BackupService {
               "attachments=${summary.attachmentCount}",
               "reports=${summary.reportCount}",
               "checksum=${summary.checksumSha256}"
-          ].join('\n')
+          ].join('\n'),
+          CompanyService.LEGACY_COMPANY_ID
       )
       new BackupResult(summary, [])
     } finally {
@@ -134,7 +135,8 @@ final class BackupService {
       if (safeHome == AppPaths.applicationHome()) {
         new AuditLogService().logRestore(
             "Backup återställd: ${safeBackup.fileName}",
-            "path=${safeBackup.toAbsolutePath()}\nschemaVersion=${manifest.schemaVersion}"
+            "path=${safeBackup.toAbsolutePath()}\nschemaVersion=${manifest.schemaVersion}",
+            CompanyService.LEGACY_COMPANY_ID
         )
       }
       new RestoreResult(

--- a/app/src/main/groovy/se/alipsa/accounting/service/CompanyService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/CompanyService.groovy
@@ -111,6 +111,14 @@ final class CompanyService {
         company.active
     ])
     long companyId = ((Number) keys.first().first()).longValue()
+    sql.executeInsert('''
+        insert into voucher_chain_head (company_id, last_content_hash, updated_at)
+        values (?, null, current_timestamp)
+    ''', [companyId])
+    sql.executeInsert('''
+        insert into audit_log_chain_head (company_id, last_entry_hash, updated_at)
+        values (?, null, current_timestamp)
+    ''', [companyId])
     findById(sql, companyId)
   }
 

--- a/app/src/main/groovy/se/alipsa/accounting/service/DatabaseService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/DatabaseService.groovy
@@ -37,7 +37,8 @@ final class DatabaseService {
       new MigrationDefinition(10, 'V10__report_archive.sql', '/db/migrations/V10__report_archive.sql'),
       new MigrationDefinition(11, 'V11__import_job.sql', '/db/migrations/V11__import_job.sql'),
       new MigrationDefinition(12, 'V12__closing_entry.sql', '/db/migrations/V12__closing_entry.sql'),
-      new MigrationDefinition(13, 'V13__multi_company_foundation.sql', '/db/migrations/V13__multi_company_foundation.sql')
+      new MigrationDefinition(13, 'V13__multi_company_foundation.sql', '/db/migrations/V13__multi_company_foundation.sql'),
+      new MigrationDefinition(14, 'V14__company_chain_heads.sql', '/db/migrations/V14__company_chain_heads.sql')
   ]
 
   static DatabaseService newForTesting() {

--- a/app/src/main/groovy/se/alipsa/accounting/service/JournoReportService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/JournoReportService.groovy
@@ -1,5 +1,8 @@
 package se.alipsa.accounting.service
 
+import groovy.sql.GroovyRowResult
+import groovy.sql.Sql
+
 import se.alipsa.accounting.domain.CompanySettings
 import se.alipsa.accounting.domain.report.ReportArchive
 import se.alipsa.accounting.domain.report.ReportResult
@@ -17,6 +20,7 @@ final class JournoReportService {
   private final ReportIntegrityService reportIntegrityService
   private final CompanySettingsService companySettingsService
   private final AuditLogService auditLogService
+  private final DatabaseService databaseService
 
   JournoReportService() {
     this(
@@ -24,7 +28,8 @@ final class JournoReportService {
         new ReportArchiveService(),
         new ReportIntegrityService(),
         new CompanySettingsService(),
-        new AuditLogService()
+        new AuditLogService(),
+        DatabaseService.instance
     )
   }
 
@@ -33,13 +38,15 @@ final class JournoReportService {
       ReportArchiveService reportArchiveService,
       ReportIntegrityService reportIntegrityService,
       CompanySettingsService companySettingsService,
-      AuditLogService auditLogService
+      AuditLogService auditLogService,
+      DatabaseService databaseService
   ) {
     this.reportDataService = reportDataService
     this.reportArchiveService = reportArchiveService
     this.reportIntegrityService = reportIntegrityService
     this.companySettingsService = companySettingsService
     this.auditLogService = auditLogService
+    this.databaseService = databaseService
   }
 
   ReportResult preview(ReportSelection selection) {
@@ -71,9 +78,11 @@ final class JournoReportService {
         'PDF',
         pdf
     )
+    long companyId = resolveCompanyId(report.fiscalYearId)
     auditLogService.logExport(
         "PDF-rapport skapad: ${report.reportType.displayName}",
-        "archiveId=${archive.id}\nchecksumSha256=${archive.checksumSha256}\nstoragePath=${archive.storagePath}"
+        "archiveId=${archive.id}\nchecksumSha256=${archive.checksumSha256}\nstoragePath=${archive.storagePath}",
+        companyId
     )
     archive
   }
@@ -85,6 +94,19 @@ final class JournoReportService {
         organizationNumber: settings?.organizationNumber ?: '',
         report            : report
     ] + report.templateModel
+  }
+
+  private long resolveCompanyId(long fiscalYearId) {
+    databaseService.withSql { Sql sql ->
+      GroovyRowResult row = sql.firstRow(
+          'select company_id as companyId from fiscal_year where id = ?',
+          [fiscalYearId]
+      ) as GroovyRowResult
+      if (row == null) {
+        throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
+      }
+      ((Number) row.get('companyId')).longValue()
+    }
   }
 
   private static JournoEngine createJournoEngine() {

--- a/app/src/main/groovy/se/alipsa/accounting/service/ReportExportService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/ReportExportService.groovy
@@ -1,5 +1,8 @@
 package se.alipsa.accounting.service
 
+import groovy.sql.GroovyRowResult
+import groovy.sql.Sql
+
 import se.alipsa.accounting.domain.report.ReportArchive
 import se.alipsa.accounting.domain.report.ReportResult
 import se.alipsa.accounting.domain.report.ReportSelection
@@ -16,13 +19,15 @@ final class ReportExportService {
   private final ReportArchiveService reportArchiveService
   private final ReportIntegrityService reportIntegrityService
   private final AuditLogService auditLogService
+  private final DatabaseService databaseService
 
   ReportExportService() {
     this(
         new ReportDataService(),
         new ReportArchiveService(),
         new ReportIntegrityService(),
-        new AuditLogService()
+        new AuditLogService(),
+        DatabaseService.instance
     )
   }
 
@@ -30,12 +35,14 @@ final class ReportExportService {
       ReportDataService reportDataService,
       ReportArchiveService reportArchiveService,
       ReportIntegrityService reportIntegrityService,
-      AuditLogService auditLogService
+      AuditLogService auditLogService,
+      DatabaseService databaseService
   ) {
     this.reportDataService = reportDataService
     this.reportArchiveService = reportArchiveService
     this.reportIntegrityService = reportIntegrityService
     this.auditLogService = auditLogService
+    this.databaseService = databaseService
   }
 
   ReportResult preview(ReportSelection selection) {
@@ -64,11 +71,26 @@ final class ReportExportService {
         'CSV',
         csv
     )
+    long companyId = resolveCompanyId(report.fiscalYearId)
     auditLogService.logExport(
         "CSV-rapport exporterad: ${report.reportType.displayName}",
-        "archiveId=${archive.id}\nchecksumSha256=${archive.checksumSha256}\nstoragePath=${archive.storagePath}"
+        "archiveId=${archive.id}\nchecksumSha256=${archive.checksumSha256}\nstoragePath=${archive.storagePath}",
+        companyId
     )
     archive
+  }
+
+  private long resolveCompanyId(long fiscalYearId) {
+    databaseService.withSql { Sql sql ->
+      GroovyRowResult row = sql.firstRow(
+          'select company_id as companyId from fiscal_year where id = ?',
+          [fiscalYearId]
+      ) as GroovyRowResult
+      if (row == null) {
+        throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
+      }
+      ((Number) row.get('companyId')).longValue()
+    }
   }
 
   private static String escapeCsv(String value) {

--- a/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
@@ -102,6 +102,7 @@ final class SieImportExportService {
         )
         new SieImportResult(job, fiscalYear, false, counts.accountsCreated, counts.openingBalanceCount, counts.voucherCount, counts.lineCount, parsed.warnings)
       }
+      long companyId = resolveCompanyId(result.fiscalYear.id)
       auditLogService.logImport(
           "Importerade SIE ${result.job.fileName}",
           [
@@ -109,7 +110,8 @@ final class SieImportExportService {
               "fiscalYearId=${result.job.fiscalYearId}",
               "checksum=${result.job.checksumSha256}",
               "summary=${result.job.summary}"
-          ].join('\n')
+          ].join('\n'),
+          companyId
       )
       result
     } catch (Exception exception) {
@@ -128,6 +130,7 @@ final class SieImportExportService {
     Files.createDirectories(safeTarget.parent)
     Files.write(safeTarget, content)
     String checksum = sha256(content)
+    long companyId = resolveCompanyId(payload.fiscalYear.id)
     auditLogService.logExport(
         "Exporterade SIE ${payload.fiscalYear.name}",
         [
@@ -137,7 +140,8 @@ final class SieImportExportService {
             "accounts=${payload.accountCount}",
             "openingBalances=${payload.openingBalanceCount}",
             "vouchers=${payload.voucherCount}"
-        ].join('\n')
+        ].join('\n'),
+        companyId
     )
     new SieExportResult(
         safeTarget.toAbsolutePath().normalize(),
@@ -897,6 +901,19 @@ final class SieImportExportService {
     safeNormalBalanceSide == 'DEBIT'
         ? scale(debitAmount - creditAmount)
         : scale(creditAmount - debitAmount)
+  }
+
+  private long resolveCompanyId(long fiscalYearId) {
+    databaseService.withSql { Sql sql ->
+      GroovyRowResult row = sql.firstRow(
+          'select company_id as companyId from fiscal_year where id = ?',
+          [fiscalYearId]
+      ) as GroovyRowResult
+      if (row == null) {
+        throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
+      }
+      ((Number) row.get('companyId')).longValue()
+    }
   }
 
   private static String normalizeAccountNumber(String accountNumber) {

--- a/app/src/main/groovy/se/alipsa/accounting/service/VoucherService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/VoucherService.groovy
@@ -151,7 +151,8 @@ final class VoucherService {
 
       String safeDescription = validateVoucherEnvelope(sql, current.fiscalYearId, accountingDate, description)
       List<VoucherLine> safeLines = normalizeLines(sql, lines, false, true)
-      replaceLines(sql, voucherId, safeLines)
+      long companyId = resolveCompanyId(sql, current.fiscalYearId)
+      replaceLines(sql, voucherId, companyId, safeLines)
       sql.executeUpdate('''
           update voucher
              set accounting_date = ?,
@@ -370,6 +371,7 @@ final class VoucherService {
     boolean requireActiveAccounts = originalVoucherId == null
     List<VoucherLine> safeLines = normalizeLines(sql, lines, false, requireActiveAccounts)
     VoucherSeries series = ensureSeries(sql, fiscalYearId, seriesCode, null)
+    long companyId = resolveCompanyId(sql, fiscalYearId)
     List<List<Object>> keys = sql.executeInsert('''
         insert into voucher (
             fiscal_year_id,
@@ -383,18 +385,20 @@ final class VoucherService {
             previous_hash,
             content_hash,
             booked_at,
+            company_id,
             created_at,
             updated_at
-        ) values (?, ?, null, null, ?, ?, 'DRAFT', ?, null, null, null, current_timestamp, current_timestamp)
+        ) values (?, ?, null, null, ?, ?, 'DRAFT', ?, null, null, null, ?, current_timestamp, current_timestamp)
     ''', [
         fiscalYearId,
         series.id,
         Date.valueOf(accountingDate),
         safeDescription,
-        originalVoucherId
+        originalVoucherId,
+        companyId
     ])
     long voucherId = ((Number) keys.first().first()).longValue()
-    replaceLines(sql, voucherId, safeLines)
+    replaceLines(sql, voucherId, companyId, safeLines)
     Voucher draft = requireVoucher(sql, voucherId)
     if (originalVoucherId == null) {
       auditLogService.recordVoucherCreated(sql, draft)
@@ -802,7 +806,7 @@ final class VoucherService {
     SqlValueMapper.toLocalDateTime(row.get('bookedAt'))
   }
 
-  private static void replaceLines(Sql sql, long voucherId, List<VoucherLine> lines) {
+  private static void replaceLines(Sql sql, long voucherId, long companyId, List<VoucherLine> lines) {
     sql.executeUpdate('delete from voucher_line where voucher_id = ?', [voucherId])
     lines.eachWithIndex { VoucherLine line, int index ->
       sql.executeInsert('''
@@ -813,15 +817,17 @@ final class VoucherService {
               line_description,
               debit_amount,
               credit_amount,
+              company_id,
               created_at
-          ) values (?, ?, ?, ?, ?, ?, current_timestamp)
+          ) values (?, ?, ?, ?, ?, ?, ?, current_timestamp)
       ''', [
           voucherId,
           index + 1,
           line.accountNumber,
           line.description,
           line.debitAmount,
-          line.creditAmount
+          line.creditAmount,
+          companyId
       ])
     }
   }

--- a/app/src/main/groovy/se/alipsa/accounting/service/VoucherService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/VoucherService.groovy
@@ -240,56 +240,66 @@ final class VoucherService {
   List<String> validateIntegrity() {
     databaseService.withTransaction { Sql sql ->
       List<String> problems = []
-      String expectedPreviousHash = null
-      String actualLastHash = null
-      sql.rows('''
-          select v.id,
-                 v.fiscal_year_id as fiscalYearId,
-                 v.voucher_series_id as voucherSeriesId,
-                 s.series_code as seriesCode,
-                 s.series_name as seriesName,
-                 v.running_number as runningNumber,
-                 v.voucher_number as voucherNumber,
-                 v.accounting_date as accountingDate,
-                 v.description,
-                 v.status,
-                 v.original_voucher_id as originalVoucherId,
-                 v.previous_hash as previousHash,
-                 v.content_hash as contentHash,
-                 v.booked_at as bookedAt
-            from voucher v
-            join voucher_series s on s.id = v.voucher_series_id
-           where v.status in ('BOOKED', 'CORRECTION')
-           order by v.id
-      ''').each { GroovyRowResult row ->
-        Voucher voucher = mapVoucher(row)
-        voucher.lines = loadLines(sql, voucher.id)
-        if (voucher.previousHash != expectedPreviousHash) {
-          problems << ("Verifikation ${voucher.id} har fel föregående hash." as String)
-        }
-        VoucherStatus status = VoucherStatus.valueOf(row.get('status') as String)
-        String calculated = calculateContentHash(
-            voucher,
-            voucher.lines,
-            status,
-            voucher.runningNumber,
-            voucher.voucherNumber,
-            voucher.previousHash
-        )
-        if (voucher.contentHash != calculated) {
-          problems << ("Verifikation ${voucher.id} har ogiltig innehållshash." as String)
-        }
-        expectedPreviousHash = voucher.contentHash
-        actualLastHash = voucher.contentHash
-      }
-      ChainHead chainHead = lockChainHead(sql)
-      if (chainHead == null) {
-        problems << 'Verifikationskedjans huvud saknas.'
-      } else if (chainHead.lastContentHash != actualLastHash) {
-        problems << 'Verifikationskedjans huvud pekar inte på sista bokförda verifikation.'
+      sql.rows('select distinct company_id as companyId from voucher').each { GroovyRowResult companyRow ->
+        long companyId = ((Number) companyRow.get('companyId')).longValue()
+        problems.addAll(validateIntegrityForCompany(sql, companyId))
       }
       problems
     }
+  }
+
+  private static List<String> validateIntegrityForCompany(Sql sql, long companyId) {
+    List<String> problems = []
+    String expectedPreviousHash = null
+    String actualLastHash = null
+    sql.rows('''
+        select v.id,
+               v.fiscal_year_id as fiscalYearId,
+               v.voucher_series_id as voucherSeriesId,
+               s.series_code as seriesCode,
+               s.series_name as seriesName,
+               v.running_number as runningNumber,
+               v.voucher_number as voucherNumber,
+               v.accounting_date as accountingDate,
+               v.description,
+               v.status,
+               v.original_voucher_id as originalVoucherId,
+               v.previous_hash as previousHash,
+               v.content_hash as contentHash,
+               v.booked_at as bookedAt
+          from voucher v
+          join voucher_series s on s.id = v.voucher_series_id
+         where v.status in ('BOOKED', 'CORRECTION')
+           and v.company_id = ?
+         order by v.id
+    ''', [companyId]).each { GroovyRowResult row ->
+      Voucher voucher = mapVoucher(row)
+      voucher.lines = loadLines(sql, voucher.id)
+      if (voucher.previousHash != expectedPreviousHash) {
+        problems << ("Verifikation ${voucher.id} har fel föregående hash." as String)
+      }
+      VoucherStatus status = VoucherStatus.valueOf(row.get('status') as String)
+      String calculated = calculateContentHash(
+          voucher,
+          voucher.lines,
+          status,
+          voucher.runningNumber,
+          voucher.voucherNumber,
+          voucher.previousHash
+      )
+      if (voucher.contentHash != calculated) {
+        problems << ("Verifikation ${voucher.id} har ogiltig innehållshash." as String)
+      }
+      expectedPreviousHash = voucher.contentHash
+      actualLastHash = voucher.contentHash
+    }
+    ChainHead chainHead = lockChainHead(sql, companyId)
+    if (chainHead == null) {
+      problems << 'Verifikationskedjans huvud saknas.'
+    } else if (chainHead.lastContentHash != actualLastHash) {
+      problems << 'Verifikationskedjans huvud pekar inte på sista bokförda verifikation.'
+    }
+    problems
   }
 
   List<Voucher> listVouchers(Long fiscalYearId = null, VoucherStatus status = null, String queryText = null) {
@@ -413,7 +423,8 @@ final class VoucherService {
 
     int runningNumber = allocateRunningNumber(sql, current.voucherSeriesId)
     String voucherNumber = "${current.seriesCode}-${runningNumber}"
-    ChainHead chainHead = lockChainHead(sql)
+    long companyId = resolveCompanyId(sql, current.fiscalYearId)
+    ChainHead chainHead = lockChainHead(sql, companyId)
     String previousHash = chainHead.lastContentHash
     LocalDateTime bookedAt = currentDatabaseTimestamp(sql)
     String contentHash = calculateContentHash(current, safeLines, targetStatus, runningNumber, voucherNumber, previousHash)
@@ -441,7 +452,7 @@ final class VoucherService {
     if (updated != 1) {
       throw new IllegalStateException("Verifikationen kunde inte bokföras: ${voucherId}")
     }
-    updateChainHead(sql, contentHash)
+    updateChainHead(sql, companyId, contentHash)
     Voucher bookedVoucher = requireVoucher(sql, voucherId)
     if (targetStatus == VoucherStatus.CORRECTION) {
       auditLogService.recordCorrectionVoucher(sql, bookedVoucher)
@@ -746,14 +757,25 @@ final class VoucherService {
     HexFormat.of().formatHex(hash)
   }
 
-  private static ChainHead lockChainHead(Sql sql) {
+  private static long resolveCompanyId(Sql sql, long fiscalYearId) {
+    GroovyRowResult row = sql.firstRow(
+        'select company_id as companyId from fiscal_year where id = ?',
+        [fiscalYearId]
+    ) as GroovyRowResult
+    if (row == null) {
+      throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
+    }
+    ((Number) row.get('companyId')).longValue()
+  }
+
+  private static ChainHead lockChainHead(Sql sql, long companyId) {
     GroovyRowResult row = sql.firstRow('''
-        select id,
+        select company_id as id,
                last_content_hash as lastContentHash
           from voucher_chain_head
-         where id = 1
+         where company_id = ?
          for update
-    ''') as GroovyRowResult
+    ''', [companyId]) as GroovyRowResult
     if (row == null) {
       throw new IllegalStateException('Kedjehuvudet för verifikationer saknas.')
     }
@@ -763,13 +785,13 @@ final class VoucherService {
     )
   }
 
-  private static void updateChainHead(Sql sql, String contentHash) {
+  private static void updateChainHead(Sql sql, long companyId, String contentHash) {
     int updated = sql.executeUpdate('''
         update voucher_chain_head
            set last_content_hash = ?,
                updated_at = current_timestamp
-         where id = 1
-    ''', [contentHash])
+         where company_id = ?
+    ''', [contentHash, companyId])
     if (updated != 1) {
       throw new IllegalStateException('Kedjehuvudet för verifikationer kunde inte uppdateras.')
     }

--- a/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
@@ -114,7 +114,8 @@ final class MainFrame implements PropertyChangeListener {
       reportDataService,
       reportArchiveService,
       reportIntegrityService,
-      auditLogService
+      auditLogService,
+      DatabaseService.instance
   )
   private final SieImportExportService sieImportExportService = new SieImportExportService(
       DatabaseService.instance,
@@ -129,7 +130,8 @@ final class MainFrame implements PropertyChangeListener {
       reportArchiveService,
       reportIntegrityService,
       companySettingsService,
-      auditLogService
+      auditLogService,
+      DatabaseService.instance
   )
   private JLabel statusLabel
   private JLabel companySummaryLabel

--- a/app/src/main/resources/db/migrations/V14__company_chain_heads.sql
+++ b/app/src/main/resources/db/migrations/V14__company_chain_heads.sql
@@ -1,0 +1,61 @@
+-- voucher_chain_head: replace singleton id with company_id
+alter table voucher_chain_head
+    drop constraint if exists ck_voucher_chain_head_singleton;
+
+alter table voucher_chain_head
+    add column if not exists company_id bigint;
+
+insert into voucher_chain_head (company_id, last_content_hash, updated_at)
+select 1, null, current_timestamp
+where not exists (select 1 from voucher_chain_head);
+
+update voucher_chain_head
+   set company_id = 1
+ where company_id is null;
+
+alter table voucher_chain_head
+    alter column company_id set not null;
+
+alter table voucher_chain_head
+    drop primary key;
+
+alter table voucher_chain_head
+    drop column if exists id;
+
+alter table voucher_chain_head
+    add constraint pk_voucher_chain_head primary key (company_id);
+
+alter table voucher_chain_head
+    add constraint fk_voucher_chain_head_company
+        foreign key (company_id) references company(id) on delete restrict;
+
+-- audit_log_chain_head: replace singleton id with company_id
+alter table audit_log_chain_head
+    drop constraint if exists ck_audit_log_chain_head_singleton;
+
+alter table audit_log_chain_head
+    add column if not exists company_id bigint;
+
+insert into audit_log_chain_head (company_id, last_entry_hash, updated_at)
+select 1, null, current_timestamp
+where not exists (select 1 from audit_log_chain_head);
+
+update audit_log_chain_head
+   set company_id = 1
+ where company_id is null;
+
+alter table audit_log_chain_head
+    alter column company_id set not null;
+
+alter table audit_log_chain_head
+    drop primary key;
+
+alter table audit_log_chain_head
+    drop column if exists id;
+
+alter table audit_log_chain_head
+    add constraint pk_audit_log_chain_head primary key (company_id);
+
+alter table audit_log_chain_head
+    add constraint fk_audit_log_chain_head_company
+        foreign key (company_id) references company(id) on delete restrict;

--- a/app/src/test/groovy/acceptance/se/alipsa/accounting/AcceptanceCriteriaTest.groovy
+++ b/app/src/test/groovy/acceptance/se/alipsa/accounting/AcceptanceCriteriaTest.groovy
@@ -246,9 +246,10 @@ class AcceptanceCriteriaTest {
             reportArchiveService,
             reportIntegrityService,
             companySettingsService,
-            auditLogService
+            auditLogService,
+            databaseService
         ),
-        reportExportService: new ReportExportService(reportDataService, reportArchiveService, reportIntegrityService, auditLogService),
+        reportExportService: new ReportExportService(reportDataService, reportArchiveService, reportIntegrityService, auditLogService, databaseService),
         vatService: new VatService(databaseService, voucherService),
         sieService: new SieImportExportService(
             databaseService,

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/BackupServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/BackupServiceTest.groovy
@@ -76,7 +76,7 @@ class BackupServiceTest {
       assertEquals(1, count(sql, 'voucher'))
       assertEquals(1, count(sql, 'attachment'))
       assertEquals(1, count(sql, 'report_archive'))
-      assertEquals(13, countSchemaVersion(sql))
+      assertEquals(14, countSchemaVersion(sql))
     }
   }
 
@@ -191,7 +191,7 @@ class BackupServiceTest {
     String manifest = [
         'formatVersion=1',
         "createdAt=${LocalDateTime.of(2026, 1, 1, 0, 0)}",
-        'schemaVersion=12',
+        'schemaVersion=14',
         'databasePath=database/script.sql',
         "databaseChecksumSha256=${sha256(scriptBytes)}",
         "databaseSizeBytes=${scriptBytes.length}",

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/DatabaseServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/DatabaseServiceTest.groovy
@@ -70,7 +70,7 @@ class DatabaseServiceTest {
       ''') as GroovyRowResult
     }
 
-    assertEquals(13, ((Number) result.version).intValue())
+    assertEquals(14, ((Number) result.version).intValue())
     assertEquals(1, ((Number) result.company).intValue())
     assertEquals(1, ((Number) result.companySettings).intValue())
     assertEquals(1, ((Number) result.fiscalYear).intValue())

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/MultiCompanyChainHeadTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/MultiCompanyChainHeadTest.groovy
@@ -1,0 +1,133 @@
+package se.alipsa.accounting.service
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotNull
+
+import groovy.sql.Sql
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+import se.alipsa.accounting.domain.AuditLogEntry
+import se.alipsa.accounting.domain.Company
+import se.alipsa.accounting.domain.VatPeriodicity
+import se.alipsa.accounting.domain.VoucherLine
+import se.alipsa.accounting.support.AppPaths
+
+import java.nio.file.Path
+import java.sql.Date
+import java.time.LocalDate
+
+class MultiCompanyChainHeadTest {
+
+  @TempDir
+  Path tempDir
+
+  private DatabaseService databaseService
+  private CompanyService companyService
+  private AccountingPeriodService accountingPeriodService
+  private VoucherService voucherService
+  private AuditLogService auditLogService
+  private String previousHome
+
+  @BeforeEach
+  void setUp() {
+    previousHome = System.getProperty(AppPaths.HOME_OVERRIDE_PROPERTY)
+    System.setProperty(AppPaths.HOME_OVERRIDE_PROPERTY, tempDir.toString())
+    databaseService = DatabaseService.newForTesting()
+    databaseService.initialize()
+    companyService = new CompanyService(databaseService)
+    auditLogService = new AuditLogService(databaseService)
+    accountingPeriodService = new AccountingPeriodService(databaseService, auditLogService)
+    voucherService = new VoucherService(databaseService, auditLogService)
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (previousHome == null) {
+      System.clearProperty(AppPaths.HOME_OVERRIDE_PROPERTY)
+    } else {
+      System.setProperty(AppPaths.HOME_OVERRIDE_PROPERTY, previousHome)
+    }
+  }
+
+  @Test
+  void secondCompanyCanBookVoucherAndLogAuditEvents() {
+    Company company2 = companyService.save(
+        new Company(null, 'Second AB', '556123-4567', 'SEK', 'sv-SE', VatPeriodicity.MONTHLY, true, null, null)
+    )
+
+    assertNotNull(company2.id)
+    assertEquals(2L, company2.id)
+
+    long fyId = databaseService.withTransaction { Sql sql ->
+      List<List<Object>> keys = sql.executeInsert('''
+          insert into fiscal_year (
+              company_id,
+              name,
+              start_date,
+              end_date,
+              created_at
+          ) values (?, ?, ?, ?, current_timestamp)
+      ''', [
+          company2.id,
+          '2026',
+          Date.valueOf(LocalDate.of(2026, 1, 1)),
+          Date.valueOf(LocalDate.of(2026, 12, 31))
+      ])
+      long id = ((Number) keys.first().first()).longValue()
+      accountingPeriodService.createPeriods(sql, id, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+      VatService.ensurePeriodsForFiscalYear(sql, id)
+      insertAccount(sql, company2.id, '1510', 'Kundfordringar', 'ASSET', 'DEBIT')
+      insertAccount(sql, company2.id, '3010', 'Försäljning', 'INCOME', 'CREDIT')
+      id
+    }
+
+    def voucher = voucherService.createAndBook(
+        fyId,
+        'A',
+        LocalDate.of(2026, 1, 15),
+        'Försäljning i bolag 2',
+        [
+            new VoucherLine(null, null, 0, '1510', null, 'Kundfordran', 100.00G, 0.00G),
+            new VoucherLine(null, null, 0, '3010', null, 'Försäljning', 0.00G, 100.00G)
+        ]
+    )
+
+    assertNotNull(voucher.voucherNumber)
+    assertEquals('BOOKED', voucher.status.name())
+
+    AuditLogEntry entry = auditLogService.logImport('SIE-import för bolag 2', 'test', company2.id)
+    assertNotNull(entry)
+
+    assertEquals([], voucherService.validateIntegrity())
+    assertEquals([], auditLogService.validateIntegrity())
+  }
+
+  private static void insertAccount(
+      Sql sql,
+      long companyId,
+      String accountNumber,
+      String accountName,
+      String accountClass,
+      String normalBalanceSide
+  ) {
+    sql.executeInsert('''
+        insert into account (
+            company_id,
+            account_number,
+            account_name,
+            account_class,
+            normal_balance_side,
+            vat_code,
+            active,
+            manual_review_required,
+            classification_note,
+            created_at,
+            updated_at
+        ) values (?, ?, ?, ?, ?, null, true, false, null, current_timestamp, current_timestamp)
+    ''', [companyId, accountNumber, accountName, accountClass, normalBalanceSide])
+  }
+}

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/MultiCompanyChainHeadTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/MultiCompanyChainHeadTest.groovy
@@ -3,6 +3,7 @@ package se.alipsa.accounting.service
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertNotNull
 
+import groovy.sql.GroovyRowResult
 import groovy.sql.Sql
 
 import org.junit.jupiter.api.AfterEach
@@ -14,6 +15,8 @@ import se.alipsa.accounting.domain.AuditLogEntry
 import se.alipsa.accounting.domain.Company
 import se.alipsa.accounting.domain.VatPeriodicity
 import se.alipsa.accounting.domain.VoucherLine
+import se.alipsa.accounting.domain.report.ReportSelection
+import se.alipsa.accounting.domain.report.ReportType
 import se.alipsa.accounting.support.AppPaths
 
 import java.nio.file.Path
@@ -28,7 +31,12 @@ class MultiCompanyChainHeadTest {
   private DatabaseService databaseService
   private CompanyService companyService
   private AccountingPeriodService accountingPeriodService
+  private FiscalYearService fiscalYearService
   private VoucherService voucherService
+  private ReportDataService reportDataService
+  private ReportArchiveService reportArchiveService
+  private ReportExportService reportExportService
+  private JournoReportService journoReportService
   private AuditLogService auditLogService
   private String previousHome
 
@@ -41,7 +49,25 @@ class MultiCompanyChainHeadTest {
     companyService = new CompanyService(databaseService)
     auditLogService = new AuditLogService(databaseService)
     accountingPeriodService = new AccountingPeriodService(databaseService, auditLogService)
+    fiscalYearService = new FiscalYearService(databaseService, accountingPeriodService, auditLogService)
     voucherService = new VoucherService(databaseService, auditLogService)
+    reportDataService = new ReportDataService(databaseService, fiscalYearService, accountingPeriodService)
+    reportArchiveService = new ReportArchiveService(databaseService)
+    reportExportService = new ReportExportService(
+        reportDataService,
+        reportArchiveService,
+        new ReportIntegrityService(voucherService, new AttachmentService(databaseService, auditLogService), auditLogService),
+        auditLogService,
+        databaseService
+    )
+    journoReportService = new JournoReportService(
+        reportDataService,
+        reportArchiveService,
+        new ReportIntegrityService(voucherService, new AttachmentService(databaseService, auditLogService), auditLogService),
+        new CompanySettingsService(databaseService),
+        auditLogService,
+        databaseService
+    )
   }
 
   @AfterEach
@@ -104,6 +130,69 @@ class MultiCompanyChainHeadTest {
 
     assertEquals([], voucherService.validateIntegrity())
     assertEquals([], auditLogService.validateIntegrity())
+  }
+
+  @Test
+  void reportExportsFromSecondCompanyLandInCorrectAuditChain() {
+    Company company2 = companyService.save(
+        new Company(null, 'Second AB', '556123-4567', 'SEK', 'sv-SE', VatPeriodicity.MONTHLY, true, null, null)
+    )
+
+    long fyId = databaseService.withTransaction { Sql sql ->
+      List<List<Object>> keys = sql.executeInsert('''
+          insert into fiscal_year (
+              company_id,
+              name,
+              start_date,
+              end_date,
+              created_at
+          ) values (?, ?, ?, ?, current_timestamp)
+      ''', [
+          company2.id,
+          '2026',
+          Date.valueOf(LocalDate.of(2026, 1, 1)),
+          Date.valueOf(LocalDate.of(2026, 12, 31))
+      ])
+      long id = ((Number) keys.first().first()).longValue()
+      accountingPeriodService.createPeriods(sql, id, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+      VatService.ensurePeriodsForFiscalYear(sql, id)
+      insertAccount(sql, company2.id, '1510', 'Kundfordringar', 'ASSET', 'DEBIT')
+      insertAccount(sql, company2.id, '3010', 'Försäljning', 'INCOME', 'CREDIT')
+      id
+    }
+
+    voucherService.createAndBook(
+        fyId,
+        'A',
+        LocalDate.of(2026, 1, 15),
+        'Försäljning i bolag 2',
+        [
+            new VoucherLine(null, null, 0, '1510', null, 'Kundfordran', 100.00G, 0.00G),
+            new VoucherLine(null, null, 0, '3010', null, 'Försäljning', 0.00G, 100.00G)
+        ]
+    )
+
+    ReportSelection selection = new ReportSelection(
+        ReportType.VOUCHER_LIST,
+        fyId,
+        null,
+        LocalDate.of(2026, 1, 1),
+        LocalDate.of(2026, 1, 31)
+    )
+
+    reportExportService.exportCsv(selection)
+    journoReportService.generatePdf(selection)
+
+    assertEquals([], auditLogService.validateIntegrity())
+
+    int exportCount = databaseService.withSql { Sql sql ->
+      GroovyRowResult row = sql.firstRow(
+          'select count(*) as total from audit_log where company_id = ? and event_type = ?',
+          [company2.id, AuditLogService.EXPORT]
+      ) as GroovyRowResult
+      ((Number) row.get('total')).intValue()
+    }
+    assertEquals(2, exportCount)
   }
 
   private static void insertAccount(

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/ReportServicesTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/ReportServicesTest.groovy
@@ -64,14 +64,16 @@ class ReportServicesTest {
         reportDataService,
         reportArchiveService,
         new ReportIntegrityService(voucherService, new AttachmentService(databaseService, auditLogService), auditLogService),
-        auditLogService
+        auditLogService,
+        databaseService
     )
     journoReportService = new JournoReportService(
         reportDataService,
         reportArchiveService,
         new ReportIntegrityService(voucherService, new AttachmentService(databaseService, auditLogService), auditLogService),
         new CompanySettingsService(databaseService),
-        auditLogService
+        auditLogService,
+        databaseService
     )
     fiscalYear = fiscalYearService.createFiscalYear('2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
     insertTestAccounts()


### PR DESCRIPTION
## Sammanfattning
Implementerar Batch 2 av flerföretagsstödet: kedjehuvuden för verifikationer och audit-logg blir företagsspecifika.

## Ändringar
- **Migration `V14__company_chain_heads.sql`**
  - Bygger om `voucher_chain_head` och `audit_log_chain_head` från singleton-tabeller till tabeller med `company_id` som primärnyckel.
  - Migrerar befintliga kedjehuvuden till `company_id = 1`.
- **`DatabaseService`**
  - Registrerar migration 14.
- **`VoucherService`**
  - `lockChainHead` / `updateChainHead` tar nu explicit `companyId`.
  - `validateIntegrity()` validerar hashkedjan per företag istället för globalt.
- **`AuditLogService`**
  - `lockChainHead` / `loadChainHead` / `updateChainHead` tar nu explicit `companyId`.
  - `recordEvent()` bestämmer `company_id` från refererade entiteter.
  - `validateIntegrity()` validerar auditkedjan per företag.
- **Tester**
  - Uppdaterade `DatabaseServiceTest` och `BackupServiceTest` för schemaversion 14.

## Validering
- `./gradlew build` passerar.