### PR TITLE
Batch 4: service-lager cutover till explicit companyId

### DIFF
--- a/app/src/main/groovy/se/alipsa/accounting/service/AccountService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/AccountService.groovy
@@ -20,21 +20,25 @@ final class AccountService {
     this.databaseService = databaseService
   }
 
-  boolean hasAccounts() {
+  boolean hasAccounts(long companyId) {
     databaseService.withSql { Sql sql ->
-      GroovyRowResult row = sql.firstRow('select count(*) as total from account') as GroovyRowResult
+      GroovyRowResult row = sql.firstRow(
+          'select count(*) as total from account where company_id = ?',
+          [companyId]
+      ) as GroovyRowResult
       ((Number) row.get('total')).intValue() > 0
     }
   }
 
-  AccountOverview loadOverview() {
+  AccountOverview loadOverview(long companyId) {
     databaseService.withSql { Sql sql ->
       GroovyRowResult row = sql.firstRow('''
           select count(*) as total,
                  coalesce(sum(case when active then 1 else 0 end), 0) as activeCount,
                  coalesce(sum(case when manual_review_required then 1 else 0 end), 0) as manualReviewCount
             from account
-      ''') as GroovyRowResult
+           where company_id = ?
+      ''', [companyId]) as GroovyRowResult
       new AccountOverview(
           ((Number) row.get('total')).intValue(),
           ((Number) row.get('activeCount')).intValue(),
@@ -43,7 +47,7 @@ final class AccountService {
     }
   }
 
-  List<Account> searchAccounts(String queryText, String classFilter, boolean activeOnly, boolean manualReviewOnly) {
+  List<Account> searchAccounts(long companyId, String queryText, String classFilter, boolean activeOnly, boolean manualReviewOnly) {
     databaseService.withSql { Sql sql ->
       StringBuilder query = new StringBuilder('''
           select id,
@@ -57,9 +61,9 @@ final class AccountService {
                  manual_review_required as manualReviewRequired,
                  classification_note as classificationNote
             from account
-           where 1 = 1
+           where company_id = ?
       ''')
-      List<Object> params = []
+      List<Object> params = [companyId]
 
       String normalizedQuery = queryText?.trim()?.toLowerCase(Locale.ROOT)
       if (normalizedQuery) {
@@ -87,7 +91,7 @@ final class AccountService {
     }
   }
 
-  Account findAccount(String accountNumber) {
+  Account findAccount(long companyId, String accountNumber) {
     String normalized = normalizeAccountNumber(accountNumber)
     databaseService.withSql { Sql sql ->
       GroovyRowResult row = sql.firstRow('''
@@ -102,21 +106,23 @@ final class AccountService {
                  manual_review_required as manualReviewRequired,
                  classification_note as classificationNote
             from account
-           where account_number = ?
-      ''', [normalized]) as GroovyRowResult
+           where company_id = ?
+             and account_number = ?
+      ''', [companyId, normalized]) as GroovyRowResult
       row == null ? null : mapAccount(row)
     }
   }
 
-  void setAccountActive(String accountNumber, boolean active) {
+  void setAccountActive(long companyId, String accountNumber, boolean active) {
     String normalized = normalizeAccountNumber(accountNumber)
     databaseService.withTransaction { Sql sql ->
       int updated = sql.executeUpdate('''
           update account
              set active = ?,
                  updated_at = current_timestamp
-           where account_number = ?
-      ''', [active, normalized])
+           where company_id = ?
+             and account_number = ?
+      ''', [active, companyId, normalized])
       if (updated != 1) {
         throw new IllegalArgumentException("Unknown account number: ${normalized}")
       }
@@ -158,7 +164,8 @@ final class AccountService {
     String normalizedAccountNumber = normalizeAccountNumber(accountNumber)
     BigDecimal normalizedAmount = normalizeAmount(amount)
     databaseService.withTransaction { Sql sql ->
-      Account account = requireBalanceAccount(sql, normalizedAccountNumber)
+      long companyId = resolveCompanyId(sql, fiscalYearId)
+      Account account = requireBalanceAccount(sql, companyId, normalizedAccountNumber)
       requireFiscalYear(sql, fiscalYearId)
       boolean exists = openingBalanceExists(sql, fiscalYearId, account.id)
       if (exists) {
@@ -217,7 +224,7 @@ final class AccountService {
     }
   }
 
-  private static Account requireBalanceAccount(Sql sql, String accountNumber) {
+  private static Account requireBalanceAccount(Sql sql, long companyId, String accountNumber) {
     GroovyRowResult row = sql.firstRow('''
         select id,
                company_id as companyId,
@@ -230,8 +237,9 @@ final class AccountService {
                manual_review_required as manualReviewRequired,
                classification_note as classificationNote
           from account
-         where account_number = ?
-    ''', [accountNumber]) as GroovyRowResult
+         where company_id = ?
+           and account_number = ?
+    ''', [companyId, accountNumber]) as GroovyRowResult
     if (row == null) {
       throw new IllegalArgumentException("Unknown account number: ${accountNumber}")
     }

--- a/app/src/main/groovy/se/alipsa/accounting/service/AccountService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/AccountService.groovy
@@ -21,6 +21,7 @@ final class AccountService {
   }
 
   boolean hasAccounts(long companyId) {
+    CompanyService.requireValidCompanyId(companyId)
     databaseService.withSql { Sql sql ->
       GroovyRowResult row = sql.firstRow(
           'select count(*) as total from account where company_id = ?',
@@ -31,6 +32,7 @@ final class AccountService {
   }
 
   AccountOverview loadOverview(long companyId) {
+    CompanyService.requireValidCompanyId(companyId)
     databaseService.withSql { Sql sql ->
       GroovyRowResult row = sql.firstRow('''
           select count(*) as total,
@@ -48,6 +50,7 @@ final class AccountService {
   }
 
   List<Account> searchAccounts(long companyId, String queryText, String classFilter, boolean activeOnly, boolean manualReviewOnly) {
+    CompanyService.requireValidCompanyId(companyId)
     databaseService.withSql { Sql sql ->
       StringBuilder query = new StringBuilder('''
           select id,
@@ -92,6 +95,7 @@ final class AccountService {
   }
 
   Account findAccount(long companyId, String accountNumber) {
+    CompanyService.requireValidCompanyId(companyId)
     String normalized = normalizeAccountNumber(accountNumber)
     databaseService.withSql { Sql sql ->
       GroovyRowResult row = sql.firstRow('''
@@ -114,6 +118,7 @@ final class AccountService {
   }
 
   void setAccountActive(long companyId, String accountNumber, boolean active) {
+    CompanyService.requireValidCompanyId(companyId)
     String normalized = normalizeAccountNumber(accountNumber)
     databaseService.withTransaction { Sql sql ->
       int updated = sql.executeUpdate('''
@@ -266,14 +271,7 @@ final class AccountService {
   }
 
   private static long resolveCompanyId(Sql sql, long fiscalYearId) {
-    GroovyRowResult row = sql.firstRow(
-        'select company_id as companyId from fiscal_year where id = ?',
-        [fiscalYearId]
-    ) as GroovyRowResult
-    if (row == null) {
-      throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
-    }
-    ((Number) row.get('companyId')).longValue()
+    CompanyService.resolveFromFiscalYear(sql, fiscalYearId)
   }
 
   @Canonical

--- a/app/src/main/groovy/se/alipsa/accounting/service/AccountingPeriodService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/AccountingPeriodService.groovy
@@ -84,6 +84,7 @@ final class AccountingPeriodService {
   }
 
   boolean isDateLocked(long companyId, LocalDate accountingDate) {
+    CompanyService.requireValidCompanyId(companyId)
     if (accountingDate == null) {
       throw new IllegalArgumentException('Accounting date is required.')
     }

--- a/app/src/main/groovy/se/alipsa/accounting/service/AccountingPeriodService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/AccountingPeriodService.groovy
@@ -83,17 +83,19 @@ final class AccountingPeriodService {
     }
   }
 
-  boolean isDateLocked(LocalDate accountingDate) {
+  boolean isDateLocked(long companyId, LocalDate accountingDate) {
     if (accountingDate == null) {
       throw new IllegalArgumentException('Accounting date is required.')
     }
     databaseService.withSql { Sql sql ->
       GroovyRowResult row = sql.firstRow('''
                 select count(*) as total
-                  from accounting_period
-                 where locked = true
-                   and ? between start_date and end_date
-            ''', [Date.valueOf(accountingDate)]) as GroovyRowResult
+                  from accounting_period ap
+                  join fiscal_year fy on fy.id = ap.fiscal_year_id
+                 where fy.company_id = ?
+                   and ap.locked = true
+                   and ? between ap.start_date and ap.end_date
+            ''', [companyId, Date.valueOf(accountingDate)]) as GroovyRowResult
       ((Number) row.get('total')).intValue() > 0
     }
   }

--- a/app/src/main/groovy/se/alipsa/accounting/service/AttachmentService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/AttachmentService.groovy
@@ -115,6 +115,7 @@ final class AttachmentService {
   }
 
   List<AttachmentMetadata> listAllAttachments(long companyId) {
+    CompanyService.requireValidCompanyId(companyId)
     databaseService.withSql { Sql sql ->
       sql.rows('''
           select id,
@@ -182,6 +183,7 @@ final class AttachmentService {
   }
 
   List<AttachmentMetadata> findIntegrityFailures(long companyId) {
+    CompanyService.requireValidCompanyId(companyId)
     databaseService.withSql { Sql sql ->
       sql.rows('''
           select id,

--- a/app/src/main/groovy/se/alipsa/accounting/service/AttachmentService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/AttachmentService.groovy
@@ -114,6 +114,26 @@ final class AttachmentService {
     }
   }
 
+  List<AttachmentMetadata> listAllAttachments(long companyId) {
+    databaseService.withSql { Sql sql ->
+      sql.rows('''
+          select id,
+                 voucher_id as voucherId,
+                 original_file_name as originalFileName,
+                 content_type as contentType,
+                 storage_path as storagePath,
+                 checksum_sha256 as checksumSha256,
+                 file_size as fileSize,
+                 created_at as createdAt
+            from attachment
+           where company_id = ?
+           order by id
+      ''', [companyId]).collect { GroovyRowResult row ->
+        mapAttachment(row)
+      }
+    }
+  }
+
   List<AttachmentMetadata> listAllAttachments() {
     databaseService.withSql { Sql sql ->
       sql.rows('''
@@ -161,7 +181,29 @@ final class AttachmentService {
     Files.deleteIfExists(resolveStoragePath(attachment.storagePath))
   }
 
-  List<AttachmentMetadata> findIntegrityFailures() {
+  List<AttachmentMetadata> findIntegrityFailures(long companyId) {
+    databaseService.withSql { Sql sql ->
+      sql.rows('''
+          select id,
+                 voucher_id as voucherId,
+                 original_file_name as originalFileName,
+                 content_type as contentType,
+                 storage_path as storagePath,
+                 checksum_sha256 as checksumSha256,
+                 file_size as fileSize,
+                 created_at as createdAt
+            from attachment
+           where company_id = ?
+           order by id
+      ''', [companyId]).collect { GroovyRowResult row ->
+        mapAttachment(row)
+      }.findAll { AttachmentMetadata attachment ->
+        !verifyAttachment(attachment)
+      }
+    }
+  }
+
+  List<AttachmentMetadata> findAllIntegrityFailures() {
     databaseService.withSql { Sql sql ->
       sql.rows('''
           select id,

--- a/app/src/main/groovy/se/alipsa/accounting/service/AuditLogService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/AuditLogService.groovy
@@ -75,7 +75,34 @@ final class AuditLogService {
     }
   }
 
-  List<AuditLogEntry> listEntries(int limit = 200) {
+  List<AuditLogEntry> listEntries(long companyId, int limit = 200) {
+    int safeLimit = Math.max(1, limit)
+    databaseService.withSql { Sql sql ->
+      sql.rows('''
+          select id,
+                 event_type as eventType,
+                 voucher_id as voucherId,
+                 attachment_id as attachmentId,
+                 fiscal_year_id as fiscalYearId,
+                 accounting_period_id as accountingPeriodId,
+                 vat_period_id as vatPeriodId,
+                 actor,
+                 summary,
+                 details,
+                 previous_hash as previousHash,
+                 entry_hash as entryHash,
+                 created_at as createdAt
+            from audit_log
+           where company_id = ?
+           order by created_at desc, id desc
+           limit ?
+      ''', [companyId, safeLimit]).collect { GroovyRowResult row ->
+        mapEntry(row)
+      }
+    }
+  }
+
+  List<AuditLogEntry> listAllEntries(int limit = 200) {
     int safeLimit = Math.max(1, limit)
     databaseService.withSql { Sql sql ->
       sql.rows('''

--- a/app/src/main/groovy/se/alipsa/accounting/service/AuditLogService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/AuditLogService.groovy
@@ -76,6 +76,7 @@ final class AuditLogService {
   }
 
   List<AuditLogEntry> listEntries(long companyId, int limit = 200) {
+    CompanyService.requireValidCompanyId(companyId)
     int safeLimit = Math.max(1, limit)
     databaseService.withSql { Sql sql ->
       sql.rows('''
@@ -132,10 +133,17 @@ final class AuditLogService {
     databaseService.withSql { Sql sql ->
       List<String> problems = []
       sql.rows('select distinct company_id as companyId from audit_log').each { GroovyRowResult companyRow ->
-        long companyId = ((Number) companyRow.get('companyId')).longValue()
-        problems.addAll(validateIntegrityForCompany(sql, companyId))
+        long cid = ((Number) companyRow.get('companyId')).longValue()
+        problems.addAll(validateIntegrityForCompany(sql, cid))
       }
       problems
+    }
+  }
+
+  List<String> validateIntegrity(long companyId) {
+    CompanyService.requireValidCompanyId(companyId)
+    databaseService.withSql { Sql sql ->
+      validateIntegrityForCompany(sql, companyId)
     }
   }
 
@@ -442,7 +450,7 @@ final class AuditLogService {
         return ((Number) row.get('companyId')).longValue()
       }
     }
-    CompanyService.LEGACY_COMPANY_ID
+    throw new IllegalStateException('Kunde inte avgöra företag från auditreferenserna.')
   }
 
   private static AuditChainHead lockChainHead(Sql sql, long companyId) {

--- a/app/src/main/groovy/se/alipsa/accounting/service/BackupService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/BackupService.groovy
@@ -77,7 +77,7 @@ final class BackupService {
       writeDatabaseScript(tempScript)
       byte[] scriptBytes = Files.readAllBytes(tempScript)
       List<AttachmentMetadata> attachments = attachmentService.listAllAttachments()
-      List<ReportArchive> archives = reportArchiveService.listArchives(10_000)
+      List<ReportArchive> archives = reportArchiveService.listAllArchives(10_000)
       BackupManifest manifest = buildManifest(tempScript, scriptBytes, attachments, archives)
       Map<String, AttachmentMetadata> attachmentsByPath = indexAttachments(attachments)
       Map<String, ReportArchive> reportsByPath = indexReports(archives)

--- a/app/src/main/groovy/se/alipsa/accounting/service/ClosingService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/ClosingService.groovy
@@ -632,14 +632,7 @@ final class ClosingService {
   }
 
   private static long resolveCompanyId(Sql sql, long fiscalYearId) {
-    GroovyRowResult row = sql.firstRow(
-        'select company_id as companyId from fiscal_year where id = ?',
-        [fiscalYearId]
-    ) as GroovyRowResult
-    if (row == null) {
-      throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
-    }
-    ((Number) row.get('companyId')).longValue()
+    CompanyService.resolveFromFiscalYear(sql, fiscalYearId)
   }
 
   private static String normalizeAccountNumber(String accountNumber) {

--- a/app/src/main/groovy/se/alipsa/accounting/service/ClosingService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/ClosingService.groovy
@@ -86,8 +86,9 @@ final class ClosingService {
       if (!preview.blockingIssues.isEmpty()) {
         throw new IllegalStateException(preview.blockingIssues.join('\n'))
       }
+      long companyId = resolveCompanyId(sql, preview.fiscalYear.id)
       FiscalYear nextFiscalYear = preview.nextFiscalYearWillBeCreated
-          ? ensureNextFiscalYear(sql, preview.fiscalYear)
+          ? ensureNextFiscalYear(sql, companyId, preview.fiscalYear)
           : preview.nextFiscalYear
       YearEndClosingPreview executionPreview = new YearEndClosingPreview(
           preview.fiscalYear,
@@ -162,7 +163,8 @@ final class ClosingService {
       blockers << ("Integritetskontrollerna måste vara gröna före årsstängning:\n${summary}" as String)
     }
 
-    BalanceAccountSeed closingAccount = loadAccount(sql, safeClosingAccount)
+    long companyId = resolveCompanyId(sql, fiscalYear.id)
+    BalanceAccountSeed closingAccount = loadAccount(sql, companyId, safeClosingAccount)
     if (closingAccount == null) {
       blockers << ("Resultat förs mot konto ${safeClosingAccount}, men kontot saknas i kontoplanen." as String)
     } else {
@@ -191,7 +193,7 @@ final class ClosingService {
       warnings << ("Bokslutsfristen passerade ${dueDate}. Årsbokslutet borde redan vara upprättat." as String)
     }
 
-    NextFiscalYearPlan nextPlan = planNextFiscalYear(sql, fiscalYear)
+    NextFiscalYearPlan nextPlan = planNextFiscalYear(sql, companyId, fiscalYear)
     if (nextPlan.conflictMessage != null) {
       blockers << nextPlan.conflictMessage
     } else if (nextPlan.fiscalYear?.id != null) {
@@ -488,7 +490,7 @@ final class ClosingService {
     closingBalances
   }
 
-  private NextFiscalYearPlan planNextFiscalYear(Sql sql, FiscalYear fiscalYear) {
+  private NextFiscalYearPlan planNextFiscalYear(Sql sql, long companyId, FiscalYear fiscalYear) {
     LocalDate nextStartDate = fiscalYear.endDate.plusDays(1)
     long daySpan = ChronoUnit.DAYS.between(fiscalYear.startDate, fiscalYear.endDate)
     LocalDate nextEndDate = nextStartDate.plusDays(daySpan)
@@ -501,9 +503,10 @@ final class ClosingService {
                closed,
                closed_at as closedAt
           from fiscal_year
-         where start_date = ?
+         where company_id = ?
+           and start_date = ?
            and end_date = ?
-    ''', [Date.valueOf(nextStartDate), Date.valueOf(nextEndDate)]) as GroovyRowResult
+    ''', [companyId, Date.valueOf(nextStartDate), Date.valueOf(nextEndDate)]) as GroovyRowResult
     if (exact != null) {
       return new NextFiscalYearPlan(mapFiscalYear(exact), false, null)
     }
@@ -511,9 +514,10 @@ final class ClosingService {
     GroovyRowResult overlap = sql.firstRow('''
         select count(*) as total
           from fiscal_year
-         where start_date <= ?
+         where company_id = ?
+           and start_date <= ?
            and end_date >= ?
-    ''', [Date.valueOf(nextEndDate), Date.valueOf(nextStartDate)]) as GroovyRowResult
+    ''', [companyId, Date.valueOf(nextEndDate), Date.valueOf(nextStartDate)]) as GroovyRowResult
     if (((Number) overlap.get('total')).intValue() > 0) {
       return new NextFiscalYearPlan(
           null,
@@ -545,8 +549,8 @@ final class ClosingService {
     mapFiscalYear(row)
   }
 
-  private FiscalYear ensureNextFiscalYear(Sql sql, FiscalYear fiscalYear) {
-    NextFiscalYearPlan plan = planNextFiscalYear(sql, fiscalYear)
+  private FiscalYear ensureNextFiscalYear(Sql sql, long companyId, FiscalYear fiscalYear) {
+    NextFiscalYearPlan plan = planNextFiscalYear(sql, companyId, fiscalYear)
     if (plan.conflictMessage != null) {
       throw new IllegalStateException(plan.conflictMessage)
     }
@@ -556,6 +560,7 @@ final class ClosingService {
     FiscalYearService.createFiscalYear(
         sql,
         accountingPeriodService,
+        companyId,
         plan.fiscalYear.name,
         plan.fiscalYear.startDate,
         plan.fiscalYear.endDate
@@ -592,7 +597,7 @@ final class ClosingService {
     ((Number) row.get('total')).intValue() > 0
   }
 
-  private static BalanceAccountSeed loadAccount(Sql sql, String accountNumber) {
+  private static BalanceAccountSeed loadAccount(Sql sql, long companyId, String accountNumber) {
     GroovyRowResult row = sql.firstRow('''
         select account_number as accountNumber,
                account_name as accountName,
@@ -600,8 +605,9 @@ final class ClosingService {
                normal_balance_side as normalBalanceSide,
                active
           from account
-         where account_number = ?
-    ''', [accountNumber]) as GroovyRowResult
+         where company_id = ?
+           and account_number = ?
+    ''', [companyId, accountNumber]) as GroovyRowResult
     if (row == null) {
       return null
     }

--- a/app/src/main/groovy/se/alipsa/accounting/service/ClosingService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/ClosingService.groovy
@@ -71,14 +71,20 @@ final class ClosingService {
   }
 
   YearEndClosingPreview previewClosing(long fiscalYearId, String closingAccountNumber = DEFAULT_CLOSING_ACCOUNT) {
-    List<String> integrityProblems = reportIntegrityService.listCriticalProblems()
+    long companyId = databaseService.withSql { Sql sql ->
+      resolveCompanyId(sql, fiscalYearId)
+    }
+    List<String> integrityProblems = reportIntegrityService.listCriticalProblems(companyId)
     databaseService.withSql { Sql sql ->
       buildPreview(sql, fiscalYearId, closingAccountNumber, integrityProblems)
     }
   }
 
   YearEndClosingResult closeFiscalYear(long fiscalYearId, String closingAccountNumber = DEFAULT_CLOSING_ACCOUNT) {
-    reportIntegrityService.ensureOperationAllowed('Årsstängning')
+    long companyId = databaseService.withSql { Sql sql ->
+      resolveCompanyId(sql, fiscalYearId)
+    }
+    reportIntegrityService.ensureOperationAllowed(companyId, 'Årsstängning')
     databaseService.withTransaction { Sql sql ->
       // Integrity is checked before opening the transaction so we do not re-run the
       // expensive cross-system validation while holding DB locks during closing.
@@ -86,7 +92,6 @@ final class ClosingService {
       if (!preview.blockingIssues.isEmpty()) {
         throw new IllegalStateException(preview.blockingIssues.join('\n'))
       }
-      long companyId = resolveCompanyId(sql, preview.fiscalYear.id)
       FiscalYear nextFiscalYear = preview.nextFiscalYearWillBeCreated
           ? ensureNextFiscalYear(sql, companyId, preview.fiscalYear)
           : preview.nextFiscalYear

--- a/app/src/main/groovy/se/alipsa/accounting/service/CompanyService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/CompanyService.groovy
@@ -148,6 +148,29 @@ final class CompanyService {
     findById(sql, company.id)
   }
 
+  static void requireValidCompanyId(long companyId) {
+    if (companyId <= 0) {
+      throw new IllegalArgumentException("Ogiltigt företags-id: ${companyId}")
+    }
+  }
+
+  static long resolveFromFiscalYear(Sql sql, long fiscalYearId) {
+    GroovyRowResult row = sql.firstRow(
+        'select company_id as companyId from fiscal_year where id = ?',
+        [fiscalYearId]
+    ) as GroovyRowResult
+    if (row == null) {
+      throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
+    }
+    ((Number) row.get('companyId')).longValue()
+  }
+
+  long resolveFromFiscalYear(long fiscalYearId) {
+    databaseService.withSql { Sql sql ->
+      resolveFromFiscalYear(sql, fiscalYearId)
+    }
+  }
+
   private static Company findById(Sql sql, long companyId) {
     GroovyRowResult row = sql.firstRow('''
         select id,

--- a/app/src/main/groovy/se/alipsa/accounting/service/FiscalYearService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/FiscalYearService.groovy
@@ -62,12 +62,14 @@ final class FiscalYearService {
   }
 
   FiscalYear createFiscalYear(long companyId, String name, LocalDate startDate, LocalDate endDate) {
+    CompanyService.requireValidCompanyId(companyId)
     databaseService.withTransaction { Sql sql ->
       createFiscalYear(sql, accountingPeriodService, companyId, name, startDate, endDate)
     }
   }
 
   List<FiscalYear> listFiscalYears(long companyId) {
+    CompanyService.requireValidCompanyId(companyId)
     databaseService.withSql { Sql sql ->
       sql.rows('''
                 select id,

--- a/app/src/main/groovy/se/alipsa/accounting/service/FiscalYearService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/FiscalYearService.groovy
@@ -61,13 +61,13 @@ final class FiscalYearService {
     this.retentionPolicyService = retentionPolicyService
   }
 
-  FiscalYear createFiscalYear(String name, LocalDate startDate, LocalDate endDate) {
+  FiscalYear createFiscalYear(long companyId, String name, LocalDate startDate, LocalDate endDate) {
     databaseService.withTransaction { Sql sql ->
-      createFiscalYear(sql, accountingPeriodService, name, startDate, endDate)
+      createFiscalYear(sql, accountingPeriodService, companyId, name, startDate, endDate)
     }
   }
 
-  List<FiscalYear> listFiscalYears() {
+  List<FiscalYear> listFiscalYears(long companyId) {
     databaseService.withSql { Sql sql ->
       sql.rows('''
                 select id,
@@ -77,8 +77,9 @@ final class FiscalYearService {
                        closed,
                        closed_at as closedAt
                   from fiscal_year
+                 where company_id = ?
                  order by start_date desc
-            ''').collect { GroovyRowResult row ->
+            ''', [companyId]).collect { GroovyRowResult row ->
         mapFiscalYear(row)
       }
     }
@@ -133,6 +134,7 @@ final class FiscalYearService {
   static FiscalYear createFiscalYear(
       Sql sql,
       AccountingPeriodService accountingPeriodService,
+      long companyId,
       String name,
       LocalDate startDate,
       LocalDate endDate,
@@ -140,17 +142,18 @@ final class FiscalYearService {
   ) {
     validateDateRange(startDate, endDate)
     String safeName = resolveName(name, startDate, endDate)
-    ensureNoOverlap(sql, startDate, endDate, overlapMessage)
+    ensureNoOverlap(sql, companyId, startDate, endDate, overlapMessage)
     List<List<Object>> keys = sql.executeInsert('''
                 insert into fiscal_year (
+                    company_id,
                     name,
                     start_date,
                     end_date,
                     closed,
                     closed_at,
                     created_at
-                ) values (?, ?, ?, false, null, current_timestamp)
-            ''', [safeName, Date.valueOf(startDate), Date.valueOf(endDate)])
+                ) values (?, ?, ?, ?, false, null, current_timestamp)
+            ''', [companyId, safeName, Date.valueOf(startDate), Date.valueOf(endDate)])
     long fiscalYearId = ((Number) keys.first().first()).longValue()
     accountingPeriodService.createPeriods(sql, fiscalYearId, startDate, endDate)
     VatService.ensurePeriodsForFiscalYear(sql, fiscalYearId)
@@ -186,13 +189,14 @@ final class FiscalYearService {
     closedYear
   }
 
-  private static void ensureNoOverlap(Sql sql, LocalDate startDate, LocalDate endDate, String overlapMessage) {
+  private static void ensureNoOverlap(Sql sql, long companyId, LocalDate startDate, LocalDate endDate, String overlapMessage) {
     GroovyRowResult row = sql.firstRow('''
             select count(*) as total
               from fiscal_year
-             where start_date <= ?
+             where company_id = ?
+               and start_date <= ?
                and end_date >= ?
-        ''', [Date.valueOf(endDate), Date.valueOf(startDate)]) as GroovyRowResult
+        ''', [companyId, Date.valueOf(endDate), Date.valueOf(startDate)]) as GroovyRowResult
     if (((Number) row.get('total')).intValue() > 0) {
       throw new IllegalArgumentException(overlapMessage)
     }

--- a/app/src/main/groovy/se/alipsa/accounting/service/JournoReportService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/JournoReportService.groovy
@@ -1,6 +1,5 @@
 package se.alipsa.accounting.service
 
-import groovy.sql.GroovyRowResult
 import groovy.sql.Sql
 
 import se.alipsa.accounting.domain.Company
@@ -90,23 +89,19 @@ final class JournoReportService {
   private Map<String, Object> buildTemplateModel(ReportResult report) {
     long companyId = resolveCompanyId(report.fiscalYearId)
     Company company = companyService.findById(companyId)
+    if (company == null) {
+      throw new IllegalStateException("Företaget kunde inte hittas: ${companyId}")
+    }
     [
-        companyName       : company?.companyName ?: 'Alipsa Accounting',
-        organizationNumber: company?.organizationNumber ?: '',
+        companyName       : company.companyName,
+        organizationNumber: company.organizationNumber,
         report            : report
     ] + report.templateModel
   }
 
   private long resolveCompanyId(long fiscalYearId) {
     databaseService.withSql { Sql sql ->
-      GroovyRowResult row = sql.firstRow(
-          'select company_id as companyId from fiscal_year where id = ?',
-          [fiscalYearId]
-      ) as GroovyRowResult
-      if (row == null) {
-        throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
-      }
-      ((Number) row.get('companyId')).longValue()
+      CompanyService.resolveFromFiscalYear(sql, fiscalYearId)
     }
   }
 

--- a/app/src/main/groovy/se/alipsa/accounting/service/JournoReportService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/JournoReportService.groovy
@@ -3,7 +3,7 @@ package se.alipsa.accounting.service
 import groovy.sql.GroovyRowResult
 import groovy.sql.Sql
 
-import se.alipsa.accounting.domain.CompanySettings
+import se.alipsa.accounting.domain.Company
 import se.alipsa.accounting.domain.report.ReportArchive
 import se.alipsa.accounting.domain.report.ReportResult
 import se.alipsa.accounting.domain.report.ReportSelection
@@ -18,7 +18,7 @@ final class JournoReportService {
   private final ReportDataService reportDataService
   private final ReportArchiveService reportArchiveService
   private final ReportIntegrityService reportIntegrityService
-  private final CompanySettingsService companySettingsService
+  private final CompanyService companyService
   private final AuditLogService auditLogService
   private final DatabaseService databaseService
 
@@ -27,7 +27,7 @@ final class JournoReportService {
         new ReportDataService(),
         new ReportArchiveService(),
         new ReportIntegrityService(),
-        new CompanySettingsService(),
+        new CompanyService(),
         new AuditLogService(),
         DatabaseService.instance
     )
@@ -37,14 +37,14 @@ final class JournoReportService {
       ReportDataService reportDataService,
       ReportArchiveService reportArchiveService,
       ReportIntegrityService reportIntegrityService,
-      CompanySettingsService companySettingsService,
+      CompanyService companyService,
       AuditLogService auditLogService,
       DatabaseService databaseService
   ) {
     this.reportDataService = reportDataService
     this.reportArchiveService = reportArchiveService
     this.reportIntegrityService = reportIntegrityService
-    this.companySettingsService = companySettingsService
+    this.companyService = companyService
     this.auditLogService = auditLogService
     this.databaseService = databaseService
   }
@@ -88,10 +88,11 @@ final class JournoReportService {
   }
 
   private Map<String, Object> buildTemplateModel(ReportResult report) {
-    CompanySettings settings = companySettingsService.getSettings()
+    long companyId = resolveCompanyId(report.fiscalYearId)
+    Company company = companyService.findById(companyId)
     [
-        companyName       : settings?.companyName ?: 'Alipsa Accounting',
-        organizationNumber: settings?.organizationNumber ?: '',
+        companyName       : company?.companyName ?: 'Alipsa Accounting',
+        organizationNumber: company?.organizationNumber ?: '',
         report            : report
     ] + report.templateModel
   }

--- a/app/src/main/groovy/se/alipsa/accounting/service/ReportArchiveService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/ReportArchiveService.groovy
@@ -87,6 +87,7 @@ final class ReportArchiveService {
   }
 
   List<ReportArchive> listArchives(long companyId, int limit = 100) {
+    CompanyService.requireValidCompanyId(companyId)
     int safeLimit = Math.max(1, limit)
     databaseService.withSql { Sql sql ->
       sql.rows('''

--- a/app/src/main/groovy/se/alipsa/accounting/service/ReportArchiveService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/ReportArchiveService.groovy
@@ -86,7 +86,34 @@ final class ReportArchiveService {
     }
   }
 
-  List<ReportArchive> listArchives(int limit = 100) {
+  List<ReportArchive> listArchives(long companyId, int limit = 100) {
+    int safeLimit = Math.max(1, limit)
+    databaseService.withSql { Sql sql ->
+      sql.rows('''
+          select ra.id,
+                 ra.report_type as reportType,
+                 ra.report_format as reportFormat,
+                 ra.fiscal_year_id as fiscalYearId,
+                 ra.accounting_period_id as accountingPeriodId,
+                 ra.start_date as startDate,
+                 ra.end_date as endDate,
+                 ra.file_name as fileName,
+                 ra.storage_path as storagePath,
+                 ra.checksum_sha256 as checksumSha256,
+                 ra.parameters,
+                 ra.created_at as createdAt
+            from report_archive ra
+            join fiscal_year fy on fy.id = ra.fiscal_year_id
+           where fy.company_id = ?
+           order by ra.created_at desc, ra.id desc
+           limit ?
+      ''', [companyId, safeLimit]).collect { GroovyRowResult row ->
+        mapArchive(row)
+      }
+    }
+  }
+
+  List<ReportArchive> listAllArchives(int limit = 10_000) {
     int safeLimit = Math.max(1, limit)
     databaseService.withSql { Sql sql ->
       sql.rows('''
@@ -131,8 +158,14 @@ final class ReportArchiveService {
     verifyArchive(archive)
   }
 
-  List<ReportArchive> findIntegrityFailures() {
-    listArchives(500).findAll { ReportArchive archive ->
+  List<ReportArchive> findIntegrityFailures(long companyId) {
+    listArchives(companyId, 500).findAll { ReportArchive archive ->
+      !verifyArchive(archive)
+    }
+  }
+
+  List<ReportArchive> findAllIntegrityFailures() {
+    listAllArchives(500).findAll { ReportArchive archive ->
       !verifyArchive(archive)
     }
   }

--- a/app/src/main/groovy/se/alipsa/accounting/service/ReportDataService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/ReportDataService.groovy
@@ -136,7 +136,7 @@ final class ReportDataService {
   @SuppressWarnings('AbcMetric')
   private ReportResult buildGeneralLedgerReport(EffectiveSelection effective) {
     databaseService.withSql { Sql sql ->
-      Map<String, AccountInfo> accountInfos = loadAccountInfos(sql)
+      Map<String, AccountInfo> accountInfos = loadAccountInfos(sql, effective.companyId)
       Map<String, BigDecimal> openingBalances = loadOpeningBalances(sql, effective.selection.fiscalYearId)
       Map<String, BigDecimal> priorBalances = effective.startDate.isAfter(effective.fiscalYear.startDate)
           ? loadSignedMovements(sql, effective.selection.fiscalYearId, effective.fiscalYear.startDate, effective.startDate.minusDays(1))
@@ -208,7 +208,7 @@ final class ReportDataService {
   @SuppressWarnings('AbcMetric')
   private ReportResult buildTrialBalanceReport(EffectiveSelection effective) {
     databaseService.withSql { Sql sql ->
-      Map<String, AccountInfo> accountInfos = loadAccountInfos(sql)
+      Map<String, AccountInfo> accountInfos = loadAccountInfos(sql, effective.companyId)
       Map<String, BigDecimal> openingBalances = loadOpeningBalances(sql, effective.selection.fiscalYearId)
       Map<String, BigDecimal> priorBalances = effective.startDate.isAfter(effective.fiscalYear.startDate)
           ? loadSignedMovements(sql, effective.selection.fiscalYearId, effective.fiscalYear.startDate, effective.startDate.minusDays(1))
@@ -255,7 +255,7 @@ final class ReportDataService {
 
   private ReportResult buildIncomeStatementReport(EffectiveSelection effective) {
     databaseService.withSql { Sql sql ->
-      Map<String, AccountInfo> accountInfos = loadAccountInfos(sql)
+      Map<String, AccountInfo> accountInfos = loadAccountInfos(sql, effective.companyId)
       Map<String, Totals> periodTotals = loadPeriodTotals(sql, effective.selection.fiscalYearId, effective.startDate, effective.endDate)
       List<IncomeStatementRow> rows = accountInfos.keySet().sort().collect { String accountNumber ->
         AccountInfo info = accountInfos[accountNumber]
@@ -293,7 +293,7 @@ final class ReportDataService {
 
   private ReportResult buildBalanceSheetReport(EffectiveSelection effective) {
     databaseService.withSql { Sql sql ->
-      Map<String, AccountInfo> accountInfos = loadAccountInfos(sql)
+      Map<String, AccountInfo> accountInfos = loadAccountInfos(sql, effective.companyId)
       Map<String, BigDecimal> openingBalances = loadOpeningBalances(sql, effective.selection.fiscalYearId)
       Map<String, BigDecimal> movements = loadSignedMovements(sql, effective.selection.fiscalYearId, effective.fiscalYear.startDate, effective.endDate)
       List<BalanceSheetRow> rows = accountInfos.keySet().sort().collect { String accountNumber ->
@@ -455,13 +455,14 @@ final class ReportDataService {
     if (startDate.isBefore(fiscalYear.startDate) || endDate.isAfter(fiscalYear.endDate) || endDate.isBefore(startDate)) {
       throw new IllegalArgumentException('Rapportintervallet måste ligga inom räkenskapsåret.')
     }
+    long companyId = resolveCompanyId(fiscalYear.id)
     String selectionLabel = period == null
         ? "Intervall ${startDate} - ${endDate}"
         : "Period ${period.periodName} (${startDate} - ${endDate})"
-    new EffectiveSelection(selection, fiscalYear, startDate, endDate, selectionLabel)
+    new EffectiveSelection(selection, fiscalYear, companyId, startDate, endDate, selectionLabel)
   }
 
-  private static Map<String, AccountInfo> loadAccountInfos(Sql sql) {
+  private static Map<String, AccountInfo> loadAccountInfos(Sql sql, long companyId) {
     Map<String, AccountInfo> accounts = [:]
     sql.rows('''
         select id as accountId,
@@ -470,8 +471,9 @@ final class ReportDataService {
                account_class as accountClass,
                normal_balance_side as normalBalanceSide
           from account
+         where company_id = ?
          order by account_number
-    ''').each { GroovyRowResult row ->
+    ''', [companyId]).each { GroovyRowResult row ->
       accounts.put(row.get('accountNumber') as String, new AccountInfo(
           ((Number) row.get('accountId')).longValue(),
           row.get('accountName') as String,
@@ -622,6 +624,19 @@ final class ReportDataService {
     )
   }
 
+  private long resolveCompanyId(long fiscalYearId) {
+    databaseService.withSql { Sql sql ->
+      GroovyRowResult row = sql.firstRow(
+          'select company_id as companyId from fiscal_year where id = ?',
+          [fiscalYearId]
+      ) as GroovyRowResult
+      if (row == null) {
+        throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
+      }
+      ((Number) row.get('companyId')).longValue()
+    }
+  }
+
   private static BigDecimal signedAmount(BigDecimal debitAmount, BigDecimal creditAmount, String normalBalanceSide) {
     String safeNormalBalanceSide = normalBalanceSide?.trim()?.toUpperCase(Locale.ROOT)
     if (!safeNormalBalanceSide) {
@@ -648,6 +663,7 @@ final class ReportDataService {
 
     final ReportSelection selection
     final FiscalYear fiscalYear
+    final long companyId
     final LocalDate startDate
     final LocalDate endDate
     final String selectionLabel
@@ -655,6 +671,7 @@ final class ReportDataService {
     private EffectiveSelection(
         ReportSelection selection,
         FiscalYear fiscalYear,
+        long companyId,
         LocalDate startDate,
         LocalDate endDate,
         String selectionLabel
@@ -667,6 +684,7 @@ final class ReportDataService {
           endDate
       )
       this.fiscalYear = fiscalYear
+      this.companyId = companyId
       this.startDate = startDate
       this.endDate = endDate
       this.selectionLabel = selectionLabel

--- a/app/src/main/groovy/se/alipsa/accounting/service/ReportDataService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/ReportDataService.groovy
@@ -626,14 +626,7 @@ final class ReportDataService {
 
   private long resolveCompanyId(long fiscalYearId) {
     databaseService.withSql { Sql sql ->
-      GroovyRowResult row = sql.firstRow(
-          'select company_id as companyId from fiscal_year where id = ?',
-          [fiscalYearId]
-      ) as GroovyRowResult
-      if (row == null) {
-        throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
-      }
-      ((Number) row.get('companyId')).longValue()
+      CompanyService.resolveFromFiscalYear(sql, fiscalYearId)
     }
   }
 

--- a/app/src/main/groovy/se/alipsa/accounting/service/ReportExportService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/ReportExportService.groovy
@@ -1,6 +1,5 @@
 package se.alipsa.accounting.service
 
-import groovy.sql.GroovyRowResult
 import groovy.sql.Sql
 
 import se.alipsa.accounting.domain.report.ReportArchive
@@ -82,14 +81,7 @@ final class ReportExportService {
 
   private long resolveCompanyId(long fiscalYearId) {
     databaseService.withSql { Sql sql ->
-      GroovyRowResult row = sql.firstRow(
-          'select company_id as companyId from fiscal_year where id = ?',
-          [fiscalYearId]
-      ) as GroovyRowResult
-      if (row == null) {
-        throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
-      }
-      ((Number) row.get('companyId')).longValue()
+      CompanyService.resolveFromFiscalYear(sql, fiscalYearId)
     }
   }
 

--- a/app/src/main/groovy/se/alipsa/accounting/service/ReportIntegrityService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/ReportIntegrityService.groovy
@@ -28,7 +28,7 @@ final class ReportIntegrityService {
   List<String> listCriticalProblems() {
     List<String> problems = []
     problems.addAll(voucherService.validateIntegrity())
-    attachmentService.findIntegrityFailures().each { AttachmentMetadata attachment ->
+    attachmentService.findAllIntegrityFailures().each { AttachmentMetadata attachment ->
       problems << ("Bilaga ${attachment.id} har avvikande checksumma eller saknas på disk." as String)
     }
     problems.addAll(auditLogService.validateIntegrity())

--- a/app/src/main/groovy/se/alipsa/accounting/service/ReportIntegrityService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/ReportIntegrityService.groovy
@@ -35,19 +35,44 @@ final class ReportIntegrityService {
     problems
   }
 
+  List<String> listCriticalProblems(long companyId) {
+    CompanyService.requireValidCompanyId(companyId)
+    List<String> problems = []
+    problems.addAll(voucherService.validateIntegrity(companyId))
+    attachmentService.findIntegrityFailures(companyId).each { AttachmentMetadata attachment ->
+      problems << ("Bilaga ${attachment.id} har avvikande checksumma eller saknas på disk." as String)
+    }
+    problems.addAll(auditLogService.validateIntegrity(companyId))
+    problems
+  }
+
   void ensureOperationAllowed(String operationLabel) {
     String safeOperationLabel = operationLabel?.trim() ?: 'Operationen'
     List<String> problems = listCriticalProblems()
+    blockIfProblems(safeOperationLabel, problems)
+  }
+
+  void ensureOperationAllowed(long companyId, String operationLabel) {
+    String safeOperationLabel = operationLabel?.trim() ?: 'Operationen'
+    List<String> problems = listCriticalProblems(companyId)
+    blockIfProblems(safeOperationLabel, problems)
+  }
+
+  void ensureReportingAllowed() {
+    ensureOperationAllowed('Rapportexport')
+  }
+
+  void ensureReportingAllowed(long companyId) {
+    ensureOperationAllowed(companyId, 'Rapportexport')
+  }
+
+  private static void blockIfProblems(String operationLabel, List<String> problems) {
     if (!problems.isEmpty()) {
       String summary = problems.take(5).join('\n')
       if (problems.size() > 5) {
         summary = "${summary}\n... samt ${problems.size() - 5} ytterligare problem."
       }
-      throw new IllegalStateException("${safeOperationLabel} blockeras eftersom integritetskontrollerna har fel:\n${summary}")
+      throw new IllegalStateException("${operationLabel} blockeras eftersom integritetskontrollerna har fel:\n${summary}")
     }
-  }
-
-  void ensureReportingAllowed() {
-    ensureOperationAllowed('Rapportexport')
   }
 }

--- a/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
@@ -77,7 +77,7 @@ final class SieImportExportService {
     this.reportIntegrityService = reportIntegrityService
     this.auditLogService = auditLogService
   }
-  SieImportResult importFile(Path filePath) {
+  SieImportResult importFile(long companyId, Path filePath) {
     Path safePath = validateImportPath(filePath)
     byte[] content = Files.readAllBytes(safePath)
     String checksum = sha256(content)
@@ -89,7 +89,7 @@ final class SieImportExportService {
     try {
       ParsedSie parsed = parseDocument(safePath)
       SieImportResult result = databaseService.withTransaction { Sql sql ->
-        FiscalYear fiscalYear = resolveTargetFiscalYear(sql, parsed.document)
+        FiscalYear fiscalYear = resolveTargetFiscalYear(sql, companyId, parsed.document)
         ImportCounts counts = importDocument(sql, fiscalYear.id, parsed.document, parsed.warnings)
         String summary = buildSuccessSummary(counts, fiscalYear, parsed.warnings)
         ImportJob job = completeImportJob(
@@ -102,7 +102,6 @@ final class SieImportExportService {
         )
         new SieImportResult(job, fiscalYear, false, counts.accountsCreated, counts.openingBalanceCount, counts.voucherCount, counts.lineCount, parsed.warnings)
       }
-      long companyId = resolveCompanyId(result.fiscalYear.id)
       auditLogService.logImport(
           "Importerade SIE ${result.job.fileName}",
           [
@@ -153,23 +152,25 @@ final class SieImportExportService {
         payload.voucherCount
     )
   }
-  List<ImportJob> listImportJobs(int limit = 20) {
+  List<ImportJob> listImportJobs(long companyId, int limit = 20) {
     int safeLimit = Math.max(1, limit)
     databaseService.withSql { Sql sql ->
       sql.rows('''
-          select id,
-                 file_name as fileName,
-                 checksum_sha256 as checksumSha256,
-                 fiscal_year_id as fiscalYearId,
-                 status,
-                 summary,
-                 error_log as errorLog,
-                 started_at as startedAt,
-                 completed_at as completedAt
-            from import_job
-           order by started_at desc, id desc
+          select ij.id,
+                 ij.file_name as fileName,
+                 ij.checksum_sha256 as checksumSha256,
+                 ij.fiscal_year_id as fiscalYearId,
+                 ij.status,
+                 ij.summary,
+                 ij.error_log as errorLog,
+                 ij.started_at as startedAt,
+                 ij.completed_at as completedAt
+            from import_job ij
+            left join fiscal_year fy on fy.id = ij.fiscal_year_id
+           where fy.company_id = ? or ij.fiscal_year_id is null
+           order by ij.started_at desc, ij.id desc
            limit ?
-      ''', [safeLimit]).collect { GroovyRowResult row ->
+      ''', [companyId, safeLimit]).collect { GroovyRowResult row ->
         mapImportJob(row)
       }
     }
@@ -269,7 +270,7 @@ final class SieImportExportService {
     new ParsedSie(document, warnings)
   }
 
-  private FiscalYear resolveTargetFiscalYear(Sql sql, SieDocument document) {
+  private FiscalYear resolveTargetFiscalYear(Sql sql, long companyId, SieDocument document) {
     SieBookingYear bookingYear = selectPrimaryBookingYear(document)
     GroovyRowResult existing = sql.firstRow('''
         select id,
@@ -279,11 +280,12 @@ final class SieImportExportService {
                closed,
                closed_at as closedAt
           from fiscal_year
-         where start_date = ?
+         where company_id = ?
+           and start_date = ?
            and end_date = ?
-    ''', [Date.valueOf(bookingYear.start), Date.valueOf(bookingYear.end)]) as GroovyRowResult
+    ''', [companyId, Date.valueOf(bookingYear.start), Date.valueOf(bookingYear.end)]) as GroovyRowResult
     FiscalYear fiscalYear = existing == null
-        ? createFiscalYear(sql, bookingYear.start, bookingYear.end)
+        ? createFiscalYear(sql, companyId, bookingYear.start, bookingYear.end)
         : mapFiscalYear(existing)
     ensureFiscalYearImportable(sql, fiscalYear)
     fiscalYear
@@ -300,13 +302,14 @@ final class SieImportExportService {
     document.getRars().values().sort { SieBookingYear year -> year.id }.first()
   }
 
-  private FiscalYear createFiscalYear(Sql sql, LocalDate startDate, LocalDate endDate) {
+  private FiscalYear createFiscalYear(Sql sql, long companyId, LocalDate startDate, LocalDate endDate) {
     String name = startDate.year == endDate.year
         ? startDate.year.toString()
         : "${startDate} - ${endDate}"
     FiscalYearService.createFiscalYear(
         sql,
         accountingPeriodService,
+        companyId,
         name,
         startDate,
         endDate,
@@ -368,9 +371,10 @@ final class SieImportExportService {
           select account_number as accountNumber,
                  manual_review_required as manualReviewRequired
             from account
-           where account_number = ?
+           where company_id = ?
+             and account_number = ?
           ''',
-          [accountNumber]
+          [companyId, accountNumber]
       ) as GroovyRowResult
       if (existing == null) {
         sql.executeInsert('''
@@ -407,13 +411,15 @@ final class SieImportExportService {
                    manual_review_required = ?,
                    classification_note = ?,
                    updated_at = current_timestamp
-             where account_number = ?
+             where company_id = ?
+               and account_number = ?
         ''', [
             accountName,
             classification.accountClass,
             classification.normalBalanceSide,
             classification.manualReviewRequired,
             classification.note,
+            companyId,
             accountNumber
         ])
       } else {
@@ -421,9 +427,11 @@ final class SieImportExportService {
             update account
                set account_name = ?,
                    updated_at = current_timestamp
-             where account_number = ?
+             where company_id = ?
+               and account_number = ?
         ''', [
             accountName,
+            companyId,
             accountNumber
         ])
       }
@@ -432,10 +440,11 @@ final class SieImportExportService {
   }
 
   private static int persistOpeningBalances(Sql sql, long fiscalYearId, List<SiePeriodValue> balances, List<String> warnings) {
+    long companyId = resolveCompanyId(sql, fiscalYearId)
     Map<String, BigDecimal> normalizedBalances = [:]
     (balances ?: []).each { SiePeriodValue value ->
       String accountNumber = normalizeAccountNumber(value.account?.number)
-      if (!isBalanceAccount(sql, accountNumber)) {
+      if (!isBalanceAccount(sql, companyId, accountNumber)) {
         warnings << ("Ingående balans för konto ${accountNumber} hoppades över eftersom kontot inte är ett balanskonto." as String)
         return
       }
@@ -444,7 +453,6 @@ final class SieImportExportService {
       }
       normalizedBalances[accountNumber] = scale(value.amount)
     }
-    long companyId = resolveCompanyId(sql, fiscalYearId)
     normalizedBalances.each { String accountNumber, BigDecimal amount ->
       GroovyRowResult account = sql.firstRow(
           'select id from account where company_id = ? and account_number = ?',
@@ -617,7 +625,8 @@ final class SieImportExportService {
       throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
     }
 
-    Map<String, AccountSeed> accounts = loadAccounts(sql)
+    long companyId = resolveCompanyId(sql, fiscalYearId)
+    Map<String, AccountSeed> accounts = loadAccounts(sql, companyId)
     Map<String, BigDecimal> openings = loadOpeningBalances(sql, fiscalYearId)
     List<ExportVoucherSeed> vouchers = loadBookedVouchers(sql, fiscalYearId)
     Map<String, BigDecimal> closings = loadClosingBalances(sql, fiscalYearId)
@@ -662,7 +671,7 @@ final class SieImportExportService {
     bookingYear
   }
 
-  private static Map<String, AccountSeed> loadAccounts(Sql sql) {
+  private static Map<String, AccountSeed> loadAccounts(Sql sql, long companyId) {
     Map<String, AccountSeed> accounts = [:]
     sql.rows('''
         select account_number as accountNumber,
@@ -670,8 +679,9 @@ final class SieImportExportService {
                account_class as accountClass,
                normal_balance_side as normalBalanceSide
           from account
+         where company_id = ?
          order by account_number
-    ''').each { GroovyRowResult row ->
+    ''', [companyId]).each { GroovyRowResult row ->
       accounts[row.get('accountNumber') as String] = new AccountSeed(
           row.get('accountName') as String,
           row.get('accountClass') as String,
@@ -900,10 +910,10 @@ final class SieImportExportService {
     )
   }
 
-  private static boolean isBalanceAccount(Sql sql, String accountNumber) {
+  private static boolean isBalanceAccount(Sql sql, long companyId, String accountNumber) {
     GroovyRowResult row = sql.firstRow(
-        'select account_class as accountClass from account where account_number = ?',
-        [accountNumber]
+        'select account_class as accountClass from account where company_id = ? and account_number = ?',
+        [companyId, accountNumber]
     ) as GroovyRowResult
     String accountClass = row?.get('accountClass') as String
     accountClass in ['ASSET', 'LIABILITY', 'EQUITY']

--- a/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
@@ -83,7 +83,7 @@ final class SieImportExportService {
     byte[] content = Files.readAllBytes(safePath)
     String checksum = sha256(content)
     long jobId = createImportJob(companyId, safePath.fileName.toString(), checksum)
-    ImportJob duplicate = markDuplicateIfNeeded(jobId, checksum)
+    ImportJob duplicate = markDuplicateIfNeeded(jobId, companyId, checksum)
     if (duplicate != null) {
       return new SieImportResult(duplicate, null, true, 0, 0, 0, 0, [])
     }
@@ -225,18 +225,19 @@ final class SieImportExportService {
       ((Number) keys.first().first()).longValue()
     }
   }
-  private ImportJob markDuplicateIfNeeded(long jobId, String checksum) {
+  private ImportJob markDuplicateIfNeeded(long jobId, long companyId, String checksum) {
     databaseService.withTransaction { Sql sql ->
       GroovyRowResult existing = sql.firstRow('''
           select id,
                  file_name as fileName
             from import_job
            where checksum_sha256 = ?
+             and company_id = ?
              and status = 'SUCCESS'
              and id <> ?
            order by completed_at desc, id desc
            limit 1
-      ''', [checksum, jobId]) as GroovyRowResult
+      ''', [checksum, companyId, jobId]) as GroovyRowResult
       if (existing == null) {
         return null
       }

--- a/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
@@ -78,18 +78,21 @@ final class SieImportExportService {
     this.auditLogService = auditLogService
   }
   SieImportResult importFile(long companyId, Path filePath) {
+    CompanyService.requireValidCompanyId(companyId)
     Path safePath = validateImportPath(filePath)
     byte[] content = Files.readAllBytes(safePath)
     String checksum = sha256(content)
-    long jobId = createImportJob(safePath.fileName.toString(), checksum)
+    long jobId = createImportJob(companyId, safePath.fileName.toString(), checksum)
     ImportJob duplicate = markDuplicateIfNeeded(jobId, checksum)
     if (duplicate != null) {
       return new SieImportResult(duplicate, null, true, 0, 0, 0, 0, [])
     }
+    Long resolvedFiscalYearId = null
     try {
       ParsedSie parsed = parseDocument(safePath)
       SieImportResult result = databaseService.withTransaction { Sql sql ->
         FiscalYear fiscalYear = resolveTargetFiscalYear(sql, companyId, parsed.document)
+        resolvedFiscalYearId = fiscalYear.id
         ImportCounts counts = importDocument(sql, fiscalYear.id, parsed.document, parsed.warnings)
         String summary = buildSuccessSummary(counts, fiscalYear, parsed.warnings)
         ImportJob job = completeImportJob(
@@ -114,7 +117,7 @@ final class SieImportExportService {
       )
       result
     } catch (Exception exception) {
-      markFailed(jobId, exception)
+      markFailed(jobId, resolvedFiscalYearId, exception)
       throw exception
     }
   }
@@ -153,6 +156,7 @@ final class SieImportExportService {
     )
   }
   List<ImportJob> listImportJobs(long companyId, int limit = 20) {
+    CompanyService.requireValidCompanyId(companyId)
     int safeLimit = Math.max(1, limit)
     databaseService.withSql { Sql sql ->
       sql.rows('''
@@ -166,8 +170,7 @@ final class SieImportExportService {
                  ij.started_at as startedAt,
                  ij.completed_at as completedAt
             from import_job ij
-            left join fiscal_year fy on fy.id = ij.fiscal_year_id
-           where fy.company_id = ? or ij.fiscal_year_id is null
+           where ij.company_id = ?
            order by ij.started_at desc, ij.id desc
            limit ?
       ''', [companyId, safeLimit]).collect { GroovyRowResult row ->
@@ -205,10 +208,11 @@ final class SieImportExportService {
     }
     settings
   }
-  private long createImportJob(String fileName, String checksum) {
+  private long createImportJob(long companyId, String fileName, String checksum) {
     databaseService.withTransaction { Sql sql ->
       List<List<Object>> keys = sql.executeInsert('''
           insert into import_job (
+              company_id,
               file_name,
               checksum_sha256,
               status,
@@ -216,8 +220,8 @@ final class SieImportExportService {
               error_log,
               started_at,
               completed_at
-          ) values (?, ?, 'STARTED', ?, null, current_timestamp, null)
-      ''', [truncate(fileName, 255), checksum, 'Import startad.'])
+          ) values (?, ?, ?, 'STARTED', ?, null, current_timestamp, null)
+      ''', [companyId, truncate(fileName, 255), checksum, 'Import startad.'])
       ((Number) keys.first().first()).longValue()
     }
   }
@@ -823,16 +827,18 @@ final class SieImportExportService {
     findImportJob(sql, jobId)
   }
 
-  private void markFailed(long jobId, Exception exception) {
+  private void markFailed(long jobId, Long fiscalYearId, Exception exception) {
     databaseService.withTransaction { Sql sql ->
       sql.executeUpdate('''
           update import_job
-             set status = 'FAILED',
+             set fiscal_year_id = coalesce(?, fiscal_year_id),
+                 status = 'FAILED',
                  summary = ?,
                  error_log = ?,
                  completed_at = current_timestamp
            where id = ?
       ''', [
+          fiscalYearId,
           truncate(exception.message ?: 'Importen misslyckades.', 1000),
           truncate(buildFailureLog(exception), 20000),
           jobId
@@ -930,19 +936,12 @@ final class SieImportExportService {
   }
 
   private static long resolveCompanyId(Sql sql, long fiscalYearId) {
-    GroovyRowResult row = sql.firstRow(
-        'select company_id as companyId from fiscal_year where id = ?',
-        [fiscalYearId]
-    ) as GroovyRowResult
-    if (row == null) {
-      throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
-    }
-    ((Number) row.get('companyId')).longValue()
+    CompanyService.resolveFromFiscalYear(sql, fiscalYearId)
   }
 
   private long resolveCompanyId(long fiscalYearId) {
     databaseService.withSql { Sql sql ->
-      resolveCompanyId(sql, fiscalYearId)
+      CompanyService.resolveFromFiscalYear(sql, fiscalYearId)
     }
   }
 

--- a/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
@@ -448,6 +448,10 @@ final class SieImportExportService {
     Map<String, BigDecimal> normalizedBalances = [:]
     (balances ?: []).each { SiePeriodValue value ->
       String accountNumber = normalizeAccountNumber(value.account?.number)
+      if (!accountExists(sql, companyId, accountNumber)) {
+        warnings << ("Ingående balans för konto ${accountNumber} hoppades över eftersom kontot inte finns." as String)
+        return
+      }
       if (!isBalanceAccount(sql, companyId, accountNumber)) {
         warnings << ("Ingående balans för konto ${accountNumber} hoppades över eftersom kontot inte är ett balanskonto." as String)
         return
@@ -917,12 +921,20 @@ final class SieImportExportService {
   }
 
   private static boolean isBalanceAccount(Sql sql, long companyId, String accountNumber) {
+    String accountClass = lookupAccountClass(sql, companyId, accountNumber)
+    accountClass in ['ASSET', 'LIABILITY', 'EQUITY']
+  }
+
+  private static boolean accountExists(Sql sql, long companyId, String accountNumber) {
+    lookupAccountClass(sql, companyId, accountNumber) != null
+  }
+
+  private static String lookupAccountClass(Sql sql, long companyId, String accountNumber) {
     GroovyRowResult row = sql.firstRow(
         'select account_class as accountClass from account where company_id = ? and account_number = ?',
         [companyId, accountNumber]
     ) as GroovyRowResult
-    String accountClass = row?.get('accountClass') as String
-    accountClass in ['ASSET', 'LIABILITY', 'EQUITY']
+    row?.get('accountClass') as String
   }
 
   private static BigDecimal signedAmount(BigDecimal debitAmount, BigDecimal creditAmount, String normalBalanceSide) {

--- a/app/src/main/groovy/se/alipsa/accounting/service/StartupVerificationService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/StartupVerificationService.groovy
@@ -44,7 +44,7 @@ final class StartupVerificationService {
     }
 
     errors.addAll(reportIntegrityService.listCriticalProblems())
-    reportArchiveService.findIntegrityFailures().each { ReportArchive archive ->
+    reportArchiveService.findAllIntegrityFailures().each { ReportArchive archive ->
       errors << ("Rapportarkiv ${archive.id} har avvikande checksumma eller saknas på disk." as String)
     }
 

--- a/app/src/main/groovy/se/alipsa/accounting/service/SystemDiagnosticsService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/SystemDiagnosticsService.groovy
@@ -34,7 +34,7 @@ final class SystemDiagnosticsService {
   SystemDiagnosticsSnapshot snapshot() {
     StartupVerificationReport verificationReport = startupVerificationService.verify()
     BackupSummary latestBackup = backupService.listBackups(1).find()
-    AuditLogEntry latestSieExport = auditLogService.listEntries(200).find { AuditLogEntry entry ->
+    AuditLogEntry latestSieExport = auditLogService.listAllEntries(200).find { AuditLogEntry entry ->
       entry.eventType == AuditLogService.EXPORT && entry.summary?.startsWith('Exporterade SIE')
     }
     Path databaseFile = AppPaths.databaseBasePath().resolveSibling('accounting.mv.db')

--- a/app/src/main/groovy/se/alipsa/accounting/service/SystemDocumentationService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/SystemDocumentationService.groovy
@@ -48,7 +48,7 @@ final class SystemDocumentationService {
     SystemDiagnosticsSnapshot diagnostics = diagnosticsService.snapshot()
     List<MigrationService.AppliedMigration> migrations = migrationService.listAppliedMigrations()
     List<AttachmentMetadata> attachments = attachmentService.listAllAttachments()
-    List<ReportArchive> archives = reportArchiveService.listArchives(200)
+    List<ReportArchive> archives = reportArchiveService.listAllArchives(200)
     List<String> lines = [
         '# Alipsa Accounting systemdokumentation',
         '',
@@ -110,7 +110,7 @@ final class SystemDocumentationService {
         '## Audit-logg',
         ''
     ])
-    auditLogService.listEntries(20).each { entry ->
+    auditLogService.listAllEntries(20).each { entry ->
       lines << "- ${entry.createdAt}: `${entry.eventType}` ${entry.summary}".toString()
     }
     lines.join('\n')

--- a/app/src/main/groovy/se/alipsa/accounting/service/VatService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/VatService.groovy
@@ -132,7 +132,8 @@ final class VatService {
       if (balances.isEmpty()) {
         throw new IllegalStateException("Momsperiod ${period.periodName} saknar momsbalanser att överföra.")
       }
-      requireSettlementAccount(sql, settlementAccount)
+      long companyId = resolveCompanyId(sql, period.fiscalYearId)
+      requireSettlementAccount(sql, companyId, settlementAccount)
       List<VoucherLine> lines = buildTransferLines(balances, settlementAccount)
       String description = "Momsöverföring ${period.periodName}"
       Voucher voucher = bookTransferVoucher(sql, period, seriesCode, description, lines)
@@ -157,12 +158,13 @@ final class VatService {
   @PackageScope
   static void ensurePeriodsForFiscalYear(Sql sql, long fiscalYearId) {
     GroovyRowResult fiscalYearRow = sql.firstRow(
-        'select count(*) as total from fiscal_year where id = ?',
+        'select company_id as companyId from fiscal_year where id = ?',
         [fiscalYearId]
     ) as GroovyRowResult
-    if (((Number) fiscalYearRow.get('total')).intValue() != 1) {
+    if (fiscalYearRow == null) {
       throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
     }
+    long companyId = ((Number) fiscalYearRow.get('companyId')).longValue()
 
     GroovyRowResult existing = sql.firstRow(
         'select count(*) as total from vat_period where fiscal_year_id = ?',
@@ -172,7 +174,7 @@ final class VatService {
       return
     }
 
-    VatPeriodicity periodicity = loadPeriodicity(sql)
+    VatPeriodicity periodicity = loadPeriodicity(sql, companyId)
     List<GroovyRowResult> accountingPeriods = sql.rows('''
         select period_index as periodIndex,
                period_name as periodName,
@@ -242,12 +244,12 @@ final class VatService {
     }
   }
 
-  private static VatPeriodicity loadPeriodicity(Sql sql) {
+  private static VatPeriodicity loadPeriodicity(Sql sql, long companyId) {
     GroovyRowResult row = sql.firstRow('''
         select vat_periodicity as vatPeriodicity
-          from company_settings
-         where id = 1
-    ''') as GroovyRowResult
+          from company
+         where id = ?
+    ''', [companyId]) as GroovyRowResult
     VatPeriodicity.fromDatabaseValue(row?.get('vatPeriodicity') as String)
   }
 
@@ -400,13 +402,14 @@ final class VatService {
     lines
   }
 
-  private static void requireSettlementAccount(Sql sql, String accountNumber) {
+  private static void requireSettlementAccount(Sql sql, long companyId, String accountNumber) {
     GroovyRowResult row = sql.firstRow('''
         select account_number as accountNumber,
                account_class as accountClass
           from account
-         where account_number = ?
-    ''', [accountNumber?.trim()]) as GroovyRowResult
+         where company_id = ?
+           and account_number = ?
+    ''', [companyId, accountNumber?.trim()]) as GroovyRowResult
     if (row == null) {
       throw new IllegalArgumentException("Momsredovisningskonto saknas: ${accountNumber}")
     }
@@ -454,6 +457,17 @@ final class VatService {
     payload.append(report.netVatToPay.toPlainString())
     MessageDigest digest = MessageDigest.getInstance('SHA-256')
     HexFormat.of().formatHex(digest.digest(payload.toString().getBytes(StandardCharsets.UTF_8)))
+  }
+
+  private static long resolveCompanyId(Sql sql, long fiscalYearId) {
+    GroovyRowResult row = sql.firstRow(
+        'select company_id as companyId from fiscal_year where id = ?',
+        [fiscalYearId]
+    ) as GroovyRowResult
+    if (row == null) {
+      throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
+    }
+    ((Number) row.get('companyId')).longValue()
   }
 
   private static VatPeriod requirePeriod(Sql sql, long vatPeriodId) {

--- a/app/src/main/groovy/se/alipsa/accounting/service/VatService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/VatService.groovy
@@ -460,14 +460,7 @@ final class VatService {
   }
 
   private static long resolveCompanyId(Sql sql, long fiscalYearId) {
-    GroovyRowResult row = sql.firstRow(
-        'select company_id as companyId from fiscal_year where id = ?',
-        [fiscalYearId]
-    ) as GroovyRowResult
-    if (row == null) {
-      throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
-    }
-    ((Number) row.get('companyId')).longValue()
+    CompanyService.resolveFromFiscalYear(sql, fiscalYearId)
   }
 
   private static VatPeriod requirePeriod(Sql sql, long vatPeriodId) {

--- a/app/src/main/groovy/se/alipsa/accounting/service/VatService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/VatService.groovy
@@ -250,7 +250,10 @@ final class VatService {
           from company
          where id = ?
     ''', [companyId]) as GroovyRowResult
-    VatPeriodicity.fromDatabaseValue(row?.get('vatPeriodicity') as String)
+    if (row == null) {
+      throw new IllegalArgumentException("Okänt företag: ${companyId}")
+    }
+    VatPeriodicity.fromDatabaseValue(row.get('vatPeriodicity') as String)
   }
 
   private static List<VatPeriod> listPeriods(Sql sql, long fiscalYearId) {

--- a/app/src/main/groovy/se/alipsa/accounting/service/VoucherService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/VoucherService.groovy
@@ -243,10 +243,17 @@ final class VoucherService {
     databaseService.withTransaction { Sql sql ->
       List<String> problems = []
       sql.rows('select distinct company_id as companyId from voucher').each { GroovyRowResult companyRow ->
-        long companyId = ((Number) companyRow.get('companyId')).longValue()
-        problems.addAll(validateIntegrityForCompany(sql, companyId))
+        long cid = ((Number) companyRow.get('companyId')).longValue()
+        problems.addAll(validateIntegrityForCompany(sql, cid))
       }
       problems
+    }
+  }
+
+  List<String> validateIntegrity(long companyId) {
+    CompanyService.requireValidCompanyId(companyId)
+    databaseService.withTransaction { Sql sql ->
+      validateIntegrityForCompany(sql, companyId)
     }
   }
 
@@ -305,6 +312,7 @@ final class VoucherService {
   }
 
   List<Voucher> listVouchers(long companyId, Long fiscalYearId = null, VoucherStatus status = null, String queryText = null) {
+    CompanyService.requireValidCompanyId(companyId)
     databaseService.withSql { Sql sql ->
       StringBuilder query = new StringBuilder('''
           select v.id,
@@ -768,14 +776,7 @@ final class VoucherService {
   }
 
   private static long resolveCompanyId(Sql sql, long fiscalYearId) {
-    GroovyRowResult row = sql.firstRow(
-        'select company_id as companyId from fiscal_year where id = ?',
-        [fiscalYearId]
-    ) as GroovyRowResult
-    if (row == null) {
-      throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
-    }
-    ((Number) row.get('companyId')).longValue()
+    CompanyService.resolveFromFiscalYear(sql, fiscalYearId)
   }
 
   private static ChainHead lockChainHead(Sql sql, long companyId) {

--- a/app/src/main/groovy/se/alipsa/accounting/service/VoucherService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/VoucherService.groovy
@@ -304,7 +304,7 @@ final class VoucherService {
     problems
   }
 
-  List<Voucher> listVouchers(Long fiscalYearId = null, VoucherStatus status = null, String queryText = null) {
+  List<Voucher> listVouchers(long companyId, Long fiscalYearId = null, VoucherStatus status = null, String queryText = null) {
     databaseService.withSql { Sql sql ->
       StringBuilder query = new StringBuilder('''
           select v.id,
@@ -323,9 +323,9 @@ final class VoucherService {
                  v.booked_at as bookedAt
             from voucher v
             join voucher_series s on s.id = v.voucher_series_id
-           where 1 = 1
+           where v.company_id = ?
       ''')
-      List<Object> params = []
+      List<Object> params = [companyId]
 
       if (fiscalYearId != null) {
         query.append(' and v.fiscal_year_id = ?')

--- a/app/src/main/groovy/se/alipsa/accounting/ui/ChartOfAccountsPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/ChartOfAccountsPanel.groovy
@@ -4,6 +4,7 @@ import se.alipsa.accounting.domain.Account
 import se.alipsa.accounting.service.AccountService
 import se.alipsa.accounting.service.ChartOfAccountsImportService
 import se.alipsa.accounting.service.ChartOfAccountsImportService.ImportSummary
+import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.support.I18n
 
@@ -217,6 +218,7 @@ final class ChartOfAccountsPanel extends JPanel implements PropertyChangeListene
     String accountClass = selectedClass in [null, allFilterLabel(), reviewFilterLabel()] ? '' : selectedClass
 
     List<Account> accounts = accountService.searchAccounts(
+        CompanyService.LEGACY_COMPANY_ID,
         searchField.text,
         accountClass,
         activeOnlyCheckBox.selected,
@@ -228,7 +230,7 @@ final class ChartOfAccountsPanel extends JPanel implements PropertyChangeListene
   }
 
   private void refreshOverview() {
-    AccountService.AccountOverview overview = accountService.loadOverview()
+    AccountService.AccountOverview overview = accountService.loadOverview(CompanyService.LEGACY_COMPANY_ID)
     overviewLabel.text = I18n.instance.format('chartOfAccountsPanel.overview',
         overview.totalCount as Object, overview.activeCount as Object,
         overview.manualReviewCount as Object)
@@ -294,7 +296,7 @@ final class ChartOfAccountsPanel extends JPanel implements PropertyChangeListene
       return
     }
 
-    accountService.setAccountActive(account.accountNumber, !account.active)
+    accountService.setAccountActive(CompanyService.LEGACY_COMPANY_ID, account.accountNumber, !account.active)
     reloadAccounts()
     selectAccount(account.accountNumber)
     String status = account.active

--- a/app/src/main/groovy/se/alipsa/accounting/ui/FiscalYearPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/FiscalYearPanel.groovy
@@ -4,6 +4,7 @@ import se.alipsa.accounting.domain.AccountingPeriod
 import se.alipsa.accounting.domain.FiscalYear
 import se.alipsa.accounting.service.AccountingPeriodService
 import se.alipsa.accounting.service.ClosingService
+import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.support.I18n
 
@@ -189,7 +190,7 @@ final class FiscalYearPanel extends JPanel implements PropertyChangeListener {
     }
 
     try {
-      FiscalYear year = fiscalYearService.createFiscalYear(nameField.text, startDate, endDate)
+      FiscalYear year = fiscalYearService.createFiscalYear(CompanyService.LEGACY_COMPANY_ID, nameField.text, startDate, endDate)
       clearInputs()
       reloadData()
       selectFiscalYear(year.id)
@@ -229,7 +230,7 @@ final class FiscalYearPanel extends JPanel implements PropertyChangeListener {
   }
 
   private void reloadData() {
-    List<FiscalYear> fiscalYears = fiscalYearService.listFiscalYears()
+    List<FiscalYear> fiscalYears = fiscalYearService.listFiscalYears(CompanyService.LEGACY_COMPANY_ID)
     fiscalYearTableModel.setRows(fiscalYears)
     if (!fiscalYears.isEmpty() && fiscalYearTable.selectedRow < 0) {
       fiscalYearTable.setRowSelectionInterval(0, 0)

--- a/app/src/main/groovy/se/alipsa/accounting/ui/OpeningBalanceDialog.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/OpeningBalanceDialog.groovy
@@ -4,6 +4,7 @@ import se.alipsa.accounting.domain.Account
 import se.alipsa.accounting.domain.FiscalYear
 import se.alipsa.accounting.domain.OpeningBalance
 import se.alipsa.accounting.service.AccountService
+import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.support.I18n
 
@@ -49,7 +50,7 @@ final class OpeningBalanceDialog extends JDialog {
     this.account = account
     this.onSave = onSave
 
-    List<FiscalYear> fiscalYears = fiscalYearService.listFiscalYears()
+    List<FiscalYear> fiscalYears = fiscalYearService.listFiscalYears(CompanyService.LEGACY_COMPANY_ID)
     fiscalYearComboBox = new JComboBox<>(fiscalYears as FiscalYear[])
     buildUi()
     refreshCurrentAmount()

--- a/app/src/main/groovy/se/alipsa/accounting/ui/ReportPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/ReportPanel.groovy
@@ -7,6 +7,7 @@ import se.alipsa.accounting.domain.report.ReportResult
 import se.alipsa.accounting.domain.report.ReportSelection
 import se.alipsa.accounting.domain.report.ReportType
 import se.alipsa.accounting.service.AccountingPeriodService
+import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.service.JournoReportService
 import se.alipsa.accounting.service.ReportArchiveService
@@ -253,7 +254,7 @@ final class ReportPanel extends JPanel implements PropertyChangeListener {
   private void reloadFiscalYears() {
     FiscalYear selected = selectedFiscalYear()
     fiscalYearComboBox.removeAllItems()
-    fiscalYearService.listFiscalYears().each { FiscalYear fiscalYear ->
+    fiscalYearService.listFiscalYears(CompanyService.LEGACY_COMPANY_ID).each { FiscalYear fiscalYear ->
       fiscalYearComboBox.addItem(fiscalYear)
     }
     if (selected != null) {
@@ -366,7 +367,7 @@ final class ReportPanel extends JPanel implements PropertyChangeListener {
   }
 
   private void reloadArchives() {
-    archiveTableModel.setRows(reportArchiveService.listArchives(100))
+    archiveTableModel.setRows(reportArchiveService.listArchives(CompanyService.LEGACY_COMPANY_ID, 100))
     updateActionButtons()
   }
 

--- a/app/src/main/groovy/se/alipsa/accounting/ui/SieExchangeDialog.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/SieExchangeDialog.groovy
@@ -2,6 +2,7 @@ package se.alipsa.accounting.ui
 
 import se.alipsa.accounting.domain.FiscalYear
 import se.alipsa.accounting.domain.ImportJob
+import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.service.SieExportResult
 import se.alipsa.accounting.service.SieImportExportService
@@ -150,7 +151,7 @@ final class SieExchangeDialog extends JDialog {
   private void reloadFiscalYears() {
     FiscalYear selected = fiscalYearComboBox.selectedItem as FiscalYear
     fiscalYearComboBox.removeAllItems()
-    fiscalYearService.listFiscalYears().each { FiscalYear fiscalYear ->
+    fiscalYearService.listFiscalYears(CompanyService.LEGACY_COMPANY_ID).each { FiscalYear fiscalYear ->
       fiscalYearComboBox.addItem(fiscalYear)
     }
     if (selected != null) {
@@ -159,7 +160,7 @@ final class SieExchangeDialog extends JDialog {
   }
 
   private void reloadJobs() {
-    importJobTableModel.setRows(sieImportExportService.listImportJobs())
+    importJobTableModel.setRows(sieImportExportService.listImportJobs(CompanyService.LEGACY_COMPANY_ID))
   }
 
   private void importRequested() {
@@ -175,7 +176,7 @@ final class SieExchangeDialog extends JDialog {
     new SwingWorker<SieImportResult, Void>() {
       @Override
       protected SieImportResult doInBackground() {
-        sieImportExportService.importFile(selectedPath)
+        sieImportExportService.importFile(CompanyService.LEGACY_COMPANY_ID, selectedPath)
       }
 
       @Override

--- a/app/src/main/groovy/se/alipsa/accounting/ui/VatPeriodPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/VatPeriodPanel.groovy
@@ -2,6 +2,7 @@ package se.alipsa.accounting.ui
 
 import se.alipsa.accounting.domain.FiscalYear
 import se.alipsa.accounting.domain.VatPeriod
+import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.service.VatService
 import se.alipsa.accounting.support.I18n
@@ -160,7 +161,7 @@ final class VatPeriodPanel extends JPanel implements PropertyChangeListener {
   private void reloadFiscalYears() {
     FiscalYear selected = selectedFiscalYear()
     fiscalYearComboBox.removeAllItems()
-    fiscalYearService.listFiscalYears().each { FiscalYear fiscalYear ->
+    fiscalYearService.listFiscalYears(CompanyService.LEGACY_COMPANY_ID).each { FiscalYear fiscalYear ->
       fiscalYearComboBox.addItem(fiscalYear)
     }
     if (selected != null) {

--- a/app/src/main/groovy/se/alipsa/accounting/ui/VoucherEditor.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/VoucherEditor.groovy
@@ -10,6 +10,7 @@ import se.alipsa.accounting.domain.VoucherStatus
 import se.alipsa.accounting.service.AccountService
 import se.alipsa.accounting.service.AttachmentService
 import se.alipsa.accounting.service.AuditLogService
+import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.service.VoucherService
 import se.alipsa.accounting.support.I18n
@@ -121,7 +122,7 @@ final class VoucherEditor extends JDialog implements PropertyChangeListener {
     this.onSave = onSave
     voucher = voucherId == null ? null : voucherService.findVoucher(voucherId)
     readOnly = voucher != null && voucher.status != VoucherStatus.DRAFT
-    fiscalYearComboBox = new JComboBox<>(fiscalYearService.listFiscalYears() as FiscalYear[])
+    fiscalYearComboBox = new JComboBox<>(fiscalYearService.listFiscalYears(CompanyService.LEGACY_COMPANY_ID) as FiscalYear[])
     lineTableModel = new LineTableModel(accountService, !readOnly)
     lineTable = new JTable(lineTableModel)
     setTitle(voucherId == null
@@ -731,7 +732,7 @@ final class VoucherEditor extends JDialog implements PropertyChangeListener {
         return ''
       }
       try {
-        Account account = accountService.findAccount(normalized)
+        Account account = accountService.findAccount(CompanyService.LEGACY_COMPANY_ID, normalized)
         account == null
             ? I18n.instance.getString('voucherEditor.table.line.unknownAccount')
             : account.accountName

--- a/app/src/main/groovy/se/alipsa/accounting/ui/VoucherListPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/VoucherListPanel.groovy
@@ -6,6 +6,7 @@ import se.alipsa.accounting.domain.VoucherStatus
 import se.alipsa.accounting.service.AccountService
 import se.alipsa.accounting.service.AttachmentService
 import se.alipsa.accounting.service.AuditLogService
+import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.service.VoucherService
 import se.alipsa.accounting.support.I18n
@@ -218,7 +219,7 @@ final class VoucherListPanel extends JPanel implements PropertyChangeListener {
       Object selected = fiscalYearComboBox.selectedItem
       fiscalYearComboBox.removeAllItems()
       fiscalYearComboBox.addItem(allFilterValue)
-      fiscalYearService.listFiscalYears().each { FiscalYear fiscalYear ->
+      fiscalYearService.listFiscalYears(CompanyService.LEGACY_COMPANY_ID).each { FiscalYear fiscalYear ->
         fiscalYearComboBox.addItem(fiscalYear)
       }
       if (selected != null) {
@@ -245,7 +246,7 @@ final class VoucherListPanel extends JPanel implements PropertyChangeListener {
     }
     Long fiscalYearId = selectedFiscalYearId()
     VoucherStatus status = selectedStatus()
-    List<Voucher> vouchers = voucherService.listVouchers(fiscalYearId, status, searchField.text)
+    List<Voucher> vouchers = voucherService.listVouchers(CompanyService.LEGACY_COMPANY_ID, fiscalYearId, status, searchField.text)
     tableModel.setRows(vouchers)
     showInfo(I18n.instance.format('voucherListPanel.message.showing', vouchers.size()))
   }

--- a/app/src/test/groovy/acceptance/se/alipsa/accounting/AcceptanceCriteriaTest.groovy
+++ b/app/src/test/groovy/acceptance/se/alipsa/accounting/AcceptanceCriteriaTest.groovy
@@ -29,6 +29,7 @@ import se.alipsa.accounting.service.BackupService
 import se.alipsa.accounting.service.BackupSummary
 import se.alipsa.accounting.service.ChartOfAccountsImportService
 import se.alipsa.accounting.service.ClosingService
+import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.CompanySettingsService
 import se.alipsa.accounting.service.DatabaseService
 import se.alipsa.accounting.service.FiscalYearService
@@ -77,7 +78,7 @@ class AcceptanceCriteriaTest {
     AcceptanceServices services = createAcceptanceServices(databaseService)
 
     services.companySettingsService.save(new CompanySettings(1L, 'Accept AB', '556677-8899', 'SEK', 'sv-SE', VatPeriodicity.MONTHLY))
-    FiscalYear fiscalYear = services.fiscalYearService.createFiscalYear('2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    FiscalYear fiscalYear = services.fiscalYearService.createFiscalYear(CompanyService.LEGACY_COMPANY_ID, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
     Path workbook = createBasWorkbook()
     new ChartOfAccountsImportService(databaseService).importFromExcel(workbook)
     configureVatAccounts(databaseService)
@@ -226,6 +227,7 @@ class AcceptanceCriteriaTest {
 
   private static AcceptanceServices createAcceptanceServices(DatabaseService databaseService) {
     CompanySettingsService companySettingsService = new CompanySettingsService(databaseService)
+    CompanyService companyService = new CompanyService(databaseService)
     AuditLogService auditLogService = new AuditLogService(databaseService)
     AccountingPeriodService accountingPeriodService = new AccountingPeriodService(databaseService, auditLogService)
     FiscalYearService fiscalYearService = new FiscalYearService(databaseService, accountingPeriodService, auditLogService)
@@ -246,7 +248,7 @@ class AcceptanceCriteriaTest {
             reportDataService,
             reportArchiveService,
             reportIntegrityService,
-            companySettingsService,
+            companyService,
             auditLogService,
             databaseService
         ),

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/AttachmentServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/AttachmentServiceTest.groovy
@@ -51,6 +51,7 @@ class AttachmentServiceTest {
     fiscalYearService = new FiscalYearService(databaseService, accountingPeriodService, auditLogService)
     voucherService = new VoucherService(databaseService, auditLogService)
     fiscalYear = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID,
         '2026',
         LocalDate.of(2026, 1, 1),
         LocalDate.of(2026, 12, 31)
@@ -83,7 +84,7 @@ class AttachmentServiceTest {
     assertEquals(attachment.id, attachments.first().id)
     assertTrue(Files.exists(attachmentService.resolveStoredPath(attachment)))
     assertTrue(attachmentService.verifyAttachment(attachment.id))
-    assertEquals([], attachmentService.findIntegrityFailures())
+    assertEquals([], attachmentService.findIntegrityFailures(CompanyService.LEGACY_COMPANY_ID))
     assertArrayEquals(Files.readAllBytes(source), attachmentService.readAttachment(attachment.id))
     assertTrue(auditEntries.any { AuditLogEntry entry -> entry.eventType == AuditLogService.ATTACHMENT_ADDED })
   }
@@ -104,7 +105,7 @@ class AttachmentServiceTest {
     Files.writeString(attachmentService.resolveStoredPath(attachment), 'modified', StandardCharsets.UTF_8)
 
     assertFalse(attachmentService.verifyAttachment(attachment.id))
-    assertEquals([attachment.id], attachmentService.findIntegrityFailures()*.id)
+    assertEquals([attachment.id], attachmentService.findIntegrityFailures(CompanyService.LEGACY_COMPANY_ID)*.id)
   }
 
   @Test
@@ -129,7 +130,7 @@ class AttachmentServiceTest {
     }
 
     assertTrue(exception.message.contains('utanför bilagearkivet'))
-    assertEquals([attachment.id], attachmentService.findIntegrityFailures()*.id)
+    assertEquals([attachment.id], attachmentService.findIntegrityFailures(CompanyService.LEGACY_COMPANY_ID)*.id)
   }
 
   private void insertTestAccounts() {

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/AuditLogServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/AuditLogServiceTest.groovy
@@ -46,7 +46,7 @@ class AuditLogServiceTest {
     auditLogService.logBackup('Skapade backup', 'archive=backup.zip')
     auditLogService.logRestore('Återställde backup', 'archive=backup.zip')
 
-    List<AuditLogEntry> entries = auditLogService.listEntries()
+    List<AuditLogEntry> entries = auditLogService.listEntries(CompanyService.LEGACY_COMPANY_ID)
 
     assertEquals(4, entries.size())
     assertTrue(entries.any { AuditLogEntry entry -> entry.eventType == AuditLogService.IMPORT })

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/BackupServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/BackupServiceTest.groovy
@@ -107,7 +107,7 @@ class BackupServiceTest {
     ReportArchiveService reportArchiveService = new ReportArchiveService(databaseService)
 
     companySettingsService.save(new CompanySettings(1L, 'Testbolaget AB', '556677-8899', 'SEK', 'sv-SE', VatPeriodicity.MONTHLY))
-    def fiscalYear = fiscalYearService.createFiscalYear('2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    def fiscalYear = fiscalYearService.createFiscalYear(CompanyService.LEGACY_COMPANY_ID, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
     databaseService.withTransaction { Sql sql ->
       insertAccount(sql, '1510', 'Kundfordringar', 'ASSET', 'DEBIT')
       insertAccount(sql, '1930', 'Bankkonto', 'ASSET', 'DEBIT')

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/ChartOfAccountsImportServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/ChartOfAccountsImportServiceTest.groovy
@@ -57,10 +57,10 @@ class ChartOfAccountsImportServiceTest {
     assertTrue(summary.createdCount > 1000)
     assertTrue(summary.manualReviewCount > 0)
 
-    Account assetAccount = accountService.findAccount(CompanyService.LEGACY_COMPANY_ID,'1010')
-    Account equityAccount = accountService.findAccount(CompanyService.LEGACY_COMPANY_ID,'2010')
-    Account incomeAccount = accountService.findAccount(CompanyService.LEGACY_COMPANY_ID,'3000')
-    Account manualReviewAccount = accountService.findAccount(CompanyService.LEGACY_COMPANY_ID,'8999')
+    Account assetAccount = accountService.findAccount(CompanyService.LEGACY_COMPANY_ID, '1010')
+    Account equityAccount = accountService.findAccount(CompanyService.LEGACY_COMPANY_ID, '2010')
+    Account incomeAccount = accountService.findAccount(CompanyService.LEGACY_COMPANY_ID, '3000')
+    Account manualReviewAccount = accountService.findAccount(CompanyService.LEGACY_COMPANY_ID, '8999')
 
     assertNotNull(assetAccount)
     assertEquals('ASSET', assetAccount.accountClass)
@@ -93,7 +93,7 @@ class ChartOfAccountsImportServiceTest {
     assertFalse(assets.isEmpty())
 
     accountService.setAccountActive(CompanyService.LEGACY_COMPANY_ID, '1010', false)
-    Account updated = accountService.findAccount(CompanyService.LEGACY_COMPANY_ID,'1010')
+    Account updated = accountService.findAccount(CompanyService.LEGACY_COMPANY_ID, '1010')
     assertFalse(updated.active)
 
     OpeningBalance openingBalance = accountService.saveOpeningBalance(fiscalYearId, '1010', 1250.50G)

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/ChartOfAccountsImportServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/ChartOfAccountsImportServiceTest.groovy
@@ -57,10 +57,10 @@ class ChartOfAccountsImportServiceTest {
     assertTrue(summary.createdCount > 1000)
     assertTrue(summary.manualReviewCount > 0)
 
-    Account assetAccount = accountService.findAccount('1010')
-    Account equityAccount = accountService.findAccount('2010')
-    Account incomeAccount = accountService.findAccount('3000')
-    Account manualReviewAccount = accountService.findAccount('8999')
+    Account assetAccount = accountService.findAccount(CompanyService.LEGACY_COMPANY_ID,'1010')
+    Account equityAccount = accountService.findAccount(CompanyService.LEGACY_COMPANY_ID,'2010')
+    Account incomeAccount = accountService.findAccount(CompanyService.LEGACY_COMPANY_ID,'3000')
+    Account manualReviewAccount = accountService.findAccount(CompanyService.LEGACY_COMPANY_ID,'8999')
 
     assertNotNull(assetAccount)
     assertEquals('ASSET', assetAccount.accountClass)
@@ -83,16 +83,17 @@ class ChartOfAccountsImportServiceTest {
   void searchToggleAndOpeningBalanceRulesWork() {
     importService.importFromExcel(workbookPath())
     long fiscalYearId = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID,
         '2026',
         LocalDate.of(2026, 1, 1),
         LocalDate.of(2026, 12, 31)
     ).id
 
-    List<Account> assets = accountService.searchAccounts('fordr', 'ASSET', true, false)
+    List<Account> assets = accountService.searchAccounts(CompanyService.LEGACY_COMPANY_ID, 'fordr', 'ASSET', true, false)
     assertFalse(assets.isEmpty())
 
-    accountService.setAccountActive('1010', false)
-    Account updated = accountService.findAccount('1010')
+    accountService.setAccountActive(CompanyService.LEGACY_COMPANY_ID, '1010', false)
+    Account updated = accountService.findAccount(CompanyService.LEGACY_COMPANY_ID,'1010')
     assertFalse(updated.active)
 
     OpeningBalance openingBalance = accountService.saveOpeningBalance(fiscalYearId, '1010', 1250.50G)

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/ClosingServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/ClosingServiceTest.groovy
@@ -69,7 +69,7 @@ class ClosingServiceTest {
 
   @Test
   void yearEndClosingCreatesClosingVoucherAndNextYearOpeningBalances() {
-    FiscalYear fiscalYear = fiscalYearService.createFiscalYear('2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    FiscalYear fiscalYear = fiscalYearService.createFiscalYear(CompanyService.LEGACY_COMPANY_ID, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
     seedClosingAccounts()
     databaseService.withTransaction { Sql sql ->
       def accountId = sql.firstRow('select id from account where account_number = ?', ['1930']).get('id')
@@ -129,7 +129,7 @@ class ClosingServiceTest {
       assertEquals(700.00G, openingBalanceFor(sql, result.nextFiscalYear.id, '2099'))
     }
 
-    List<AuditLogEntry> auditEntries = auditLogService.listEntries()
+    List<AuditLogEntry> auditEntries = auditLogService.listEntries(CompanyService.LEGACY_COMPANY_ID)
     assertTrue(auditEntries.any { AuditLogEntry entry ->
       entry.eventType == AuditLogService.CLOSE_FISCAL_YEAR && entry.fiscalYearId == fiscalYear.id
     })
@@ -138,7 +138,7 @@ class ClosingServiceTest {
 
   @Test
   void previewWarnsOnDeadlineAndBlocksOpenPeriods() {
-    FiscalYear fiscalYear = fiscalYearService.createFiscalYear('2024', LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31))
+    FiscalYear fiscalYear = fiscalYearService.createFiscalYear(CompanyService.LEGACY_COMPANY_ID, '2024', LocalDate.of(2024, 1, 1), LocalDate.of(2024, 12, 31))
     seedClosingAccounts()
 
     def preview = closingService.previewClosing(fiscalYear.id)
@@ -149,7 +149,7 @@ class ClosingServiceTest {
 
   @Test
   void reClosingAnAlreadyClosedYearIsBlocked() {
-    FiscalYear fiscalYear = fiscalYearService.createFiscalYear('2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    FiscalYear fiscalYear = fiscalYearService.createFiscalYear(CompanyService.LEGACY_COMPANY_ID, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
     seedClosingAccounts()
     accountingPeriodService.listPeriods(fiscalYear.id).each { period ->
       accountingPeriodService.lockPeriod(period.id, 'Bokslutstest')

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/FiscalYearServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/FiscalYearServiceTest.groovy
@@ -50,7 +50,7 @@ class FiscalYearServiceTest {
 
   @Test
   void createFiscalYearGeneratesMonthlyPeriodsForBrokenYear() {
-    FiscalYear year = fiscalYearService.createFiscalYear(
+    FiscalYear year = fiscalYearService.createFiscalYear(CompanyService.LEGACY_COMPANY_ID,
         '2025/2026 brutet',
         LocalDate.of(2025, 7, 15),
         LocalDate.of(2026, 7, 14)
@@ -67,14 +67,14 @@ class FiscalYearServiceTest {
 
   @Test
   void overlappingFiscalYearsAreRejected() {
-    fiscalYearService.createFiscalYear(
+    fiscalYearService.createFiscalYear(CompanyService.LEGACY_COMPANY_ID,
         '2025/2026',
         LocalDate.of(2025, 7, 1),
         LocalDate.of(2026, 6, 30)
     )
 
     Executable action = {
-      fiscalYearService.createFiscalYear(
+      fiscalYearService.createFiscalYear(CompanyService.LEGACY_COMPANY_ID,
           '2026 kalenderår',
           LocalDate.of(2026, 1, 1),
           LocalDate.of(2026, 12, 31)
@@ -86,7 +86,7 @@ class FiscalYearServiceTest {
 
   @Test
   void periodLockAndYearCloseUpdateLockStatus() {
-    FiscalYear year = fiscalYearService.createFiscalYear(
+    FiscalYear year = fiscalYearService.createFiscalYear(CompanyService.LEGACY_COMPANY_ID,
         '2026',
         LocalDate.of(2026, 1, 1),
         LocalDate.of(2026, 12, 31)
@@ -100,12 +100,12 @@ class FiscalYearServiceTest {
       accountingPeriodService.lockPeriod(period.id, 'Årsslut.')
     }
 
-    assertTrue(accountingPeriodService.isDateLocked(LocalDate.of(2026, 1, 15)))
-    assertTrue(accountingPeriodService.isDateLocked(LocalDate.of(2026, 2, 15)))
+    assertTrue(accountingPeriodService.isDateLocked(CompanyService.LEGACY_COMPANY_ID,LocalDate.of(2026, 1, 15)))
+    assertTrue(accountingPeriodService.isDateLocked(CompanyService.LEGACY_COMPANY_ID,LocalDate.of(2026, 2, 15)))
 
     FiscalYear closedYear = fiscalYearService.closeFiscalYear(year.id)
     List<AccountingPeriod> closedPeriods = accountingPeriodService.listPeriods(year.id)
-    List<AuditLogEntry> auditEntries = auditLogService.listEntries()
+    List<AuditLogEntry> auditEntries = auditLogService.listEntries(CompanyService.LEGACY_COMPANY_ID)
 
     assertTrue(closedYear.closed)
     assertTrue(closedPeriods.every { AccountingPeriod period -> period.locked })
@@ -119,7 +119,7 @@ class FiscalYearServiceTest {
 
   @Test
   void closingYearWithOpenPeriodsIsRejected() {
-    FiscalYear year = fiscalYearService.createFiscalYear(
+    FiscalYear year = fiscalYearService.createFiscalYear(CompanyService.LEGACY_COMPANY_ID,
         '2026',
         LocalDate.of(2026, 1, 1),
         LocalDate.of(2026, 12, 31)
@@ -134,7 +134,7 @@ class FiscalYearServiceTest {
 
   @Test
   void lockingAnAlreadyLockedPeriodIsRejected() {
-    FiscalYear year = fiscalYearService.createFiscalYear(
+    FiscalYear year = fiscalYearService.createFiscalYear(CompanyService.LEGACY_COMPANY_ID,
         '2026',
         LocalDate.of(2026, 1, 1),
         LocalDate.of(2026, 12, 31)
@@ -158,7 +158,7 @@ class FiscalYearServiceTest {
         auditLogService,
         new RetentionPolicyService(Clock.fixed(Instant.parse('2030-01-01T00:00:00Z'), ZoneOffset.UTC))
     )
-    FiscalYear year = fiscalYearService.createFiscalYear(
+    FiscalYear year = fiscalYearService.createFiscalYear(CompanyService.LEGACY_COMPANY_ID,
         '2020',
         LocalDate.of(2020, 1, 1),
         LocalDate.of(2020, 12, 31)

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/FiscalYearServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/FiscalYearServiceTest.groovy
@@ -100,8 +100,8 @@ class FiscalYearServiceTest {
       accountingPeriodService.lockPeriod(period.id, 'Årsslut.')
     }
 
-    assertTrue(accountingPeriodService.isDateLocked(CompanyService.LEGACY_COMPANY_ID,LocalDate.of(2026, 1, 15)))
-    assertTrue(accountingPeriodService.isDateLocked(CompanyService.LEGACY_COMPANY_ID,LocalDate.of(2026, 2, 15)))
+    assertTrue(accountingPeriodService.isDateLocked(CompanyService.LEGACY_COMPANY_ID, LocalDate.of(2026, 1, 15)))
+    assertTrue(accountingPeriodService.isDateLocked(CompanyService.LEGACY_COMPANY_ID, LocalDate.of(2026, 2, 15)))
 
     FiscalYear closedYear = fiscalYearService.closeFiscalYear(year.id)
     List<AccountingPeriod> closedPeriods = accountingPeriodService.listPeriods(year.id)

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/MultiCompanyChainHeadTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/MultiCompanyChainHeadTest.groovy
@@ -64,7 +64,7 @@ class MultiCompanyChainHeadTest {
         reportDataService,
         reportArchiveService,
         new ReportIntegrityService(voucherService, new AttachmentService(databaseService, auditLogService), auditLogService),
-        new CompanySettingsService(databaseService),
+        companyService,
         auditLogService,
         databaseService
     )

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/MultiCompanyChainHeadTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/MultiCompanyChainHeadTest.groovy
@@ -2,6 +2,7 @@ package se.alipsa.accounting.service
 
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertNotNull
+import static org.junit.jupiter.api.Assertions.assertTrue
 
 import groovy.sql.GroovyRowResult
 import groovy.sql.Sql
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.io.TempDir
 
 import se.alipsa.accounting.domain.AuditLogEntry
 import se.alipsa.accounting.domain.Company
+import se.alipsa.accounting.domain.FiscalYear
 import se.alipsa.accounting.domain.VatPeriodicity
 import se.alipsa.accounting.domain.VoucherLine
 import se.alipsa.accounting.domain.report.ReportSelection
@@ -193,6 +195,25 @@ class MultiCompanyChainHeadTest {
       ((Number) row.get('total')).intValue()
     }
     assertEquals(2, exportCount)
+  }
+
+  @Test
+  void listFiscalYearsIsolatesDataByCompany() {
+    FiscalYear fy1 = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    Company company2 = companyService.save(
+        new Company(null, 'Isolation AB', '556999-0001', 'SEK', 'sv-SE', VatPeriodicity.MONTHLY, true, null, null))
+    FiscalYear fy2 = fiscalYearService.createFiscalYear(
+        company2.id, '2026-B', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+
+    List<FiscalYear> company1Years = fiscalYearService.listFiscalYears(CompanyService.LEGACY_COMPANY_ID)
+    List<FiscalYear> company2Years = fiscalYearService.listFiscalYears(company2.id)
+
+    assertEquals(1, company1Years.size())
+    assertEquals(fy1.id, company1Years.first().id)
+    assertEquals(1, company2Years.size())
+    assertEquals(fy2.id, company2Years.first().id)
+    assertTrue(company1Years.every { FiscalYear fy -> fy.id != fy2.id })
   }
 
   private static void insertAccount(

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/ReportServicesTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/ReportServicesTest.groovy
@@ -71,11 +71,11 @@ class ReportServicesTest {
         reportDataService,
         reportArchiveService,
         new ReportIntegrityService(voucherService, new AttachmentService(databaseService, auditLogService), auditLogService),
-        new CompanySettingsService(databaseService),
+        new CompanyService(databaseService),
         auditLogService,
         databaseService
     )
-    fiscalYear = fiscalYearService.createFiscalYear('2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    fiscalYear = fiscalYearService.createFiscalYear(CompanyService.LEGACY_COMPANY_ID, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
     insertTestAccounts()
     bookFixtures()
   }
@@ -132,7 +132,7 @@ class ReportServicesTest {
     assertEquals(ReportType.INCOME_STATEMENT, archive.reportType)
     assertTrue(new String(pdf, 0, 5, StandardCharsets.US_ASCII).startsWith('%PDF-'))
     assertTrue(Files.size(reportArchiveService.resolveStoredPath(archive)) > 500L)
-    assertEquals('c662c635ccea3d6d722d49ae996ea40edcdae8cf4f20c0aab7f8a176c52b560c', sha256(journoReportService.renderHtml(preview).getBytes(StandardCharsets.UTF_8)))
+    assertEquals('ccf4d53a601b18ee472bdb2c9b945f7b8bb1c297239e58cb3f7bc2ebbf56e19d', sha256(journoReportService.renderHtml(preview).getBytes(StandardCharsets.UTF_8)))
   }
 
   @Test

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/SieImportExportServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/SieImportExportServiceTest.groovy
@@ -163,7 +163,7 @@ class SieImportExportServiceTest {
     }
 
     assertTrue(exception.message.contains('låsta perioder'))
-    assertEquals(ImportJobStatus.FAILED, targetService.listImportJobs(1).first().status)
+    assertEquals(ImportJobStatus.FAILED, targetService.listImportJobs(CompanyService.LEGACY_COMPANY_ID, 1).first().status)
   }
 
   @Test

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/SieImportExportServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/SieImportExportServiceTest.groovy
@@ -51,7 +51,7 @@ class SieImportExportServiceTest {
     targetDatabaseService.initialize()
     SieImportExportService targetService = createSieService(targetDatabaseService)
 
-    def result = targetService.importFile(exportPath)
+    def result = targetService.importFile(CompanyService.LEGACY_COMPANY_ID, exportPath)
 
     assertFalse(result.duplicate)
     assertEquals(ImportJobStatus.SUCCESS, result.job.status)
@@ -74,9 +74,9 @@ class SieImportExportServiceTest {
     targetDatabaseService.initialize()
     SieImportExportService targetService = createSieService(targetDatabaseService)
 
-    def firstImport = targetService.importFile(exportPath)
-    def secondImport = targetService.importFile(exportPath)
-    List<ImportJob> jobs = targetService.listImportJobs(10)
+    def firstImport = targetService.importFile(CompanyService.LEGACY_COMPANY_ID, exportPath)
+    def secondImport = targetService.importFile(CompanyService.LEGACY_COMPANY_ID, exportPath)
+    List<ImportJob> jobs = targetService.listImportJobs(CompanyService.LEGACY_COMPANY_ID, 10)
 
     assertEquals(ImportJobStatus.SUCCESS, firstImport.job.status)
     assertTrue(secondImport.duplicate)
@@ -116,11 +116,11 @@ class SieImportExportServiceTest {
     malformed.toFile().text = 'this is not a sie file'
 
     IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
-      service.importFile(malformed)
+      service.importFile(CompanyService.LEGACY_COMPANY_ID, malformed)
     }
 
     assertTrue(exception.message.contains('SIE'))
-    assertEquals(ImportJobStatus.FAILED, service.listImportJobs(1).first().status)
+    assertEquals(ImportJobStatus.FAILED, service.listImportJobs(CompanyService.LEGACY_COMPANY_ID, 1).first().status)
   }
 
   @Test
@@ -136,11 +136,11 @@ class SieImportExportServiceTest {
     }
 
     IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
-      service.importFile(oversized)
+      service.importFile(CompanyService.LEGACY_COMPANY_ID, oversized)
     }
 
     assertTrue(exception.message.contains('Max 50 MB'))
-    assertTrue(service.listImportJobs().isEmpty())
+    assertTrue(service.listImportJobs(CompanyService.LEGACY_COMPANY_ID).isEmpty())
   }
 
   @Test
@@ -154,12 +154,12 @@ class SieImportExportServiceTest {
     AuditLogService auditLogService = new AuditLogService(targetDatabaseService)
     AccountingPeriodService accountingPeriodService = new AccountingPeriodService(targetDatabaseService, auditLogService)
     FiscalYearService fiscalYearService = new FiscalYearService(targetDatabaseService, accountingPeriodService, auditLogService)
-    FiscalYear fiscalYear = fiscalYearService.createFiscalYear('2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    FiscalYear fiscalYear = fiscalYearService.createFiscalYear(CompanyService.LEGACY_COMPANY_ID, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
     accountingPeriodService.lockPeriod(accountingPeriodService.listPeriods(fiscalYear.id).first().id, 'låst för test')
     SieImportExportService targetService = createSieService(targetDatabaseService)
 
     IllegalStateException exception = assertThrows(IllegalStateException) {
-      targetService.importFile(exportPath)
+      targetService.importFile(CompanyService.LEGACY_COMPANY_ID, exportPath)
     }
 
     assertTrue(exception.message.contains('låsta perioder'))
@@ -174,7 +174,7 @@ class SieImportExportServiceTest {
     SieImportExportService service = createSieService(databaseService)
     Path filePath = writeSimpleSie(tempDir.resolve('group21.sie'), '2120', 'Periodiseringsfonder')
 
-    service.importFile(filePath)
+    service.importFile(CompanyService.LEGACY_COMPANY_ID, filePath)
 
     databaseService.withSql { Sql sql ->
       GroovyRowResult row = sql.firstRow(
@@ -197,7 +197,7 @@ class SieImportExportServiceTest {
     SieImportExportService service = createSieService(databaseService)
     Path filePath = writeSimpleSie(tempDir.resolve('preserve.sie'), '2120', 'Periodiseringsfonder')
 
-    service.importFile(filePath)
+    service.importFile(CompanyService.LEGACY_COMPANY_ID, filePath)
 
     databaseService.withSql { Sql sql ->
       GroovyRowResult row = sql.firstRow('''
@@ -231,7 +231,7 @@ class SieImportExportServiceTest {
     VoucherService voucherService = new VoucherService(databaseService, auditLogService)
     CompanySettingsService companySettingsService = new CompanySettingsService(databaseService)
     companySettingsService.save(new CompanySettings(null, 'Testbolaget AB', '556677-8899', 'SEK', 'sv-SE', VatPeriodicity.MONTHLY))
-    FiscalYear fiscalYear = fiscalYearService.createFiscalYear('2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    FiscalYear fiscalYear = fiscalYearService.createFiscalYear(CompanyService.LEGACY_COMPANY_ID, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
 
     databaseService.withTransaction { Sql sql ->
       insertAccount(sql, '2010', 'Eget kapital', 'EQUITY', 'CREDIT')

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/StartupVerificationServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/StartupVerificationServiceTest.groovy
@@ -50,7 +50,7 @@ class StartupVerificationServiceTest {
     VoucherService voucherService = new VoucherService(databaseService, auditLogService)
     ReportIntegrityService reportIntegrityService = new ReportIntegrityService(voucherService, attachmentService, auditLogService)
 
-    def fiscalYear = fiscalYearService.createFiscalYear('2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    def fiscalYear = fiscalYearService.createFiscalYear(CompanyService.LEGACY_COMPANY_ID, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
     def archive = reportArchiveService.archiveReport(
         new ReportSelection(ReportType.VOUCHER_LIST, fiscalYear.id, null, fiscalYear.startDate, fiscalYear.endDate),
         'PDF',

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/VatServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/VatServiceTest.groovy
@@ -54,6 +54,7 @@ class VatServiceTest {
     voucherService = new VoucherService(databaseService, auditLogService)
     vatService = new VatService(databaseService, voucherService)
     fiscalYear = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID,
         '2026',
         LocalDate.of(2026, 1, 1),
         LocalDate.of(2026, 12, 31)
@@ -108,7 +109,7 @@ class VatServiceTest {
     VatPeriod january = vatService.listPeriods(fiscalYear.id).first()
 
     VatPeriod reportedPeriod = vatService.reportPeriod(january.id)
-    List<AuditLogEntry> auditEntries = auditLogService.listEntries()
+    List<AuditLogEntry> auditEntries = auditLogService.listEntries(CompanyService.LEGACY_COMPANY_ID)
 
     assertEquals(VatService.REPORTED, reportedPeriod.status)
     assertTrue(auditEntries.any { AuditLogEntry entry ->
@@ -145,7 +146,7 @@ class VatServiceTest {
 
     Voucher transferVoucher = vatService.bookTransfer(january.id)
     VatPeriod lockedPeriod = vatService.findPeriod(january.id)
-    List<AuditLogEntry> auditEntries = auditLogService.listEntries()
+    List<AuditLogEntry> auditEntries = auditLogService.listEntries(CompanyService.LEGACY_COMPANY_ID)
 
     assertEquals(VatService.LOCKED, lockedPeriod.status)
     assertEquals(transferVoucher.id, lockedPeriod.transferVoucherId)
@@ -249,6 +250,7 @@ class VatServiceTest {
         )
     )
     FiscalYear annualYear = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID,
         '2027',
         LocalDate.of(2027, 1, 1),
         LocalDate.of(2027, 12, 31)

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/VoucherServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/VoucherServiceTest.groovy
@@ -53,6 +53,7 @@ class VoucherServiceTest {
     fiscalYearService = new FiscalYearService(databaseService, accountingPeriodService, auditLogService)
     voucherService = new VoucherService(databaseService, auditLogService)
     fiscalYear = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID,
         '2026',
         LocalDate.of(2026, 1, 1),
         LocalDate.of(2026, 12, 31)

--- a/app/src/test/groovy/integration/se/alipsa/accounting/ui/VatPeriodPanelTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/ui/VatPeriodPanelTest.groovy
@@ -17,6 +17,7 @@ import se.alipsa.accounting.domain.Voucher
 import se.alipsa.accounting.domain.VoucherLine
 import se.alipsa.accounting.service.AccountingPeriodService
 import se.alipsa.accounting.service.AuditLogService
+import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.DatabaseService
 import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.service.VatService
@@ -64,6 +65,7 @@ class VatPeriodPanelTest {
     voucherService = new VoucherService(databaseService, auditLogService)
     vatService = new VatService(databaseService, voucherService, auditLogService)
     fiscalYear = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID,
         '2026',
         LocalDate.of(2026, 1, 1),
         LocalDate.of(2026, 12, 31)

--- a/config/codenarc/ruleset.groovy
+++ b/config/codenarc/ruleset.groovy
@@ -90,7 +90,6 @@ ruleset {
         exclude 'ConsecutiveBlankLines'
         exclude 'Indentation'
         exclude 'LineLength'
-        exclude 'SpaceAfterComma'
         exclude 'SpaceAfterMethodCallName'
         exclude 'SpaceAfterOpeningBrace'
         exclude 'SpaceAroundMapEntryColon'


### PR DESCRIPTION
## Summary
- Alla 16 centrala tjänster tar nu explicit `companyId`-parameter på sina publika metoder (ingen dold thread-local state)
- Systemtjänster (BackupService, StartupVerificationService, SystemDiagnosticsService, SystemDocumentationService, ReportIntegrityService) har cross-company-varianter (`listAllArchives`, `listAllEntries`, `findAllIntegrityFailures`, `listAllAttachments`)
- JournoReportService bytte från `CompanySettingsService` till `CompanyService` för att hämta företagsdata per bolag
- UI-lagret använder `CompanyService.LEGACY_COMPANY_ID` som övergångslösning

## Påverkade tjänster
AccountService, AccountingPeriodService, AttachmentService, AuditLogService, BackupService, ClosingService, FiscalYearService, JournoReportService, ReportArchiveService, ReportDataService, ReportIntegrityService, SieImportExportService, StartupVerificationService, SystemDiagnosticsService, SystemDocumentationService, VatService, VoucherService

## Schema/migration
Ingen ny migration – använder `company_id`-kolumner från V13.

## Test plan
- [x] `./gradlew build` passerar (123 tester gröna, Spotless + CodeNarc OK)
- [ ] Manuell verifiering av desktop-appen med ett bolag

🤖 Generated with [Claude Code](https://claude.com/claude-code)