### PR TITLE
Batch 5: UI för aktivt företag

### DIFF
--- a/app/src/main/groovy/se/alipsa/accounting/domain/Company.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/domain/Company.groovy
@@ -19,4 +19,9 @@ final class Company {
   boolean active = true
   LocalDateTime createdAt
   LocalDateTime updatedAt
+
+  @Override
+  String toString() {
+    companyName ?: ''
+  }
 }

--- a/app/src/main/groovy/se/alipsa/accounting/ui/ActiveCompanyManager.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/ActiveCompanyManager.groovy
@@ -1,0 +1,52 @@
+package se.alipsa.accounting.ui
+
+import se.alipsa.accounting.domain.Company
+import se.alipsa.accounting.service.CompanyService
+
+import java.beans.PropertyChangeListener
+import java.beans.PropertyChangeSupport
+
+/**
+ * Observable holder for the active company. Panels listen for changes
+ * to reload their data when the user switches company.
+ */
+final class ActiveCompanyManager {
+
+  static final String COMPANY_ID_PROPERTY = 'companyId'
+
+  private final CompanyService companyService
+  private final PropertyChangeSupport support = new PropertyChangeSupport(this)
+  private long companyId
+
+  ActiveCompanyManager(CompanyService companyService) {
+    this.companyService = companyService
+    List<Company> companies = companyService.listCompanies(true)
+    this.companyId = companies.isEmpty() ? 0L : companies.first().id
+  }
+
+  long getCompanyId() {
+    companyId
+  }
+
+  void setCompanyId(long newCompanyId) {
+    long old = this.companyId
+    this.companyId = newCompanyId
+    support.firePropertyChange(COMPANY_ID_PROPERTY, old, newCompanyId)
+  }
+
+  boolean hasActiveCompany() {
+    companyId > 0
+  }
+
+  Company getActiveCompany() {
+    companyId > 0 ? companyService.findById(companyId) : null
+  }
+
+  void addPropertyChangeListener(PropertyChangeListener listener) {
+    support.addPropertyChangeListener(listener)
+  }
+
+  void removePropertyChangeListener(PropertyChangeListener listener) {
+    support.removePropertyChangeListener(listener)
+  }
+}

