### PR TITLE
Batch 6: Rapporter, moms, SIE och bokslut

### DIFF
--- a/app/src/main/groovy/se/alipsa/accounting/service/ReportArchiveService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/ReportArchiveService.groovy
@@ -49,9 +49,11 @@ final class ReportArchiveService {
 
     try {
       databaseService.withTransaction { Sql sql ->
+        long companyId = CompanyService.resolveFromFiscalYear(sql, safeSelection.fiscalYearId)
         LocalDateTime createdAt = currentDatabaseTimestamp(sql)
         List<List<Object>> keys = sql.executeInsert('''
             insert into report_archive (
+                company_id,
                 report_type,
                 report_format,
                 fiscal_year_id,
@@ -63,8 +65,9 @@ final class ReportArchiveService {
                 checksum_sha256,
                 parameters,
                 created_at
-            ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ''', [
+            companyId,
             safeSelection.reportType.name(),
             safeFormat,
             safeSelection.fiscalYearId,

--- a/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportModels.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportModels.groovy
@@ -99,6 +99,7 @@ final class ExportLineSeed {
 @Canonical
 final class ExportPayload {
 
+  long companyId
   SieDocument document
   FiscalYear fiscalYear
   int accountCount

--- a/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
@@ -123,20 +123,19 @@ final class SieImportExportService {
   }
   SieExportResult exportFiscalYear(long fiscalYearId, Path targetPath) {
     Path safeTarget = normalizeExportPath(targetPath)
-    reportIntegrityService.ensureReportingAllowed()
     ExportPayload payload = databaseService.withSql { Sql sql ->
       long companyId = resolveCompanyId(sql, fiscalYearId)
       Company company = companyService.findById(companyId)
       if (company == null) {
         throw new IllegalStateException('Företagsuppgifter måste sparas innan SIE-export kan göras.')
       }
+      reportIntegrityService.ensureReportingAllowed(companyId)
       buildExportPayload(sql, fiscalYearId, company)
     }
     byte[] content = renderDocument(payload.document)
     Files.createDirectories(safeTarget.parent)
     Files.write(safeTarget, content)
     String checksum = sha256(content)
-    long companyId = resolveCompanyId(payload.fiscalYear.id)
     auditLogService.logExport(
         "Exporterade SIE ${payload.fiscalYear.name}",
         [
@@ -147,7 +146,7 @@ final class SieImportExportService {
             "openingBalances=${payload.openingBalanceCount}",
             "vouchers=${payload.voucherCount}"
         ].join('\n'),
-        companyId
+        payload.companyId
     )
     new SieExportResult(
         safeTarget.toAbsolutePath().normalize(),
@@ -660,6 +659,7 @@ final class SieImportExportService {
     document.setVER(buildExportVouchers(document, vouchers))
 
     new ExportPayload(
+        company.id,
         document,
         fiscalYear,
         accounts.size(),

--- a/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
@@ -15,7 +15,7 @@ import alipsa.sieparser.SieType
 import alipsa.sieparser.SieVoucher
 import alipsa.sieparser.SieVoucherRow
 
-import se.alipsa.accounting.domain.CompanySettings
+import se.alipsa.accounting.domain.Company
 import se.alipsa.accounting.domain.FiscalYear
 import se.alipsa.accounting.domain.ImportJob
 import se.alipsa.accounting.domain.ImportJobStatus
@@ -49,7 +49,7 @@ final class SieImportExportService {
   private final DatabaseService databaseService
   private final AccountingPeriodService accountingPeriodService
   private final VoucherService voucherService
-  private final CompanySettingsService companySettingsService
+  private final CompanyService companyService
   private final ReportIntegrityService reportIntegrityService
   private final AuditLogService auditLogService
   SieImportExportService() {
@@ -57,7 +57,7 @@ final class SieImportExportService {
         DatabaseService.instance,
         new AccountingPeriodService(DatabaseService.instance),
         new VoucherService(DatabaseService.instance),
-        new CompanySettingsService(DatabaseService.instance),
+        new CompanyService(DatabaseService.instance),
         new ReportIntegrityService(),
         new AuditLogService(DatabaseService.instance)
     )
@@ -66,14 +66,14 @@ final class SieImportExportService {
       DatabaseService databaseService,
       AccountingPeriodService accountingPeriodService,
       VoucherService voucherService,
-      CompanySettingsService companySettingsService,
+      CompanyService companyService,
       ReportIntegrityService reportIntegrityService,
       AuditLogService auditLogService
   ) {
     this.databaseService = databaseService
     this.accountingPeriodService = accountingPeriodService
     this.voucherService = voucherService
-    this.companySettingsService = companySettingsService
+    this.companyService = companyService
     this.reportIntegrityService = reportIntegrityService
     this.auditLogService = auditLogService
   }
@@ -124,9 +124,13 @@ final class SieImportExportService {
   SieExportResult exportFiscalYear(long fiscalYearId, Path targetPath) {
     Path safeTarget = normalizeExportPath(targetPath)
     reportIntegrityService.ensureReportingAllowed()
-    CompanySettings settings = requireCompanySettings()
     ExportPayload payload = databaseService.withSql { Sql sql ->
-      buildExportPayload(sql, fiscalYearId, settings)
+      long companyId = resolveCompanyId(sql, fiscalYearId)
+      Company company = companyService.findById(companyId)
+      if (company == null) {
+        throw new IllegalStateException('Företagsuppgifter måste sparas innan SIE-export kan göras.')
+      }
+      buildExportPayload(sql, fiscalYearId, company)
     }
     byte[] content = renderDocument(payload.document)
     Files.createDirectories(safeTarget.parent)
@@ -200,13 +204,6 @@ final class SieImportExportService {
       throw new IllegalArgumentException("Ogiltig exportväg: ${normalized}")
     }
     normalized
-  }
-  private CompanySettings requireCompanySettings() {
-    CompanySettings settings = companySettingsService.getSettings()
-    if (settings == null) {
-      throw new IllegalStateException('Företagsuppgifter måste sparas innan SIE-export kan göras.')
-    }
-    settings
   }
   private long createImportJob(long companyId, String fileName, String checksum) {
     databaseService.withTransaction { Sql sql ->
@@ -628,14 +625,13 @@ final class SieImportExportService {
     closing
   }
 
-  private ExportPayload buildExportPayload(Sql sql, long fiscalYearId, CompanySettings settings) {
+  private static ExportPayload buildExportPayload(Sql sql, long fiscalYearId, Company company) {
     FiscalYear fiscalYear = findFiscalYear(sql, fiscalYearId)
     if (fiscalYear == null) {
       throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
     }
 
-    long companyId = resolveCompanyId(sql, fiscalYearId)
-    Map<String, AccountSeed> accounts = loadAccounts(sql, companyId)
+    Map<String, AccountSeed> accounts = loadAccounts(sql, company.id)
     Map<String, BigDecimal> openings = loadOpeningBalances(sql, fiscalYearId)
     List<ExportVoucherSeed> vouchers = loadBookedVouchers(sql, fiscalYearId)
     Map<String, BigDecimal> closings = loadClosingBalances(sql, fiscalYearId)
@@ -647,10 +643,10 @@ final class SieImportExportService {
     document.setGEN_NAMN(GENERATOR_NAME)
     document.setOMFATTN(fiscalYear.endDate)
     document.setPROGRAM([PROGRAM_NAME, PROGRAM_VERSION])
-    document.setVALUTA(settings.defaultCurrency?.trim()?.toUpperCase(Locale.ROOT) ?: 'SEK')
+    document.setVALUTA(company.defaultCurrency?.trim()?.toUpperCase(Locale.ROOT) ?: 'SEK')
     document.setFNAMN(new SieCompany())
-    document.getFNAMN().setName(settings.companyName)
-    document.getFNAMN().setOrgIdentifier(settings.organizationNumber)
+    document.getFNAMN().setName(company.companyName)
+    document.getFNAMN().setOrgIdentifier(company.organizationNumber)
     document.setRars([(0): buildBookingYear(fiscalYear)])
 
     Map<String, SieAccount> konto = [:]

--- a/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
@@ -124,7 +124,7 @@ final class MainFrame implements PropertyChangeListener {
       DatabaseService.instance,
       accountingPeriodService,
       voucherService,
-      companySettingsService,
+      companyService,
       reportIntegrityService,
       auditLogService
   )

--- a/app/src/test/groovy/acceptance/se/alipsa/accounting/AcceptanceCriteriaTest.groovy
+++ b/app/src/test/groovy/acceptance/se/alipsa/accounting/AcceptanceCriteriaTest.groovy
@@ -258,7 +258,7 @@ class AcceptanceCriteriaTest {
             databaseService,
             accountingPeriodService,
             voucherService,
-            companySettingsService,
+            companyService,
             reportIntegrityService,
             auditLogService
         ),

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/SieImportExportServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/SieImportExportServiceTest.groovy
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
-import se.alipsa.accounting.domain.CompanySettings
+import se.alipsa.accounting.domain.Company
 import se.alipsa.accounting.domain.FiscalYear
 import se.alipsa.accounting.domain.ImportJob
 import se.alipsa.accounting.domain.ImportJobStatus
@@ -229,8 +229,11 @@ class SieImportExportServiceTest {
     AccountingPeriodService accountingPeriodService = new AccountingPeriodService(databaseService, auditLogService)
     FiscalYearService fiscalYearService = new FiscalYearService(databaseService, accountingPeriodService, auditLogService)
     VoucherService voucherService = new VoucherService(databaseService, auditLogService)
-    CompanySettingsService companySettingsService = new CompanySettingsService(databaseService)
-    companySettingsService.save(new CompanySettings(null, 'Testbolaget AB', '556677-8899', 'SEK', 'sv-SE', VatPeriodicity.MONTHLY))
+    CompanyService companyService = new CompanyService(databaseService)
+    companyService.save(new Company(
+        CompanyService.LEGACY_COMPANY_ID, 'Testbolaget AB', '556677-8899', 'SEK', 'sv-SE',
+        VatPeriodicity.MONTHLY, true, null, null
+    ))
     FiscalYear fiscalYear = fiscalYearService.createFiscalYear(CompanyService.LEGACY_COMPANY_ID, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
 
     databaseService.withTransaction { Sql sql ->
@@ -293,7 +296,7 @@ class SieImportExportServiceTest {
         databaseService,
         accountingPeriodService,
         voucherService,
-        new CompanySettingsService(databaseService),
+        new CompanyService(databaseService),
         reportIntegrityService,
         auditLogService
     )


### PR DESCRIPTION
## Summary
- **SIE export**: replaced `CompanySettingsService` (singleton) with `CompanyService` — export now resolves company metadata from the fiscal year's `company_id`, so multi-company SIE exports use the correct company name, org number, and currency
- **Report archive**: `archiveReport` now explicitly sets `company_id` in the INSERT instead of relying on the default value (1)

## Changes (5 files, +29 −27)
| File | Change |
|------|--------|
| `SieImportExportService.groovy` | Replaced `CompanySettingsService` with `CompanyService`; `exportFiscalYear` resolves `Company` from fiscal year; removed `requireCompanySettings()` |
| `ReportArchiveService.groovy` | `archiveReport` resolves and inserts `company_id` via `CompanyService.resolveFromFiscalYear()` |
| `MainFrame.groovy` | Updated `SieImportExportService` constructor wiring |
| `SieImportExportServiceTest.groovy` | Updated to use `CompanyService` instead of `CompanySettingsService` |
| `AcceptanceCriteriaTest.groovy` | Updated SIE service constructor |

## No changes needed
- `ReportDataService`, `JournoReportService`, `VatService`, `ClosingService` — already company-scoped via fiscal year
- `ReportArchiveService` global methods (`listAllArchives`, `findAllIntegrityFailures`) — intentionally system-level for backup/diagnostics/startup verification

## Test plan
- [x] `./gradlew build` passes (compilation, tests, Spotless, CodeNarc)
- [ ] Manual: export SIE for company A → verify header contains company A's name and org number
- [ ] Manual: export SIE for company B → verify header contains company B's data, not company A's
- [ ] Manual: generate and archive a report → verify `report_archive.company_id` matches the fiscal year's company

🤖 Generated with [Claude Code](https://claude.com/claude-code)