--- a/app/src/main/groovy/se/alipsa/accounting/ui/ActiveCompanyManager.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/ActiveCompanyManager.groovy
@@ -20,8 +20,12 @@ final class ActiveCompanyManager {
 
   ActiveCompanyManager(CompanyService companyService) {
     this.companyService = companyService
-    List<Company> companies = companyService.listCompanies(true)
-    this.companyId = companies.isEmpty() ? 0L : companies.first().id
+    try {
+      List<Company> companies = companyService.listCompanies(true)
+      this.companyId = companies.isEmpty() ? 0L : companies.first().id
+    } catch (Exception ignored) {
+      this.companyId = 0L
+    }
   }
 
   long getCompanyId() {

--- a/app/src/main/groovy/se/alipsa/accounting/ui/ActiveCompanyManager.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/ActiveCompanyManager.groovy
@@ -21,7 +21,7 @@ final class ActiveCompanyManager {
   ActiveCompanyManager(CompanyService companyService) {
     this.companyService = companyService
     try {
-      List<Company> companies = companyService.listCompanies(true)
+      List<Company> companies = companyService.listCompanies(true) ?: []
       this.companyId = companies.isEmpty() ? 0L : companies.first().id
     } catch (Exception ignored) {
       this.companyId = 0L

--- a/app/src/main/groovy/se/alipsa/accounting/ui/ChartOfAccountsPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/ChartOfAccountsPanel.groovy
@@ -239,6 +239,10 @@ final class ChartOfAccountsPanel extends JPanel implements PropertyChangeListene
   }
 
   private void refreshOverview() {
+    if (!activeCompanyManager.hasActiveCompany()) {
+      overviewLabel.text = ''
+      return
+    }
     AccountService.AccountOverview overview = accountService.loadOverview(activeCompanyManager.companyId)
     overviewLabel.text = I18n.instance.format('chartOfAccountsPanel.overview',
         overview.totalCount as Object, overview.activeCount as Object,

--- a/app/src/main/groovy/se/alipsa/accounting/ui/ChartOfAccountsPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/ChartOfAccountsPanel.groovy
@@ -4,7 +4,6 @@ import se.alipsa.accounting.domain.Account
 import se.alipsa.accounting.service.AccountService
 import se.alipsa.accounting.service.ChartOfAccountsImportService
 import se.alipsa.accounting.service.ChartOfAccountsImportService.ImportSummary
-import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.support.I18n
 
@@ -44,6 +43,7 @@ final class ChartOfAccountsPanel extends JPanel implements PropertyChangeListene
   private final AccountService accountService
   private final ChartOfAccountsImportService importService
   private final FiscalYearService fiscalYearService
+  private final ActiveCompanyManager activeCompanyManager
 
   private final JTextField searchField = new JTextField(18)
   private final JComboBox<String> classFilter = new JComboBox<>()
@@ -67,12 +67,15 @@ final class ChartOfAccountsPanel extends JPanel implements PropertyChangeListene
   ChartOfAccountsPanel(
       AccountService accountService,
       ChartOfAccountsImportService importService,
-      FiscalYearService fiscalYearService
+      FiscalYearService fiscalYearService,
+      ActiveCompanyManager activeCompanyManager
   ) {
     this.accountService = accountService
     this.importService = importService
     this.fiscalYearService = fiscalYearService
+    this.activeCompanyManager = activeCompanyManager
     I18n.instance.addLocaleChangeListener(this)
+    activeCompanyManager.addPropertyChangeListener(this)
     rebuildClassFilter()
     buildUi()
     reloadAccounts()
@@ -82,6 +85,8 @@ final class ChartOfAccountsPanel extends JPanel implements PropertyChangeListene
   void propertyChange(PropertyChangeEvent evt) {
     if ('locale' == evt.propertyName) {
       SwingUtilities.invokeLater { applyLocale() }
+    } else if (ActiveCompanyManager.COMPANY_ID_PROPERTY == evt.propertyName) {
+      SwingUtilities.invokeLater { reloadAccounts() }
     }
   }
 
@@ -218,7 +223,7 @@ final class ChartOfAccountsPanel extends JPanel implements PropertyChangeListene
     String accountClass = selectedClass in [null, allFilterLabel(), reviewFilterLabel()] ? '' : selectedClass
 
     List<Account> accounts = accountService.searchAccounts(
-        CompanyService.LEGACY_COMPANY_ID,
+        activeCompanyManager.companyId,
         searchField.text,
         accountClass,
         activeOnlyCheckBox.selected,
@@ -230,7 +235,7 @@ final class ChartOfAccountsPanel extends JPanel implements PropertyChangeListene
   }
 
   private void refreshOverview() {
-    AccountService.AccountOverview overview = accountService.loadOverview(CompanyService.LEGACY_COMPANY_ID)
+    AccountService.AccountOverview overview = accountService.loadOverview(activeCompanyManager.companyId)
     overviewLabel.text = I18n.instance.format('chartOfAccountsPanel.overview',
         overview.totalCount as Object, overview.activeCount as Object,
         overview.manualReviewCount as Object)
@@ -296,7 +301,7 @@ final class ChartOfAccountsPanel extends JPanel implements PropertyChangeListene
       return
     }
 
-    accountService.setAccountActive(CompanyService.LEGACY_COMPANY_ID, account.accountNumber, !account.active)
+    accountService.setAccountActive(activeCompanyManager.companyId, account.accountNumber, !account.active)
     reloadAccounts()
     selectAccount(account.accountNumber)
     String status = account.active
@@ -316,7 +321,7 @@ final class ChartOfAccountsPanel extends JPanel implements PropertyChangeListene
       return
     }
 
-    OpeningBalanceDialog.showDialog(ownerFrame(), accountService, fiscalYearService, account, {
+    OpeningBalanceDialog.showDialog(ownerFrame(), accountService, fiscalYearService, activeCompanyManager.companyId, account, {
       showInfo(I18n.instance.format('chartOfAccountsPanel.message.openingBalanceUpdated', account.accountNumber))
     } as Runnable)
   }

--- a/app/src/main/groovy/se/alipsa/accounting/ui/ChartOfAccountsPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/ChartOfAccountsPanel.groovy
@@ -218,6 +218,10 @@ final class ChartOfAccountsPanel extends JPanel implements PropertyChangeListene
   }
 
   private void reloadAccounts() {
+    if (!activeCompanyManager.hasActiveCompany()) {
+      accountTableModel.setRows([])
+      return
+    }
     String selectedClass = classFilter.selectedItem as String
     boolean manualReviewOnly = selectedClass == reviewFilterLabel()
     String accountClass = selectedClass in [null, allFilterLabel(), reviewFilterLabel()] ? '' : selectedClass

--- a/app/src/main/groovy/se/alipsa/accounting/ui/CompanyDialog.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/CompanyDialog.groovy
@@ -14,6 +14,7 @@ import java.awt.GridBagLayout
 import java.awt.Insets
 import java.beans.PropertyChangeEvent
 import java.beans.PropertyChangeListener
+import java.util.function.Consumer
 
 import javax.swing.BorderFactory
 import javax.swing.JButton
@@ -31,7 +32,7 @@ import javax.swing.SwingUtilities
 final class CompanyDialog extends JDialog implements PropertyChangeListener {
 
   private final CompanyService companyService
-  private final Runnable onSave
+  private final Consumer<Company> onSave
   private Company company
 
   private final JTextField companyNameField = new JTextField(28)
@@ -49,7 +50,7 @@ final class CompanyDialog extends JDialog implements PropertyChangeListener {
   private JButton cancelButton
   private JButton saveButton
 
-  CompanyDialog(Frame owner, CompanyService companyService, Company company, Runnable onSave) {
+  CompanyDialog(Frame owner, CompanyService companyService, Company company, Consumer<Company> onSave) {
     super(owner, I18n.instance.getString('companyDialog.title.new'), true)
     this.companyService = companyService
     this.company = company
@@ -62,7 +63,7 @@ final class CompanyDialog extends JDialog implements PropertyChangeListener {
     populate()
   }
 
-  static void showDialog(Frame owner, CompanyService companyService, Company company, Runnable onSave) {
+  static void showDialog(Frame owner, CompanyService companyService, Company company, Consumer<Company> onSave) {
     CompanyDialog dialog = new CompanyDialog(owner, companyService, company, onSave)
     dialog.setVisible(true)
   }
@@ -205,10 +206,10 @@ final class CompanyDialog extends JDialog implements PropertyChangeListener {
           null
       )
       company = companyService.save(toSave)
-      onSave.run()
+      onSave.accept(company)
       dispose()
-    } catch (IllegalArgumentException exception) {
-      showValidation([ValidationSupport.fieldError('', exception.message)])
+    } catch (Exception exception) {
+      showValidation([ValidationSupport.fieldError('', exception.message ?: exception.class.simpleName)])
     }
   }
 

--- a/app/src/main/groovy/se/alipsa/accounting/ui/CompanyDialog.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/CompanyDialog.groovy
@@ -1,0 +1,257 @@
+package se.alipsa.accounting.ui
+
+import se.alipsa.accounting.domain.Company
+import se.alipsa.accounting.domain.VatPeriodicity
+import se.alipsa.accounting.service.CompanyService
+import se.alipsa.accounting.support.I18n
+
+import java.awt.BorderLayout
+import java.awt.Color
+import java.awt.FlowLayout
+import java.awt.Frame
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.Insets
+import java.beans.PropertyChangeEvent
+import java.beans.PropertyChangeListener
+
+import javax.swing.BorderFactory
+import javax.swing.JButton
+import javax.swing.JComboBox
+import javax.swing.JDialog
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JTextArea
+import javax.swing.JTextField
+import javax.swing.SwingUtilities
+
+/**
+ * Modal dialog for creating and editing companies.
+ */
+final class CompanyDialog extends JDialog implements PropertyChangeListener {
+
+  private final CompanyService companyService
+  private final Runnable onSave
+  private Company company
+
+  private final JTextField companyNameField = new JTextField(28)
+  private final JTextField organizationNumberField = new JTextField(18)
+  private final JTextField defaultCurrencyField = new JTextField(6)
+  private final JTextField localeTagField = new JTextField(12)
+  private final JComboBox<VatPeriodicity> vatPeriodicityComboBox = new JComboBox<>(VatPeriodicity.values())
+  private final JTextArea validationArea = new JTextArea(4, 30)
+
+  private JLabel companyNameLabel
+  private JLabel orgNumberLabel
+  private JLabel currencyLabel
+  private JLabel localeLabel
+  private JLabel vatPeriodLabel
+  private JButton cancelButton
+  private JButton saveButton
+
+  CompanyDialog(Frame owner, CompanyService companyService, Company company, Runnable onSave) {
+    super(owner, I18n.instance.getString('companyDialog.title.new'), true)
+    this.companyService = companyService
+    this.company = company
+    this.onSave = onSave
+    if (company != null) {
+      title = I18n.instance.getString('companyDialog.title.edit')
+    }
+    I18n.instance.addLocaleChangeListener(this)
+    buildUi()
+    populate()
+  }
+
+  static void showDialog(Frame owner, CompanyService companyService, Company company, Runnable onSave) {
+    CompanyDialog dialog = new CompanyDialog(owner, companyService, company, onSave)
+    dialog.setVisible(true)
+  }
+
+  @Override
+  void propertyChange(PropertyChangeEvent evt) {
+    if ('locale' == evt.propertyName) {
+      SwingUtilities.invokeLater { applyLocale() }
+    }
+  }
+
+  @Override
+  void dispose() {
+    I18n.instance.removeLocaleChangeListener(this)
+    super.dispose()
+  }
+
+  private void applyLocale() {
+    title = company == null
+        ? I18n.instance.getString('companyDialog.title.new')
+        : I18n.instance.getString('companyDialog.title.edit')
+    companyNameLabel.text = I18n.instance.getString('companySettingsDialog.label.companyName')
+    orgNumberLabel.text = I18n.instance.getString('companySettingsDialog.label.orgNumber')
+    currencyLabel.text = I18n.instance.getString('companySettingsDialog.label.currency')
+    localeLabel.text = I18n.instance.getString('companySettingsDialog.label.locale')
+    vatPeriodLabel.text = I18n.instance.getString('companySettingsDialog.label.vatPeriod')
+    cancelButton.text = I18n.instance.getString('companySettingsDialog.button.cancel')
+    saveButton.text = I18n.instance.getString('companySettingsDialog.button.save')
+    pack()
+  }
+
+  private void buildUi() {
+    setLayout(new BorderLayout(12, 12))
+    ((JPanel) contentPane).setBorder(BorderFactory.createEmptyBorder(12, 12, 12, 12))
+    add(buildValidationPanel(), BorderLayout.NORTH)
+    add(buildFormPanel(), BorderLayout.CENTER)
+    add(buildButtonPanel(), BorderLayout.SOUTH)
+    pack()
+    setResizable(false)
+    setLocationRelativeTo(owner)
+  }
+
+  private JPanel buildFormPanel() {
+    JPanel panel = new JPanel(new GridBagLayout())
+    GridBagConstraints labelConstraints = new GridBagConstraints(
+        0, 0, 1, 1, 0.0d, 0.0d,
+        GridBagConstraints.WEST, GridBagConstraints.NONE,
+        new Insets(4, 0, 4, 8), 0, 0
+    )
+    GridBagConstraints fieldConstraints = new GridBagConstraints(
+        1, 0, 1, 1, 1.0d, 0.0d,
+        GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL,
+        new Insets(4, 0, 4, 0), 0, 0
+    )
+
+    companyNameLabel = new JLabel(I18n.instance.getString('companySettingsDialog.label.companyName'))
+    panel.add(companyNameLabel, labelConstraints)
+    panel.add(companyNameField, fieldConstraints)
+
+    labelConstraints.gridy = 1
+    fieldConstraints.gridy = 1
+    orgNumberLabel = new JLabel(I18n.instance.getString('companySettingsDialog.label.orgNumber'))
+    panel.add(orgNumberLabel, labelConstraints)
+    panel.add(organizationNumberField, fieldConstraints)
+
+    labelConstraints.gridy = 2
+    fieldConstraints.gridy = 2
+    currencyLabel = new JLabel(I18n.instance.getString('companySettingsDialog.label.currency'))
+    panel.add(currencyLabel, labelConstraints)
+    panel.add(defaultCurrencyField, fieldConstraints)
+
+    labelConstraints.gridy = 3
+    fieldConstraints.gridy = 3
+    localeLabel = new JLabel(I18n.instance.getString('companySettingsDialog.label.locale'))
+    panel.add(localeLabel, labelConstraints)
+    panel.add(localeTagField, fieldConstraints)
+
+    labelConstraints.gridy = 4
+    fieldConstraints.gridy = 4
+    vatPeriodLabel = new JLabel(I18n.instance.getString('companySettingsDialog.label.vatPeriod'))
+    panel.add(vatPeriodLabel, labelConstraints)
+    panel.add(vatPeriodicityComboBox, fieldConstraints)
+
+    panel
+  }
+
+  private JTextArea buildValidationPanel() {
+    validationArea.setEditable(false)
+    validationArea.setLineWrap(true)
+    validationArea.setWrapStyleWord(true)
+    validationArea.setForeground(new Color(153, 27, 27))
+    validationArea.setBackground(background)
+    validationArea.setBorder(BorderFactory.createEmptyBorder(0, 0, 8, 0))
+    validationArea.setVisible(false)
+    validationArea
+  }
+
+  private JPanel buildButtonPanel() {
+    JPanel panel = new JPanel(new FlowLayout(FlowLayout.RIGHT))
+    cancelButton = new JButton(I18n.instance.getString('companySettingsDialog.button.cancel'))
+    cancelButton.addActionListener { dispose() }
+    saveButton = new JButton(I18n.instance.getString('companySettingsDialog.button.save'))
+    saveButton.addActionListener { saveRequested() }
+    panel.add(cancelButton)
+    panel.add(saveButton)
+    panel
+  }
+
+  private void populate() {
+    if (company == null) {
+      defaultCurrencyField.text = 'SEK'
+      localeTagField.text = Locale.getDefault().toLanguageTag()
+      vatPeriodicityComboBox.selectedItem = VatPeriodicity.MONTHLY
+      return
+    }
+    companyNameField.text = company.companyName
+    organizationNumberField.text = company.organizationNumber
+    defaultCurrencyField.text = company.defaultCurrency
+    localeTagField.text = company.localeTag
+    vatPeriodicityComboBox.selectedItem = company.vatPeriodicity ?: VatPeriodicity.MONTHLY
+  }
+
+  private void saveRequested() {
+    List<ValidationMessage> messages = validateInput()
+    if (!messages.isEmpty()) {
+      showValidation(messages)
+      return
+    }
+
+    try {
+      Company toSave = new Company(
+          company?.id,
+          companyNameField.text.trim(),
+          organizationNumberField.text.trim(),
+          defaultCurrencyField.text.trim().toUpperCase(Locale.ROOT),
+          localeTagField.text.trim(),
+          vatPeriodicityComboBox.selectedItem as VatPeriodicity,
+          true,
+          null,
+          null
+      )
+      company = companyService.save(toSave)
+      onSave.run()
+      dispose()
+    } catch (IllegalArgumentException exception) {
+      showValidation([ValidationSupport.fieldError('', exception.message)])
+    }
+  }
+
+  private List<ValidationMessage> validateInput() {
+    List<ValidationMessage> messages = []
+    if (!companyNameField.text?.trim()) {
+      messages << ValidationSupport.fieldError(
+          I18n.instance.getString('companySettingsDialog.label.companyName'),
+          I18n.instance.getString('companySettingsDialog.error.companyNameRequired'))
+    }
+    if (!organizationNumberField.text?.trim()) {
+      messages << ValidationSupport.fieldError(
+          I18n.instance.getString('companySettingsDialog.label.orgNumber'),
+          I18n.instance.getString('companySettingsDialog.error.orgNumberRequired'))
+    }
+    String currency = defaultCurrencyField.text?.trim()
+    if (!currency) {
+      messages << ValidationSupport.fieldError(
+          I18n.instance.getString('companySettingsDialog.label.currency'),
+          I18n.instance.getString('companySettingsDialog.error.currencyRequired'))
+    } else if (currency.length() != 3) {
+      messages << ValidationSupport.fieldError(
+          I18n.instance.getString('companySettingsDialog.label.currency'),
+          I18n.instance.getString('companySettingsDialog.error.currencyFormat'),
+          I18n.instance.getString('companySettingsDialog.error.currencyHint'))
+    }
+    String localeTag = localeTagField.text?.trim()
+    if (!localeTag) {
+      messages << ValidationSupport.fieldError(
+          I18n.instance.getString('companySettingsDialog.label.locale'),
+          I18n.instance.getString('companySettingsDialog.error.localeRequired'))
+    } else if (Locale.forLanguageTag(localeTag).toLanguageTag() == 'und') {
+      messages << ValidationSupport.fieldError(
+          I18n.instance.getString('companySettingsDialog.label.locale'),
+          I18n.instance.getString('companySettingsDialog.error.localeInvalid'),
+          I18n.instance.getString('companySettingsDialog.error.localeHint'))
+    }
+    messages
+  }
+
+  private void showValidation(List<ValidationMessage> messages) {
+    validationArea.text = ValidationSupport.summaryText(messages)
+    validationArea.visible = true
+    pack()
+  }
+}

--- a/app/src/main/groovy/se/alipsa/accounting/ui/FiscalYearPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/FiscalYearPanel.groovy
@@ -235,6 +235,11 @@ final class FiscalYearPanel extends JPanel implements PropertyChangeListener {
   }
 
   private void reloadData() {
+    if (!activeCompanyManager.hasActiveCompany()) {
+      fiscalYearTableModel.setRows([])
+      periodTableModel.setRows([])
+      return
+    }
     List<FiscalYear> fiscalYears = fiscalYearService.listFiscalYears(activeCompanyManager.companyId)
     fiscalYearTableModel.setRows(fiscalYears)
     if (!fiscalYears.isEmpty() && fiscalYearTable.selectedRow < 0) {

--- a/app/src/main/groovy/se/alipsa/accounting/ui/FiscalYearPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/FiscalYearPanel.groovy
@@ -4,7 +4,6 @@ import se.alipsa.accounting.domain.AccountingPeriod
 import se.alipsa.accounting.domain.FiscalYear
 import se.alipsa.accounting.service.AccountingPeriodService
 import se.alipsa.accounting.service.ClosingService
-import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.support.I18n
 
@@ -32,6 +31,7 @@ final class FiscalYearPanel extends JPanel implements PropertyChangeListener {
   private final FiscalYearService fiscalYearService
   private final AccountingPeriodService accountingPeriodService
   private final ClosingService closingService
+  private final ActiveCompanyManager activeCompanyManager
 
   private final JTextField nameField = new JTextField(20)
   private final JTextField startDateField = new JTextField(10)
@@ -52,12 +52,15 @@ final class FiscalYearPanel extends JPanel implements PropertyChangeListener {
   FiscalYearPanel(
       FiscalYearService fiscalYearService,
       AccountingPeriodService accountingPeriodService,
-      ClosingService closingService
+      ClosingService closingService,
+      ActiveCompanyManager activeCompanyManager
   ) {
     this.fiscalYearService = fiscalYearService
     this.accountingPeriodService = accountingPeriodService
     this.closingService = closingService
+    this.activeCompanyManager = activeCompanyManager
     I18n.instance.addLocaleChangeListener(this)
+    activeCompanyManager.addPropertyChangeListener(this)
     buildUi()
     reloadData()
   }
@@ -66,6 +69,8 @@ final class FiscalYearPanel extends JPanel implements PropertyChangeListener {
   void propertyChange(PropertyChangeEvent evt) {
     if ('locale' == evt.propertyName) {
       SwingUtilities.invokeLater { applyLocale() }
+    } else if (ActiveCompanyManager.COMPANY_ID_PROPERTY == evt.propertyName) {
+      SwingUtilities.invokeLater { reloadData() }
     }
   }
 
@@ -190,7 +195,7 @@ final class FiscalYearPanel extends JPanel implements PropertyChangeListener {
     }
 
     try {
-      FiscalYear year = fiscalYearService.createFiscalYear(CompanyService.LEGACY_COMPANY_ID, nameField.text, startDate, endDate)
+      FiscalYear year = fiscalYearService.createFiscalYear(activeCompanyManager.companyId, nameField.text, startDate, endDate)
       clearInputs()
       reloadData()
       selectFiscalYear(year.id)
@@ -230,7 +235,7 @@ final class FiscalYearPanel extends JPanel implements PropertyChangeListener {
   }
 
   private void reloadData() {
-    List<FiscalYear> fiscalYears = fiscalYearService.listFiscalYears(CompanyService.LEGACY_COMPANY_ID)
+    List<FiscalYear> fiscalYears = fiscalYearService.listFiscalYears(activeCompanyManager.companyId)
     fiscalYearTableModel.setRows(fiscalYears)
     if (!fiscalYears.isEmpty() && fiscalYearTable.selectedRow < 0) {
       fiscalYearTable.setRowSelectionInterval(0, 0)

--- a/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
@@ -3,6 +3,7 @@ package se.alipsa.accounting.ui
 import groovy.swing.SwingBuilder
 import groovy.transform.CompileDynamic
 
+import se.alipsa.accounting.domain.Company
 import se.alipsa.accounting.domain.CompanySettings
 import se.alipsa.accounting.service.AccountService
 import se.alipsa.accounting.service.AccountingPeriodService
@@ -11,6 +12,7 @@ import se.alipsa.accounting.service.AuditLogService
 import se.alipsa.accounting.service.BackupService
 import se.alipsa.accounting.service.ChartOfAccountsImportService
 import se.alipsa.accounting.service.ClosingService
+import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.CompanySettingsService
 import se.alipsa.accounting.service.DatabaseService
 import se.alipsa.accounting.service.FiscalYearService
@@ -62,6 +64,7 @@ final class MainFrame implements PropertyChangeListener {
   ]
 
   private final SwingBuilder swing = new SwingBuilder()
+  private final CompanyService companyService = new CompanyService()
   private final CompanySettingsService companySettingsService = new CompanySettingsService()
   private final UserPreferencesService userPreferencesService = new UserPreferencesService()
   private final AuditLogService auditLogService = new AuditLogService()
@@ -129,15 +132,21 @@ final class MainFrame implements PropertyChangeListener {
       reportDataService,
       reportArchiveService,
       reportIntegrityService,
-      companySettingsService,
+      companyService,
       auditLogService,
       DatabaseService.instance
   )
+  private final ActiveCompanyManager activeCompanyManager = new ActiveCompanyManager(companyService)
+
   private JLabel statusLabel
   private JLabel companySummaryLabel
   private JLabel overviewDescriptionLabel
+  private JLabel companyLabel
+  private JComboBox<Company> companyComboBox
   private JMenu fileMenu
   private JMenuItem companySettingsMenuItem
+  private JMenuItem newCompanyMenuItem
+  private JMenuItem editCompanyMenuItem
   private JMenuItem sieExchangeMenuItem
   private JMenuItem exitMenuItem
   private JMenu helpMenu
@@ -157,17 +166,19 @@ final class MainFrame implements PropertyChangeListener {
 
   MainFrame() {
     I18n.instance.addLocaleChangeListener(this)
+    activeCompanyManager.addPropertyChangeListener(this)
     frame = buildFrame()
     applyIcons()
     refreshCompanySettingsSummary()
+    refreshTitle()
     setStatus(I18n.instance.getString('mainFrame.status.started'))
   }
 
   void display() {
     frame.visible = true
-    if (!companySettingsService.isConfigured()) {
+    if (!activeCompanyManager.hasActiveCompany()) {
       SwingUtilities.invokeLater {
-        showCompanySettingsDialog()
+        showNewCompanyDialog()
       }
     }
     checkForUpdateInBackground()
@@ -181,15 +192,36 @@ final class MainFrame implements PropertyChangeListener {
   void propertyChange(PropertyChangeEvent evt) {
     if ('locale' == evt.propertyName) {
       SwingUtilities.invokeLater { applyLocale() }
+    } else if (ActiveCompanyManager.COMPANY_ID_PROPERTY == evt.propertyName) {
+      SwingUtilities.invokeLater { onCompanyChanged() }
+    }
+  }
+
+  private void onCompanyChanged() {
+    refreshTitle()
+    refreshCompanySettingsSummary()
+    Company active = activeCompanyManager.activeCompany
+    if (active != null) {
+      setStatus(I18n.instance.format('mainFrame.status.companySwitched', active.companyName))
+    }
+  }
+
+  private void refreshTitle() {
+    Company active = activeCompanyManager.activeCompany
+    if (active != null) {
+      frame.title = I18n.instance.format('mainFrame.title.company', active.companyName)
+    } else {
+      frame.title = I18n.instance.getString('mainFrame.title')
     }
   }
 
   private void applyLocale() {
-    frame.title = I18n.instance.getString('mainFrame.title')
+    refreshTitle()
     statusLabel.text = I18n.instance.getString('mainFrame.status.ready')
     applyMenuLocale()
     applyTabLocale()
     editCompanySettingsButton.text = I18n.instance.getString('mainFrame.button.editCompanySettings')
+    companyLabel.text = I18n.instance.getString('mainFrame.label.activeCompany')
     languageLabel.text = I18n.instance.getString('companySettingsDialog.label.language')
     updateLanguageButtonBorders()
     if (pendingUpdate != null) {
@@ -201,6 +233,8 @@ final class MainFrame implements PropertyChangeListener {
   private void applyMenuLocale() {
     fileMenu.text = I18n.instance.getString('mainFrame.menu.file')
     companySettingsMenuItem.text = I18n.instance.getString('mainFrame.menu.file.companySettings')
+    newCompanyMenuItem.text = I18n.instance.getString('mainFrame.menu.file.newCompany')
+    editCompanyMenuItem.text = I18n.instance.getString('mainFrame.menu.file.editCompany')
     sieExchangeMenuItem.text = I18n.instance.getString('mainFrame.menu.file.sieExchange')
     exitMenuItem.text = I18n.instance.getString('mainFrame.menu.file.exit')
     helpMenu.text = I18n.instance.getString('mainFrame.menu.help')
@@ -235,8 +269,12 @@ final class MainFrame implements PropertyChangeListener {
       lookAndFeel 'system'
       menuBar {
         fileMenu = menu(text: I18n.instance.getString('mainFrame.menu.file')) {
+          newCompanyMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.file.newCompany'), actionPerformed: { showNewCompanyDialog() })
+          editCompanyMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.file.editCompany'), actionPerformed: { showEditCompanyDialog() })
+          separator()
           companySettingsMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.file.companySettings'), actionPerformed: { showCompanySettingsDialog() })
           sieExchangeMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.file.sieExchange'), actionPerformed: { showSieExchangeDialog() })
+          separator()
           exitMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.file.exit'), actionPerformed: { exitRequested() })
         }
         helpMenu = menu(text: I18n.instance.getString('mainFrame.menu.help')) {
@@ -310,24 +348,57 @@ final class MainFrame implements PropertyChangeListener {
   }
 
   private JPanel buildStatusBar() {
-    swing.panel(border: swing.lineBorder(color: Color.LIGHT_GRAY)) {
-      borderLayout()
-      statusLabel = label(
-          text: I18n.instance.getString('mainFrame.status.ready'),
-          border: swing.emptyBorder(6, 12, 6, 12),
-          constraints: BorderLayout.CENTER
-      ) as JLabel
-      updateNotificationButton = button(
-          text: I18n.instance.getString('mainFrame.button.updateAvailable'),
-          constraints: BorderLayout.EAST,
-          visible: false,
-          cursor: Cursor.getPredefinedCursor(Cursor.HAND_CURSOR),
-          borderPainted: false,
-          contentAreaFilled: false,
-          foreground: new Color(22, 101, 52),
-          actionPerformed: { showUpdateDialog() }
-      ) as JButton
-    } as JPanel
+    JPanel statusBar = new JPanel(new BorderLayout())
+    statusBar.border = BorderFactory.createCompoundBorder(
+        BorderFactory.createMatteBorder(1, 0, 0, 0, Color.LIGHT_GRAY),
+        BorderFactory.createEmptyBorder(4, 8, 4, 8)
+    )
+
+    JPanel leftPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 0))
+    companyLabel = new JLabel(I18n.instance.getString('mainFrame.label.activeCompany'))
+    companyComboBox = new JComboBox<>()
+    reloadCompanyComboBox()
+    companyComboBox.addActionListener { onCompanyComboBoxChanged() }
+    leftPanel.add(companyLabel)
+    leftPanel.add(companyComboBox)
+
+    statusLabel = new JLabel(I18n.instance.getString('mainFrame.status.ready'))
+    statusLabel.border = BorderFactory.createEmptyBorder(0, 12, 0, 0)
+
+    updateNotificationButton = new JButton(I18n.instance.getString('mainFrame.button.updateAvailable'))
+    updateNotificationButton.visible = false
+    updateNotificationButton.cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+    updateNotificationButton.borderPainted = false
+    updateNotificationButton.contentAreaFilled = false
+    updateNotificationButton.foreground = new Color(22, 101, 52)
+    updateNotificationButton.addActionListener { showUpdateDialog() }
+
+    statusBar.add(leftPanel, BorderLayout.WEST)
+    statusBar.add(statusLabel, BorderLayout.CENTER)
+    statusBar.add(updateNotificationButton, BorderLayout.EAST)
+    statusBar
+  }
+
+  private void reloadCompanyComboBox() {
+    List<Company> companies = companyService.listCompanies(true)
+    Company selected = companyComboBox.selectedItem as Company
+    companyComboBox.removeAllItems()
+    companies.each { Company c -> companyComboBox.addItem(c) }
+    if (selected != null) {
+      Company match = companies.find { Company c -> c.id == selected.id }
+      if (match != null) {
+        companyComboBox.selectedItem = match
+      }
+    } else if (!companies.isEmpty()) {
+      companyComboBox.selectedIndex = 0
+    }
+  }
+
+  private void onCompanyComboBoxChanged() {
+    Company selected = companyComboBox.selectedItem as Company
+    if (selected != null && selected.id != activeCompanyManager.companyId) {
+      activeCompanyManager.companyId = selected.id
+    }
   }
 
   private JPanel buildOverviewPanel() {
@@ -346,8 +417,8 @@ final class MainFrame implements PropertyChangeListener {
   private List<Map<String, Object>> buildMainTabs() {
     [
         [title: I18n.instance.getString('mainFrame.tab.overview'), component: buildOverviewPanel()],
-        [title: I18n.instance.getString('mainFrame.tab.vouchers'), component: new VoucherListPanel(voucherService, fiscalYearService, accountService, attachmentService, auditLogService)],
-        [title: I18n.instance.getString('mainFrame.tab.vat'), component: new VatPeriodPanel(vatService, fiscalYearService)],
+        [title: I18n.instance.getString('mainFrame.tab.vouchers'), component: new VoucherListPanel(voucherService, fiscalYearService, accountService, attachmentService, auditLogService, activeCompanyManager)],
+        [title: I18n.instance.getString('mainFrame.tab.vat'), component: new VatPeriodPanel(vatService, fiscalYearService, activeCompanyManager)],
         [title: I18n.instance.getString('mainFrame.tab.reports'), component: new ReportPanel(
             reportDataService,
             journoReportService,
@@ -355,10 +426,11 @@ final class MainFrame implements PropertyChangeListener {
             reportArchiveService,
             fiscalYearService,
             accountingPeriodService,
-            new VoucherEditor.Dependencies(voucherService, fiscalYearService, accountService, attachmentService, auditLogService)
+            new VoucherEditor.Dependencies(voucherService, fiscalYearService, accountService, attachmentService, auditLogService),
+            activeCompanyManager
         )],
-        [title: I18n.instance.getString('mainFrame.tab.chartOfAccounts'), component: new ChartOfAccountsPanel(accountService, chartOfAccountsImportService, fiscalYearService)],
-        [title: I18n.instance.getString('mainFrame.tab.fiscalYears'), component: new FiscalYearPanel(fiscalYearService, accountingPeriodService, closingService)],
+        [title: I18n.instance.getString('mainFrame.tab.chartOfAccounts'), component: new ChartOfAccountsPanel(accountService, chartOfAccountsImportService, fiscalYearService, activeCompanyManager)],
+        [title: I18n.instance.getString('mainFrame.tab.fiscalYears'), component: new FiscalYearPanel(fiscalYearService, accountingPeriodService, closingService, activeCompanyManager)],
         [title: I18n.instance.getString('mainFrame.tab.system'), component: new SystemDocumentationPanel(
             systemDocumentationService,
             diagnosticsService,
@@ -389,12 +461,35 @@ final class MainFrame implements PropertyChangeListener {
   private void showCompanySettingsDialog() {
     CompanySettingsDialog.showDialog(frame, companySettingsService, {
       refreshCompanySettingsSummary()
+      reloadCompanyComboBox()
       setStatus(I18n.instance.getString('mainFrame.status.companySaved'))
     } as Runnable)
   }
 
+  private void showNewCompanyDialog() {
+    CompanyDialog.showDialog(frame, companyService, null, {
+      reloadCompanyComboBox()
+      Company last = companyComboBox.getItemAt(companyComboBox.itemCount - 1) as Company
+      if (last != null) {
+        companyComboBox.selectedItem = last
+      }
+    } as Runnable)
+  }
+
+  private void showEditCompanyDialog() {
+    Company active = activeCompanyManager.activeCompany
+    if (active == null) {
+      return
+    }
+    CompanyDialog.showDialog(frame, companyService, active, {
+      reloadCompanyComboBox()
+      refreshTitle()
+      refreshCompanySettingsSummary()
+    } as Runnable)
+  }
+
   private void showSieExchangeDialog() {
-    SieExchangeDialog.showDialog(frame, sieImportExportService, fiscalYearService)
+    SieExchangeDialog.showDialog(frame, sieImportExportService, fiscalYearService, activeCompanyManager.companyId)
     setStatus(I18n.instance.getString('mainFrame.status.sieExchangeClosed'))
   }
 
@@ -446,18 +541,18 @@ final class MainFrame implements PropertyChangeListener {
     if (companySummaryLabel == null) {
       return
     }
-    CompanySettings settings = companySettingsService.getSettings()
-    if (settings == null) {
+    Company active = activeCompanyManager.activeCompany
+    if (active == null) {
       companySummaryLabel.text = I18n.instance.getString('mainFrame.companySettings.noProfile')
       return
     }
     companySummaryLabel.text = I18n.instance.format(
         'mainFrame.companySettings.summary',
-        escapeHtml(settings.companyName),
-        I18n.instance.getString('mainFrame.companySettings.orgNumber'), escapeHtml(settings.organizationNumber),
-        I18n.instance.getString('mainFrame.companySettings.currency'), escapeHtml(settings.defaultCurrency),
-        escapeHtml(settings.localeTag),
-        I18n.instance.getString('mainFrame.companySettings.vatPeriod'), escapeHtml(settings.vatPeriodicity?.displayName ?: I18n.instance.getString('vatPeriodicity.MONTHLY'))
+        escapeHtml(active.companyName),
+        I18n.instance.getString('mainFrame.companySettings.orgNumber'), escapeHtml(active.organizationNumber),
+        I18n.instance.getString('mainFrame.companySettings.currency'), escapeHtml(active.defaultCurrency),
+        escapeHtml(active.localeTag),
+        I18n.instance.getString('mainFrame.companySettings.vatPeriod'), escapeHtml(active.vatPeriodicity?.displayName ?: I18n.instance.getString('vatPeriodicity.MONTHLY'))
     )
   }
 

--- a/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
@@ -382,15 +382,31 @@ final class MainFrame implements PropertyChangeListener {
   private void reloadCompanyComboBox() {
     List<Company> companies = companyService.listCompanies(true)
     Company selected = companyComboBox.selectedItem as Company
-    companyComboBox.removeAllItems()
-    companies.each { Company c -> companyComboBox.addItem(c) }
-    if (selected != null) {
-      Company match = companies.find { Company c -> c.id == selected.id }
-      if (match != null) {
-        companyComboBox.selectedItem = match
+    java.awt.event.ActionListener[] listeners = companyComboBox.actionListeners
+    listeners.each { companyComboBox.removeActionListener(it) }
+    try {
+      companyComboBox.removeAllItems()
+      companies.each { Company c -> companyComboBox.addItem(c) }
+      if (selected != null) {
+        Company match = companies.find { Company c -> c.id == selected.id }
+        if (match != null) {
+          companyComboBox.selectedItem = match
+        }
+      } else if (!companies.isEmpty()) {
+        companyComboBox.selectedIndex = 0
       }
-    } else if (!companies.isEmpty()) {
-      companyComboBox.selectedIndex = 0
+    } finally {
+      listeners.each { companyComboBox.addActionListener(it) }
+    }
+  }
+
+  private void selectCompanyInComboBox(Long companyId) {
+    for (int index = 0; index < companyComboBox.itemCount; index++) {
+      Company c = companyComboBox.getItemAt(index) as Company
+      if (c?.id == companyId) {
+        companyComboBox.selectedItem = c
+        return
+      }
     }
   }
 
@@ -467,25 +483,23 @@ final class MainFrame implements PropertyChangeListener {
   }
 
   private void showNewCompanyDialog() {
-    CompanyDialog.showDialog(frame, companyService, null, {
+    CompanyDialog.showDialog(frame, companyService, null, { Company saved ->
       reloadCompanyComboBox()
-      Company last = companyComboBox.getItemAt(companyComboBox.itemCount - 1) as Company
-      if (last != null) {
-        companyComboBox.selectedItem = last
-      }
-    } as Runnable)
+      selectCompanyInComboBox(saved.id)
+    } as java.util.function.Consumer<Company>)
   }
 
   private void showEditCompanyDialog() {
     Company active = activeCompanyManager.activeCompany
     if (active == null) {
+      setStatus(I18n.instance.getString('mainFrame.companySettings.noProfile'))
       return
     }
-    CompanyDialog.showDialog(frame, companyService, active, {
+    CompanyDialog.showDialog(frame, companyService, active, { Company saved ->
       reloadCompanyComboBox()
       refreshTitle()
       refreshCompanySettingsSummary()
-    } as Runnable)
+    } as java.util.function.Consumer<Company>)
   }
 
   private void showSieExchangeDialog() {

--- a/app/src/main/groovy/se/alipsa/accounting/ui/OpeningBalanceDialog.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/OpeningBalanceDialog.groovy
@@ -4,7 +4,6 @@ import se.alipsa.accounting.domain.Account
 import se.alipsa.accounting.domain.FiscalYear
 import se.alipsa.accounting.domain.OpeningBalance
 import se.alipsa.accounting.service.AccountService
-import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.support.I18n
 
@@ -42,6 +41,7 @@ final class OpeningBalanceDialog extends JDialog {
       Frame owner,
       AccountService accountService,
       FiscalYearService fiscalYearService,
+      long companyId,
       Account account,
       Runnable onSave
   ) {
@@ -50,7 +50,7 @@ final class OpeningBalanceDialog extends JDialog {
     this.account = account
     this.onSave = onSave
 
-    List<FiscalYear> fiscalYears = fiscalYearService.listFiscalYears(CompanyService.LEGACY_COMPANY_ID)
+    List<FiscalYear> fiscalYears = fiscalYearService.listFiscalYears(companyId)
     fiscalYearComboBox = new JComboBox<>(fiscalYears as FiscalYear[])
     buildUi()
     refreshCurrentAmount()
@@ -60,13 +60,14 @@ final class OpeningBalanceDialog extends JDialog {
       Frame owner,
       AccountService accountService,
       FiscalYearService fiscalYearService,
+      long companyId,
       Account account,
       Runnable onSave
   ) {
     if (!account.isBalanceAccount()) {
       throw new IllegalArgumentException('Opening balances may only be set on balance accounts.')
     }
-    OpeningBalanceDialog dialog = new OpeningBalanceDialog(owner, accountService, fiscalYearService, account, onSave)
+    OpeningBalanceDialog dialog = new OpeningBalanceDialog(owner, accountService, fiscalYearService, companyId, account, onSave)
     dialog.setVisible(true)
   }
 

--- a/app/src/main/groovy/se/alipsa/accounting/ui/ReportPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/ReportPanel.groovy
@@ -7,7 +7,6 @@ import se.alipsa.accounting.domain.report.ReportResult
 import se.alipsa.accounting.domain.report.ReportSelection
 import se.alipsa.accounting.domain.report.ReportType
 import se.alipsa.accounting.service.AccountingPeriodService
-import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.service.JournoReportService
 import se.alipsa.accounting.service.ReportArchiveService
@@ -57,6 +56,7 @@ final class ReportPanel extends JPanel implements PropertyChangeListener {
   private final FiscalYearService fiscalYearService
   private final AccountingPeriodService accountingPeriodService
   private final VoucherEditor.Dependencies voucherEditorDependencies
+  private final ActiveCompanyManager activeCompanyManager
   private final JComboBox<ReportType> reportTypeComboBox = new JComboBox<>(ReportType.values())
   private final JComboBox<FiscalYear> fiscalYearComboBox = new JComboBox<>()
   private final JComboBox<Object> accountingPeriodComboBox = new JComboBox<>()
@@ -88,7 +88,8 @@ final class ReportPanel extends JPanel implements PropertyChangeListener {
       ReportArchiveService reportArchiveService,
       FiscalYearService fiscalYearService,
       AccountingPeriodService accountingPeriodService,
-      VoucherEditor.Dependencies voucherEditorDependencies
+      VoucherEditor.Dependencies voucherEditorDependencies,
+      ActiveCompanyManager activeCompanyManager
   ) {
     this.reportDataService = reportDataService
     this.journoReportService = journoReportService
@@ -97,7 +98,9 @@ final class ReportPanel extends JPanel implements PropertyChangeListener {
     this.fiscalYearService = fiscalYearService
     this.accountingPeriodService = accountingPeriodService
     this.voucherEditorDependencies = voucherEditorDependencies
+    this.activeCompanyManager = activeCompanyManager
     I18n.instance.addLocaleChangeListener(this)
+    activeCompanyManager.addPropertyChangeListener(this)
     buildUi()
     reloadFiscalYears()
     reloadArchives()
@@ -108,6 +111,12 @@ final class ReportPanel extends JPanel implements PropertyChangeListener {
   void propertyChange(PropertyChangeEvent evt) {
     if ('locale' == evt.propertyName) {
       SwingUtilities.invokeLater { applyLocale() }
+    } else if (ActiveCompanyManager.COMPANY_ID_PROPERTY == evt.propertyName) {
+      SwingUtilities.invokeLater {
+        reloadFiscalYears()
+        reloadArchives()
+        reloadReport()
+      }
     }
   }
 
@@ -254,7 +263,7 @@ final class ReportPanel extends JPanel implements PropertyChangeListener {
   private void reloadFiscalYears() {
     FiscalYear selected = selectedFiscalYear()
     fiscalYearComboBox.removeAllItems()
-    fiscalYearService.listFiscalYears(CompanyService.LEGACY_COMPANY_ID).each { FiscalYear fiscalYear ->
+    fiscalYearService.listFiscalYears(activeCompanyManager.companyId).each { FiscalYear fiscalYear ->
       fiscalYearComboBox.addItem(fiscalYear)
     }
     if (selected != null) {
@@ -367,7 +376,7 @@ final class ReportPanel extends JPanel implements PropertyChangeListener {
   }
 
   private void reloadArchives() {
-    archiveTableModel.setRows(reportArchiveService.listArchives(CompanyService.LEGACY_COMPANY_ID, 100))
+    archiveTableModel.setRows(reportArchiveService.listArchives(activeCompanyManager.companyId, 100))
     updateActionButtons()
   }
 
@@ -376,7 +385,7 @@ final class ReportPanel extends JPanel implements PropertyChangeListener {
     if (voucherId == null) {
       return
     }
-    VoucherEditor.showDialog(ownerFrame(), voucherEditorDependencies, voucherId, {
+    VoucherEditor.showDialog(ownerFrame(), voucherEditorDependencies, activeCompanyManager.companyId, voucherId, {
       reloadReport()
     } as Runnable)
   }

--- a/app/src/main/groovy/se/alipsa/accounting/ui/ReportPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/ReportPanel.groovy
@@ -261,6 +261,10 @@ final class ReportPanel extends JPanel implements PropertyChangeListener {
   }
 
   private void reloadFiscalYears() {
+    if (!activeCompanyManager.hasActiveCompany()) {
+      fiscalYearComboBox.removeAllItems()
+      return
+    }
     FiscalYear selected = selectedFiscalYear()
     fiscalYearComboBox.removeAllItems()
     fiscalYearService.listFiscalYears(activeCompanyManager.companyId).each { FiscalYear fiscalYear ->

--- a/app/src/main/groovy/se/alipsa/accounting/ui/SieExchangeDialog.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/SieExchangeDialog.groovy
@@ -2,7 +2,6 @@ package se.alipsa.accounting.ui
 
 import se.alipsa.accounting.domain.FiscalYear
 import se.alipsa.accounting.domain.ImportJob
-import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.service.SieExportResult
 import se.alipsa.accounting.service.SieImportExportService
@@ -45,6 +44,7 @@ final class SieExchangeDialog extends JDialog {
 
   private final SieImportExportService sieImportExportService
   private final FiscalYearService fiscalYearService
+  private final long companyId
 
   private final JComboBox<FiscalYear> fiscalYearComboBox = new JComboBox<>()
   private final JTextArea summaryArea = new JTextArea(5, 50)
@@ -55,18 +55,19 @@ final class SieExchangeDialog extends JDialog {
   private final JButton exportButton = new JButton(I18n.instance.getString('sieExchangeDialog.button.export'))
   private boolean workInProgress
 
-  SieExchangeDialog(Frame owner, SieImportExportService sieImportExportService, FiscalYearService fiscalYearService) {
+  SieExchangeDialog(Frame owner, SieImportExportService sieImportExportService, FiscalYearService fiscalYearService, long companyId) {
     super(owner, I18n.instance.getString('sieExchangeDialog.title'), true)
     this.sieImportExportService = sieImportExportService
     this.fiscalYearService = fiscalYearService
+    this.companyId = companyId
     buildUi()
     reloadFiscalYears()
     reloadJobs()
     showInfo(I18n.instance.getString('sieExchangeDialog.status.initial'))
   }
 
-  static void showDialog(Frame owner, SieImportExportService sieImportExportService, FiscalYearService fiscalYearService) {
-    SieExchangeDialog dialog = new SieExchangeDialog(owner, sieImportExportService, fiscalYearService)
+  static void showDialog(Frame owner, SieImportExportService sieImportExportService, FiscalYearService fiscalYearService, long companyId) {
+    SieExchangeDialog dialog = new SieExchangeDialog(owner, sieImportExportService, fiscalYearService, companyId)
     dialog.visible = true
   }
 
@@ -151,7 +152,7 @@ final class SieExchangeDialog extends JDialog {
   private void reloadFiscalYears() {
     FiscalYear selected = fiscalYearComboBox.selectedItem as FiscalYear
     fiscalYearComboBox.removeAllItems()
-    fiscalYearService.listFiscalYears(CompanyService.LEGACY_COMPANY_ID).each { FiscalYear fiscalYear ->
+    fiscalYearService.listFiscalYears(companyId).each { FiscalYear fiscalYear ->
       fiscalYearComboBox.addItem(fiscalYear)
     }
     if (selected != null) {
@@ -160,7 +161,7 @@ final class SieExchangeDialog extends JDialog {
   }
 
   private void reloadJobs() {
-    importJobTableModel.setRows(sieImportExportService.listImportJobs(CompanyService.LEGACY_COMPANY_ID))
+    importJobTableModel.setRows(sieImportExportService.listImportJobs(companyId))
   }
 
   private void importRequested() {
@@ -176,7 +177,7 @@ final class SieExchangeDialog extends JDialog {
     new SwingWorker<SieImportResult, Void>() {
       @Override
       protected SieImportResult doInBackground() {
-        sieImportExportService.importFile(CompanyService.LEGACY_COMPANY_ID, selectedPath)
+        sieImportExportService.importFile(companyId, selectedPath)
       }
 
       @Override

--- a/app/src/main/groovy/se/alipsa/accounting/ui/VatPeriodPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/VatPeriodPanel.groovy
@@ -166,6 +166,12 @@ final class VatPeriodPanel extends JPanel implements PropertyChangeListener {
   }
 
   private void reloadFiscalYears() {
+    if (!activeCompanyManager.hasActiveCompany()) {
+      fiscalYearComboBox.removeAllItems()
+      periodTableModel.setRows([])
+      reportTableModel.setRows([])
+      return
+    }
     FiscalYear selected = selectedFiscalYear()
     fiscalYearComboBox.removeAllItems()
     fiscalYearService.listFiscalYears(activeCompanyManager.companyId).each { FiscalYear fiscalYear ->

--- a/app/src/main/groovy/se/alipsa/accounting/ui/VatPeriodPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/VatPeriodPanel.groovy
@@ -2,7 +2,6 @@ package se.alipsa.accounting.ui
 
 import se.alipsa.accounting.domain.FiscalYear
 import se.alipsa.accounting.domain.VatPeriod
-import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.service.VatService
 import se.alipsa.accounting.support.I18n
@@ -38,6 +37,7 @@ final class VatPeriodPanel extends JPanel implements PropertyChangeListener {
 
   private final VatService vatService
   private final FiscalYearService fiscalYearService
+  private final ActiveCompanyManager activeCompanyManager
   private final JComboBox<FiscalYear> fiscalYearComboBox = new JComboBox<>()
   private final JTextArea feedbackArea = new JTextArea(3, 40)
   private final JLabel summaryLabel = new JLabel(I18n.instance.getString('vatPeriodPanel.summary.initial'))
@@ -55,10 +55,12 @@ final class VatPeriodPanel extends JPanel implements PropertyChangeListener {
   private JButton transferButton
   private boolean fiscalYearListenerInstalled = false
 
-  VatPeriodPanel(VatService vatService, FiscalYearService fiscalYearService) {
+  VatPeriodPanel(VatService vatService, FiscalYearService fiscalYearService, ActiveCompanyManager activeCompanyManager) {
     this.vatService = vatService
     this.fiscalYearService = fiscalYearService
+    this.activeCompanyManager = activeCompanyManager
     I18n.instance.addLocaleChangeListener(this)
+    activeCompanyManager.addPropertyChangeListener(this)
     buildUi()
     reloadFiscalYears()
     reloadPeriods()
@@ -68,6 +70,11 @@ final class VatPeriodPanel extends JPanel implements PropertyChangeListener {
   void propertyChange(PropertyChangeEvent evt) {
     if ('locale' == evt.propertyName) {
       SwingUtilities.invokeLater { applyLocale() }
+    } else if (ActiveCompanyManager.COMPANY_ID_PROPERTY == evt.propertyName) {
+      SwingUtilities.invokeLater {
+        reloadFiscalYears()
+        reloadPeriods()
+      }
     }
   }
 
@@ -161,7 +168,7 @@ final class VatPeriodPanel extends JPanel implements PropertyChangeListener {
   private void reloadFiscalYears() {
     FiscalYear selected = selectedFiscalYear()
     fiscalYearComboBox.removeAllItems()
-    fiscalYearService.listFiscalYears(CompanyService.LEGACY_COMPANY_ID).each { FiscalYear fiscalYear ->
+    fiscalYearService.listFiscalYears(activeCompanyManager.companyId).each { FiscalYear fiscalYear ->
       fiscalYearComboBox.addItem(fiscalYear)
     }
     if (selected != null) {

--- a/app/src/main/groovy/se/alipsa/accounting/ui/VoucherEditor.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/VoucherEditor.groovy
@@ -10,7 +10,6 @@ import se.alipsa.accounting.domain.VoucherStatus
 import se.alipsa.accounting.service.AccountService
 import se.alipsa.accounting.service.AttachmentService
 import se.alipsa.accounting.service.AuditLogService
-import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.service.VoucherService
 import se.alipsa.accounting.support.I18n
@@ -77,6 +76,7 @@ final class VoucherEditor extends JDialog implements PropertyChangeListener {
   private final AccountService accountService
   private final AttachmentService attachmentService
   private final AuditLogService auditLogService
+  private final long companyId
   private final Runnable onSave
   private final JComboBox<FiscalYear> fiscalYearComboBox
   private final JTextField seriesField = new JTextField(6)
@@ -110,6 +110,7 @@ final class VoucherEditor extends JDialog implements PropertyChangeListener {
   VoucherEditor(
       Frame owner,
       Dependencies dependencies,
+      long companyId,
       Long voucherId,
       Runnable onSave
   ) {
@@ -119,11 +120,12 @@ final class VoucherEditor extends JDialog implements PropertyChangeListener {
     this.accountService = dependencies.accountService
     this.attachmentService = dependencies.attachmentService
     this.auditLogService = dependencies.auditLogService
+    this.companyId = companyId
     this.onSave = onSave
     voucher = voucherId == null ? null : voucherService.findVoucher(voucherId)
     readOnly = voucher != null && voucher.status != VoucherStatus.DRAFT
-    fiscalYearComboBox = new JComboBox<>(fiscalYearService.listFiscalYears(CompanyService.LEGACY_COMPANY_ID) as FiscalYear[])
-    lineTableModel = new LineTableModel(accountService, !readOnly)
+    fiscalYearComboBox = new JComboBox<>(fiscalYearService.listFiscalYears(companyId) as FiscalYear[])
+    lineTableModel = new LineTableModel(accountService, companyId, !readOnly)
     lineTable = new JTable(lineTableModel)
     setTitle(voucherId == null
         ? I18n.instance.getString('voucherEditor.title.new')
@@ -166,10 +168,11 @@ final class VoucherEditor extends JDialog implements PropertyChangeListener {
   static void showDialog(
       Frame owner,
       Dependencies dependencies,
+      long companyId,
       Long voucherId,
       Runnable onSave
   ) {
-    VoucherEditor editor = new VoucherEditor(owner, dependencies, voucherId, onSave)
+    VoucherEditor editor = new VoucherEditor(owner, dependencies, companyId, voucherId, onSave)
     editor.setVisible(true)
   }
 
@@ -584,11 +587,13 @@ final class VoucherEditor extends JDialog implements PropertyChangeListener {
   private static final class LineTableModel extends AbstractTableModel {
 
     private final AccountService accountService
+    private final long companyId
     private final boolean editable
     private final List<LineEntry> rows = []
 
-    LineTableModel(AccountService accountService, boolean editable) {
+    LineTableModel(AccountService accountService, long companyId, boolean editable) {
       this.accountService = accountService
+      this.companyId = companyId
       this.editable = editable
     }
 
@@ -732,7 +737,7 @@ final class VoucherEditor extends JDialog implements PropertyChangeListener {
         return ''
       }
       try {
-        Account account = accountService.findAccount(CompanyService.LEGACY_COMPANY_ID, normalized)
+        Account account = accountService.findAccount(companyId, normalized)
         account == null
             ? I18n.instance.getString('voucherEditor.table.line.unknownAccount')
             : account.accountName

--- a/app/src/main/groovy/se/alipsa/accounting/ui/VoucherListPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/VoucherListPanel.groovy
@@ -6,7 +6,6 @@ import se.alipsa.accounting.domain.VoucherStatus
 import se.alipsa.accounting.service.AccountService
 import se.alipsa.accounting.service.AttachmentService
 import se.alipsa.accounting.service.AuditLogService
-import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.service.VoucherService
 import se.alipsa.accounting.support.I18n
@@ -47,6 +46,7 @@ final class VoucherListPanel extends JPanel implements PropertyChangeListener {
   private final AccountService accountService
   private final AttachmentService attachmentService
   private final AuditLogService auditLogService
+  private final ActiveCompanyManager activeCompanyManager
   private final VoucherEditor.Dependencies editorDependencies
   private final Timer searchDebounceTimer
   private final JComboBox<Object> fiscalYearComboBox = new JComboBox<>()
@@ -72,13 +72,15 @@ final class VoucherListPanel extends JPanel implements PropertyChangeListener {
       FiscalYearService fiscalYearService,
       AccountService accountService,
       AttachmentService attachmentService,
-      AuditLogService auditLogService
+      AuditLogService auditLogService,
+      ActiveCompanyManager activeCompanyManager
   ) {
     this.voucherService = voucherService
     this.fiscalYearService = fiscalYearService
     this.accountService = accountService
     this.attachmentService = attachmentService
     this.auditLogService = auditLogService
+    this.activeCompanyManager = activeCompanyManager
     editorDependencies = new VoucherEditor.Dependencies(
         voucherService,
         fiscalYearService,
@@ -90,6 +92,7 @@ final class VoucherListPanel extends JPanel implements PropertyChangeListener {
     searchDebounceTimer = new Timer(SEARCH_DEBOUNCE_MILLIS, { reloadVouchers() } as ActionListener)
     searchDebounceTimer.repeats = false
     I18n.instance.addLocaleChangeListener(this)
+    activeCompanyManager.addPropertyChangeListener(this)
     buildUi()
     reloadFiscalYears()
     installFilterListeners()
@@ -100,6 +103,8 @@ final class VoucherListPanel extends JPanel implements PropertyChangeListener {
   void propertyChange(PropertyChangeEvent evt) {
     if ('locale' == evt.propertyName) {
       SwingUtilities.invokeLater { applyLocale() }
+    } else if (ActiveCompanyManager.COMPANY_ID_PROPERTY == evt.propertyName) {
+      SwingUtilities.invokeLater { refreshData() }
     }
   }
 
@@ -219,7 +224,7 @@ final class VoucherListPanel extends JPanel implements PropertyChangeListener {
       Object selected = fiscalYearComboBox.selectedItem
       fiscalYearComboBox.removeAllItems()
       fiscalYearComboBox.addItem(allFilterValue)
-      fiscalYearService.listFiscalYears(CompanyService.LEGACY_COMPANY_ID).each { FiscalYear fiscalYear ->
+      fiscalYearService.listFiscalYears(activeCompanyManager.companyId).each { FiscalYear fiscalYear ->
         fiscalYearComboBox.addItem(fiscalYear)
       }
       if (selected != null) {
@@ -246,7 +251,7 @@ final class VoucherListPanel extends JPanel implements PropertyChangeListener {
     }
     Long fiscalYearId = selectedFiscalYearId()
     VoucherStatus status = selectedStatus()
-    List<Voucher> vouchers = voucherService.listVouchers(CompanyService.LEGACY_COMPANY_ID, fiscalYearId, status, searchField.text)
+    List<Voucher> vouchers = voucherService.listVouchers(activeCompanyManager.companyId, fiscalYearId, status, searchField.text)
     tableModel.setRows(vouchers)
     showInfo(I18n.instance.format('voucherListPanel.message.showing', vouchers.size()))
   }
@@ -285,7 +290,7 @@ final class VoucherListPanel extends JPanel implements PropertyChangeListener {
   }
 
   private void openEditor(Long voucherId) {
-    VoucherEditor.showDialog(ownerFrame(), editorDependencies, voucherId, {
+    VoucherEditor.showDialog(ownerFrame(), editorDependencies, activeCompanyManager.companyId, voucherId, {
       refreshData()
     } as Runnable)
   }

--- a/app/src/main/groovy/se/alipsa/accounting/ui/VoucherListPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/VoucherListPanel.groovy
@@ -261,6 +261,10 @@ final class VoucherListPanel extends JPanel implements PropertyChangeListener {
   }
 
   private void refreshData() {
+    if (!activeCompanyManager.hasActiveCompany()) {
+      tableModel.setRows([])
+      return
+    }
     reloadFiscalYears()
     reloadVouchers()
   }

--- a/app/src/main/resources/i18n/messages.properties
+++ b/app/src/main/resources/i18n/messages.properties
@@ -32,9 +32,12 @@ reportType.VAT_REPORT=VAT report
 
 # MainFrame
 mainFrame.title=Alipsa Accounting
+mainFrame.title.company=Alipsa Accounting \u2014 {0}
 mainFrame.status.ready=Ready
 mainFrame.status.started=Application started and ready for chart of accounts, company settings and fiscal years.
 mainFrame.menu.file.companySettings=Company settings...
+mainFrame.menu.file.newCompany=New company...
+mainFrame.menu.file.editCompany=Edit company...
 mainFrame.menu.file.sieExchange=SIE import/export...
 mainFrame.menu.file.exit=Exit
 mainFrame.menu.help.manual=User manual
@@ -58,6 +61,8 @@ mainFrame.about.title=About Alipsa Accounting
 mainFrame.about.message=Alipsa Accounting\nVersion: {0}
 mainFrame.about.versionDefault=development version
 mainFrame.status.companySaved=Company settings saved.
+mainFrame.status.companySwitched=Switched to {0}.
+mainFrame.label.activeCompany=Company
 mainFrame.status.sieExchangeClosed=SIE import/export closed.
 mainFrame.status.manualShown=User manual displayed.
 mainFrame.companySettings.noProfile=<html><h2>Company settings</h2><p>No company profile saved yet. Open the dialog to complete initial setup.</p></html>
@@ -65,6 +70,10 @@ mainFrame.companySettings.summary=<html><h2>{0}</h2><p>{1}: {2}</p><p>{3}: {4}</
 mainFrame.companySettings.orgNumber=Organization number
 mainFrame.companySettings.currency=Currency
 mainFrame.companySettings.vatPeriod=VAT period
+
+# CompanyDialog
+companyDialog.title.new=New company
+companyDialog.title.edit=Edit company
 
 # CompanySettingsDialog
 companySettingsDialog.title=Company settings

--- a/app/src/main/resources/i18n/messages_sv.properties
+++ b/app/src/main/resources/i18n/messages_sv.properties
@@ -32,12 +32,12 @@ reportType.VAT_REPORT=Momsrapport
 
 # MainFrame
 mainFrame.title=Alipsa Accounting
-mainFrame.title.company=Alipsa Accounting \u2014 {0}
+mainFrame.title.company=Alipsa Accounting — {0}
 mainFrame.status.ready=Redo
-mainFrame.status.started=Applikationen \u00e4r startad och redo f\u00f6r kontoplan, f\u00f6retagsinst\u00e4llningar och r\u00e4kenskaps\u00e5r.
-mainFrame.menu.file.companySettings=F\u00f6retagsuppgifter...
-mainFrame.menu.file.newCompany=Nytt f\u00f6retag...
-mainFrame.menu.file.editCompany=Redigera f\u00f6retag...
+mainFrame.status.started=Applikationen är startad och redo för kontoplan, företagsinställningar och räkenskapsår.
+mainFrame.menu.file.companySettings=Företagsuppgifter...
+mainFrame.menu.file.newCompany=Nytt företag...
+mainFrame.menu.file.editCompany=Redigera företag...
 mainFrame.menu.file.sieExchange=SIE import/export...
 mainFrame.menu.file.exit=Avsluta
 mainFrame.menu.help.manual=Användarmanual
@@ -60,9 +60,9 @@ mainFrame.button.updateVersion=⬆ Uppdatera till {0}
 mainFrame.about.title=Om Alipsa Accounting
 mainFrame.about.message=Alipsa Accounting\nVersion: {0}
 mainFrame.about.versionDefault=utvecklingsversion
-mainFrame.status.companySaved=F\u00f6retagsinst\u00e4llningarna sparades.
+mainFrame.status.companySaved=Företagsinställningarna sparades.
 mainFrame.status.companySwitched=Bytte till {0}.
-mainFrame.label.activeCompany=F\u00f6retag
+mainFrame.label.activeCompany=Företag
 mainFrame.status.sieExchangeClosed=SIE-import/export stängdes.
 mainFrame.status.manualShown=Användarmanualen visades.
 mainFrame.companySettings.noProfile=<html><h2>Företagsinställningar</h2><p>Ingen företagsprofil är sparad än. Öppna dialogen för att genomföra grundinställningen.</p></html>
@@ -72,8 +72,8 @@ mainFrame.companySettings.currency=Valuta
 mainFrame.companySettings.vatPeriod=Momsperiod
 
 # CompanyDialog
-companyDialog.title.new=Nytt f\u00f6retag
-companyDialog.title.edit=Redigera f\u00f6retag
+companyDialog.title.new=Nytt företag
+companyDialog.title.edit=Redigera företag
 
 # CompanySettingsDialog
 companySettingsDialog.title=Företagsinställningar

--- a/app/src/main/resources/i18n/messages_sv.properties
+++ b/app/src/main/resources/i18n/messages_sv.properties
@@ -32,9 +32,12 @@ reportType.VAT_REPORT=Momsrapport
 
 # MainFrame
 mainFrame.title=Alipsa Accounting
+mainFrame.title.company=Alipsa Accounting \u2014 {0}
 mainFrame.status.ready=Redo
-mainFrame.status.started=Applikationen är startad och redo för kontoplan, företagsinställningar och räkenskapsår.
-mainFrame.menu.file.companySettings=Företagsuppgifter...
+mainFrame.status.started=Applikationen \u00e4r startad och redo f\u00f6r kontoplan, f\u00f6retagsinst\u00e4llningar och r\u00e4kenskaps\u00e5r.
+mainFrame.menu.file.companySettings=F\u00f6retagsuppgifter...
+mainFrame.menu.file.newCompany=Nytt f\u00f6retag...
+mainFrame.menu.file.editCompany=Redigera f\u00f6retag...
 mainFrame.menu.file.sieExchange=SIE import/export...
 mainFrame.menu.file.exit=Avsluta
 mainFrame.menu.help.manual=Användarmanual
@@ -57,7 +60,9 @@ mainFrame.button.updateVersion=⬆ Uppdatera till {0}
 mainFrame.about.title=Om Alipsa Accounting
 mainFrame.about.message=Alipsa Accounting\nVersion: {0}
 mainFrame.about.versionDefault=utvecklingsversion
-mainFrame.status.companySaved=Företagsinställningarna sparades.
+mainFrame.status.companySaved=F\u00f6retagsinst\u00e4llningarna sparades.
+mainFrame.status.companySwitched=Bytte till {0}.
+mainFrame.label.activeCompany=F\u00f6retag
 mainFrame.status.sieExchangeClosed=SIE-import/export stängdes.
 mainFrame.status.manualShown=Användarmanualen visades.
 mainFrame.companySettings.noProfile=<html><h2>Företagsinställningar</h2><p>Ingen företagsprofil är sparad än. Öppna dialogen för att genomföra grundinställningen.</p></html>
@@ -65,6 +70,10 @@ mainFrame.companySettings.summary=<html><h2>{0}</h2><p>{1}: {2}</p><p>{3}: {4}</
 mainFrame.companySettings.orgNumber=Organisationsnummer
 mainFrame.companySettings.currency=Valuta
 mainFrame.companySettings.vatPeriod=Momsperiod
+
+# CompanyDialog
+companyDialog.title.new=Nytt f\u00f6retag
+companyDialog.title.edit=Redigera f\u00f6retag
 
 # CompanySettingsDialog
 companySettingsDialog.title=Företagsinställningar

--- a/app/src/test/groovy/integration/se/alipsa/accounting/ui/VatPeriodPanelTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/ui/VatPeriodPanelTest.groovy
@@ -43,10 +43,12 @@ class VatPeriodPanelTest {
   Path tempDir
 
   private DatabaseService databaseService
+  private CompanyService companyService
   private AccountingPeriodService accountingPeriodService
   private FiscalYearService fiscalYearService
   private VoucherService voucherService
   private VatService vatService
+  private ActiveCompanyManager activeCompanyManager
   private FiscalYear fiscalYear
   private String previousHome
   private Locale previousLocale
@@ -59,11 +61,13 @@ class VatPeriodPanelTest {
     System.setProperty(AppPaths.HOME_OVERRIDE_PROPERTY, tempDir.toString())
     databaseService = DatabaseService.newForTesting()
     databaseService.initialize()
+    companyService = new CompanyService(databaseService)
     AuditLogService auditLogService = new AuditLogService(databaseService)
     accountingPeriodService = new AccountingPeriodService(databaseService, auditLogService)
     fiscalYearService = new FiscalYearService(databaseService, accountingPeriodService, auditLogService)
     voucherService = new VoucherService(databaseService, auditLogService)
     vatService = new VatService(databaseService, voucherService, auditLogService)
+    activeCompanyManager = new ActiveCompanyManager(companyService)
     fiscalYear = fiscalYearService.createFiscalYear(
         CompanyService.LEGACY_COMPANY_ID,
         '2026',
@@ -84,7 +88,7 @@ class VatPeriodPanelTest {
     bookVatFixtures()
 
     VatPeriodPanel panel = onEdt {
-      new VatPeriodPanel(vatService, fiscalYearService)
+      new VatPeriodPanel(vatService, fiscalYearService, activeCompanyManager)
     }
 
     JTable periodTable = findTable(panel, 'Period')
@@ -102,7 +106,7 @@ class VatPeriodPanelTest {
     bookVatFixtures()
 
     VatPeriodPanel panel = onEdt {
-      new VatPeriodPanel(vatService, fiscalYearService)
+      new VatPeriodPanel(vatService, fiscalYearService, activeCompanyManager)
     }
 
     JTable periodTable = findTable(panel, 'Period')

--- a/app/src/test/groovy/unit/se/alipsa/accounting/ui/ActiveCompanyManagerTest.groovy
+++ b/app/src/test/groovy/unit/se/alipsa/accounting/ui/ActiveCompanyManagerTest.groovy
@@ -1,0 +1,103 @@
+package se.alipsa.accounting.ui
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+import se.alipsa.accounting.domain.Company
+import se.alipsa.accounting.domain.VatPeriodicity
+import se.alipsa.accounting.service.CompanyService
+import se.alipsa.accounting.service.DatabaseService
+import se.alipsa.accounting.support.AppPaths
+
+import java.beans.PropertyChangeEvent
+import java.nio.file.Path
+
+class ActiveCompanyManagerTest {
+
+  @TempDir
+  Path tempDir
+
+  private DatabaseService databaseService
+  private CompanyService companyService
+  private String previousHome
+
+  @BeforeEach
+  void setUp() {
+    previousHome = System.getProperty(AppPaths.HOME_OVERRIDE_PROPERTY)
+    System.setProperty(AppPaths.HOME_OVERRIDE_PROPERTY, tempDir.toString())
+    databaseService = DatabaseService.newForTesting()
+    databaseService.initialize()
+    companyService = new CompanyService(databaseService)
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (previousHome == null) {
+      System.clearProperty(AppPaths.HOME_OVERRIDE_PROPERTY)
+    } else {
+      System.setProperty(AppPaths.HOME_OVERRIDE_PROPERTY, previousHome)
+    }
+  }
+
+  @Test
+  void initializesToFirstCompany() {
+    ActiveCompanyManager manager = new ActiveCompanyManager(companyService)
+
+    assertTrue(manager.hasActiveCompany())
+    assertEquals(CompanyService.LEGACY_COMPANY_ID, manager.companyId)
+  }
+
+  @Test
+  void firesPropertyChangeEventOnCompanySwitch() {
+    Company second = companyService.save(new Company(
+        null, 'Zetterberg AB', '556000-0002', 'SEK', 'sv-SE', VatPeriodicity.MONTHLY, true, null, null
+    ))
+
+    ActiveCompanyManager manager = new ActiveCompanyManager(companyService)
+    long initialId = manager.companyId
+    List<PropertyChangeEvent> events = []
+    manager.addPropertyChangeListener { PropertyChangeEvent evt -> events << evt }
+
+    manager.companyId = second.id
+
+    assertEquals(1, events.size())
+    assertEquals(ActiveCompanyManager.COMPANY_ID_PROPERTY, events[0].propertyName)
+    assertEquals(initialId, events[0].oldValue)
+    assertEquals(second.id, events[0].newValue)
+    assertEquals(second.id, manager.companyId)
+  }
+
+  @Test
+  void doesNotFireEventWhenSettingSameCompanyId() {
+    ActiveCompanyManager manager = new ActiveCompanyManager(companyService)
+    long initialId = manager.companyId
+    List<PropertyChangeEvent> events = []
+    manager.addPropertyChangeListener { PropertyChangeEvent evt -> events << evt }
+
+    manager.companyId = initialId
+
+    assertTrue(events.isEmpty())
+  }
+
+  @Test
+  void removedListenerDoesNotReceiveEvents() {
+    Company second = companyService.save(new Company(
+        null, 'Gamma AB', '556000-0003', 'SEK', 'sv-SE', VatPeriodicity.MONTHLY, true, null, null
+    ))
+
+    ActiveCompanyManager manager = new ActiveCompanyManager(companyService)
+    List<PropertyChangeEvent> events = []
+    java.beans.PropertyChangeListener listener = { PropertyChangeEvent evt -> events << evt }
+    manager.addPropertyChangeListener(listener)
+    manager.removePropertyChangeListener(listener)
+
+    manager.companyId = second.id
+
+    assertTrue(events.isEmpty())
+  }
+}


### PR DESCRIPTION
## Summary
- **ActiveCompanyManager** — observable holder for active company ID; panels listen for changes and reload data automatically when the user switches company
- **CompanyDialog** — modal dialog for creating and editing companies (name, org number, currency, locale, VAT periodicity)
- **MainFrame** — company selector combo box in status bar, File menu items for new/edit company, title shows active company name
- All panels and dialogs now use dynamic `companyId` from `ActiveCompanyManager` instead of `CompanyService.LEGACY_COMPANY_ID`

## Changes (14 files, +543 −79)
| File | Change |
|------|--------|
| `ActiveCompanyManager.groovy` | **New** — observable active-company holder with `PropertyChangeSupport` |
| `CompanyDialog.groovy` | **New** — create/edit company dialog |
| `MainFrame.groovy` | Company selector, menu items, title, wiring |
| `FiscalYearPanel.groovy` | Listen for company changes, use dynamic ID |
| `VoucherListPanel.groovy` | Listen for company changes, use dynamic ID |
| `VoucherEditor.groovy` | Accept `companyId` parameter |
| `VatPeriodPanel.groovy` | Listen for company changes, use dynamic ID |
| `ReportPanel.groovy` | Listen for company changes, use dynamic ID |
| `ChartOfAccountsPanel.groovy` | Listen for company changes, use dynamic ID |
| `OpeningBalanceDialog.groovy` | Accept `companyId` parameter |
| `SieExchangeDialog.groovy` | Accept `companyId` parameter |
| `messages.properties` | New i18n keys for company UI |
| `messages_sv.properties` | Swedish translations |
| `VatPeriodPanelTest.groovy` | Updated for new constructor signature |

## Notes
- `SieImportExportService` still uses `CompanySettingsService` for SIE header metadata — will be addressed in batch 6
- Fixed pre-existing bug: `MainFrame` passed `companySettingsService` to `JournoReportService` constructor which expects `CompanyService` (masked by `@CompileDynamic`)

## Test plan
- [x] `./gradlew build` passes (compilation, tests, Spotless, CodeNarc)
- [ ] Manual: start app → create new company → verify title and status bar update
- [ ] Manual: switch between companies → verify all panels reload
- [ ] Manual: edit company → verify changes persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)