### PR TITLE
Batch 7: testcutover för flerföretagsverifiering

### DIFF
--- a/app/src/main/groovy/se/alipsa/accounting/service/ReportArchiveService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/ReportArchiveService.groovy
@@ -41,7 +41,11 @@ final class ReportArchiveService {
     String safeFormat = normalizeFormat(reportFormat)
     AppPaths.ensureDirectoryStructure()
     String fileName = buildFileName(safeSelection, safeFormat)
-    String storagePath = buildStoragePath(fileName)
+
+    long companyId = databaseService.withSql { Sql sql ->
+      CompanyService.resolveFromFiscalYear(sql, safeSelection.fiscalYearId)
+    }
+    String storagePath = buildStoragePath(companyId, fileName)
     Path targetPath = resolveStoragePath(storagePath)
     Files.createDirectories(targetPath.parent)
     Files.write(targetPath, content)
@@ -49,7 +53,6 @@ final class ReportArchiveService {
 
     try {
       databaseService.withTransaction { Sql sql ->
-        long companyId = CompanyService.resolveFromFiscalYear(sql, safeSelection.fiscalYearId)
         LocalDateTime createdAt = currentDatabaseTimestamp(sql)
         List<List<Object>> keys = sql.executeInsert('''
             insert into report_archive (
@@ -252,10 +255,10 @@ final class ReportArchiveService {
     "${selection.reportType.name().toLowerCase(Locale.ROOT)}-${selection.startDate}-${selection.endDate}.${suffix}"
   }
 
-  private static String buildStoragePath(String fileName) {
+  private static String buildStoragePath(long companyId, String fileName) {
     LocalDateTime now = LocalDateTime.now()
     String safeFileName = fileName.replaceAll(/[^A-Za-z0-9._-]/, '_')
-    "${now.year}/${String.format('%02d', now.monthValue)}/${safeFileName}"
+    "c${companyId}/${now.year}/${String.format('%02d', now.monthValue)}/${safeFileName}"
   }
 
   private static Path resolveStoragePath(String storagePath) {

--- a/app/src/test/groovy/acceptance/se/alipsa/accounting/AcceptanceCriteriaTest.groovy
+++ b/app/src/test/groovy/acceptance/se/alipsa/accounting/AcceptanceCriteriaTest.groovy
@@ -206,16 +206,16 @@ class AcceptanceCriteriaTest {
     services.voucherService.createAndBook(
         fyA.id, 'A', LocalDate.of(2026, 1, 15), 'Försäljning i Alfa',
         [
-            new VoucherLine(null, null, 0, '1510', null, 'Kundfordran', 1000.00G, 0.00G),
-            new VoucherLine(null, null, 0, '3010', null, 'Försäljning', 0.00G, 800.00G),
-            new VoucherLine(null, null, 0, '2611', null, 'Utgående moms', 0.00G, 200.00G)
+            new VoucherLine(null, null, 0, null, '1510', null, 'Kundfordran', 1000.00G, 0.00G),
+            new VoucherLine(null, null, 0, null, '3010', null, 'Försäljning', 0.00G, 800.00G),
+            new VoucherLine(null, null, 0, null, '2611', null, 'Utgående moms', 0.00G, 200.00G)
         ])
     services.voucherService.createAndBook(
         fyB.id, 'A', LocalDate.of(2026, 1, 15), 'Försäljning i Bravo',
         [
-            new VoucherLine(null, null, 0, '1510', null, 'Kundfordran', 2500.00G, 0.00G),
-            new VoucherLine(null, null, 0, '3010', null, 'Försäljning', 0.00G, 2000.00G),
-            new VoucherLine(null, null, 0, '2611', null, 'Utgående moms', 0.00G, 500.00G)
+            new VoucherLine(null, null, 0, null, '1510', null, 'Kundfordran', 2500.00G, 0.00G),
+            new VoucherLine(null, null, 0, null, '3010', null, 'Försäljning', 0.00G, 2000.00G),
+            new VoucherLine(null, null, 0, null, '2611', null, 'Utgående moms', 0.00G, 500.00G)
         ])
 
     ReportArchive reportA = services.journoReportService.generatePdf(

--- a/app/src/test/groovy/acceptance/se/alipsa/accounting/AcceptanceCriteriaTest.groovy
+++ b/app/src/test/groovy/acceptance/se/alipsa/accounting/AcceptanceCriteriaTest.groovy
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertNotNull
 import static org.junit.jupiter.api.Assertions.assertTrue
 
+import groovy.sql.GroovyRowResult
 import groovy.sql.Sql
 
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
+import se.alipsa.accounting.domain.Company
 import se.alipsa.accounting.domain.CompanySettings
 import se.alipsa.accounting.domain.FiscalYear
 import se.alipsa.accounting.domain.VatCode
@@ -39,6 +41,7 @@ import se.alipsa.accounting.service.ReportArchiveService
 import se.alipsa.accounting.service.ReportDataService
 import se.alipsa.accounting.service.ReportExportService
 import se.alipsa.accounting.service.ReportIntegrityService
+import se.alipsa.accounting.service.SieExportResult
 import se.alipsa.accounting.service.SieImportExportService
 import se.alipsa.accounting.service.VatService
 import se.alipsa.accounting.service.VoucherService
@@ -177,6 +180,120 @@ class AcceptanceCriteriaTest {
     assertTrue(Files.isRegularFile(packagingRoot.resolve('linux').resolve('AlipsaAccounting.png')))
     assertTrue(Files.isRegularFile(packagingRoot.resolve('windows').resolve('AlipsaAccounting.ico')))
     assertTrue(Files.isRegularFile(packagingRoot.resolve('macos').resolve('AlipsaAccounting.icns')))
+  }
+
+  @Test
+  void multiCompanyIsolationCanBeDemonstrated() {
+    DatabaseService databaseService = DatabaseService.newForTesting()
+    databaseService.initialize()
+    AcceptanceServices services = createAcceptanceServices(databaseService)
+
+    CompanyService companyService = new CompanyService(databaseService)
+    Company companyA = companyService.findById(CompanyService.LEGACY_COMPANY_ID)
+    companyA = companyService.save(new Company(
+        companyA.id, 'Alfa AB', '556001-0001', 'SEK', 'sv-SE', VatPeriodicity.MONTHLY, true, null, null))
+    Company companyB = companyService.save(new Company(
+        null, 'Bravo AB', '556002-0002', 'SEK', 'sv-SE', VatPeriodicity.MONTHLY, true, null, null))
+
+    FiscalYear fyA = services.fiscalYearService.createFiscalYear(
+        companyA.id, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    FiscalYear fyB = services.fiscalYearService.createFiscalYear(
+        companyB.id, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+
+    seedCompanyAccounts(databaseService, companyA.id)
+    seedCompanyAccounts(databaseService, companyB.id)
+
+    services.voucherService.createAndBook(
+        fyA.id, 'A', LocalDate.of(2026, 1, 15), 'Försäljning i Alfa',
+        [
+            new VoucherLine(null, null, 0, '1510', null, 'Kundfordran', 1000.00G, 0.00G),
+            new VoucherLine(null, null, 0, '3010', null, 'Försäljning', 0.00G, 800.00G),
+            new VoucherLine(null, null, 0, '2611', null, 'Utgående moms', 0.00G, 200.00G)
+        ])
+    services.voucherService.createAndBook(
+        fyB.id, 'A', LocalDate.of(2026, 1, 15), 'Försäljning i Bravo',
+        [
+            new VoucherLine(null, null, 0, '1510', null, 'Kundfordran', 2500.00G, 0.00G),
+            new VoucherLine(null, null, 0, '3010', null, 'Försäljning', 0.00G, 2000.00G),
+            new VoucherLine(null, null, 0, '2611', null, 'Utgående moms', 0.00G, 500.00G)
+        ])
+
+    ReportArchive reportA = services.journoReportService.generatePdf(
+        new ReportSelection(ReportType.VOUCHER_LIST, fyA.id, null, fyA.startDate, fyA.endDate))
+    assertNotNull(reportA)
+
+    Path sieB = tempDir.resolve('bravo.sie')
+    SieExportResult sieResultB = services.sieService.exportFiscalYear(fyB.id, sieB)
+    assertNotNull(sieResultB.checksumSha256)
+    String sieContent = sieB.toFile().getText('CP437')
+    assertTrue(sieContent.contains('Bravo AB'))
+    assertTrue(!sieContent.contains('Alfa AB'))
+
+    lockAllAccountingPeriods(services.accountingPeriodService, fyA.id)
+    YearEndClosingResult closingA = services.closingService.closeFiscalYear(fyA.id)
+    assertTrue(closingA.closedFiscalYear.closed)
+    assertEquals('2027', closingA.nextFiscalYear.name)
+
+    FiscalYear fyBAfter = services.fiscalYearService.findById(fyB.id)
+    assertTrue(!fyBAfter.closed)
+    List<FiscalYear> companyBYears = services.fiscalYearService.listFiscalYears(companyB.id)
+    assertEquals(1, companyBYears.size())
+
+    databaseService.withSql { Sql sql ->
+      int vouchersA = countVouchersForFiscalYear(sql, fyA.id)
+      int vouchersB = countVouchersForFiscalYear(sql, fyB.id)
+      assertTrue(vouchersA >= 1)
+      assertTrue(vouchersB == 1)
+    }
+  }
+
+  private static int countVouchersForFiscalYear(Sql sql, long fiscalYearId) {
+    GroovyRowResult row = sql.firstRow(
+        'select count(*) as total from voucher where fiscal_year_id = ?', [fiscalYearId]) as GroovyRowResult
+    ((Number) row.get('total')).intValue()
+  }
+
+  private static void seedCompanyAccounts(DatabaseService databaseService, long companyId) {
+    databaseService.withTransaction { Sql sql ->
+      insertAccountIfMissing(sql, companyId, '1510', 'Kundfordringar', 'ASSET', 'DEBIT', null)
+      insertAccountIfMissing(sql, companyId, '1930', 'Företagskonto', 'ASSET', 'DEBIT', null)
+      insertAccountIfMissing(sql, companyId, '2099', 'Årets resultat', 'EQUITY', 'CREDIT', null)
+      insertAccountIfMissing(sql, companyId, '2611', 'Utgående moms 25%', 'LIABILITY', 'CREDIT', VatCode.OUTPUT_25.name())
+      insertAccountIfMissing(sql, companyId, '2650', 'Redovisningskonto för moms', 'LIABILITY', 'CREDIT', null)
+      insertAccountIfMissing(sql, companyId, '3010', 'Försäljning', 'INCOME', 'CREDIT', VatCode.OUTPUT_25.name())
+      insertAccountIfMissing(sql, companyId, '4010', 'Varukostnad', 'EXPENSE', 'DEBIT', null)
+    }
+  }
+
+  private static void insertAccountIfMissing(
+      Sql sql,
+      long companyId,
+      String accountNumber,
+      String accountName,
+      String accountClass,
+      String normalBalanceSide,
+      String vatCode
+  ) {
+    if (sql.firstRow(
+        'select account_number from account where company_id = ? and account_number = ?',
+        [companyId, accountNumber]) != null) {
+      return
+    }
+    sql.executeInsert('''
+        insert into account (
+            company_id,
+            account_number,
+            account_name,
+            account_class,
+            normal_balance_side,
+            vat_code,
+            active,
+            manual_review_required,
+            classification_note,
+            created_at,
+            updated_at
+        ) values (?, ?, ?, ?, ?, ?, true, false, null, current_timestamp, current_timestamp)
+    ''', [companyId, accountNumber, accountName, accountClass, normalBalanceSide, vatCode])
   }
 
   private static void lockAllAccountingPeriods(AccountingPeriodService accountingPeriodService, long fiscalYearId) {

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/MultiCompanyIsolationTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/MultiCompanyIsolationTest.groovy
@@ -258,14 +258,14 @@ class MultiCompanyIsolationTest {
     voucherService.createAndBook(
         fyA.id, 'A', LocalDate.of(2026, 1, 15), 'Försäljning A',
         [
-            new VoucherLine(null, null, 0, '1510', null, 'Kundfordran', 1000.00G, 0.00G),
-            new VoucherLine(null, null, 0, '3010', null, 'Försäljning', 0.00G, 1000.00G)
+            new VoucherLine(null, null, 0, null, '1510', null, 'Kundfordran', 1000.00G, 0.00G),
+            new VoucherLine(null, null, 0, null, '3010', null, 'Försäljning', 0.00G, 1000.00G)
         ])
     voucherService.createAndBook(
         fyB.id, 'A', LocalDate.of(2026, 1, 15), 'Försäljning B',
         [
-            new VoucherLine(null, null, 0, '1510', null, 'Kundfordran', 2000.00G, 0.00G),
-            new VoucherLine(null, null, 0, '3010', null, 'Försäljning', 0.00G, 2000.00G)
+            new VoucherLine(null, null, 0, null, '1510', null, 'Kundfordran', 2000.00G, 0.00G),
+            new VoucherLine(null, null, 0, null, '3010', null, 'Försäljning', 0.00G, 2000.00G)
         ])
 
     accountingPeriodService.listPeriods(fyA.id).each { period ->
@@ -285,9 +285,10 @@ class MultiCompanyIsolationTest {
     assertEquals('2026', companyBYears.first().name)
 
     databaseService.withSql { Sql sql ->
-      int closingEntriesB = countRows(sql, 'closing_entry',
-          "fiscal_year_id = ${fyB.id}")
-      assertEquals(0, closingEntriesB)
+      GroovyRowResult row = sql.firstRow(
+          'select count(*) as total from closing_entry where fiscal_year_id = ?',
+          [fyB.id]) as GroovyRowResult
+      assertEquals(0, ((Number) row.get('total')).intValue())
     }
   }
 
@@ -384,12 +385,6 @@ class MultiCompanyIsolationTest {
           [companyId]) as GroovyRowResult
       ((Number) row.get('total')).intValue()
     }
-  }
-
-  private static int countRows(Sql sql, String tableName, String whereClause) {
-    GroovyRowResult row = sql.firstRow(
-        "select count(*) as total from ${tableName} where ${whereClause}" as String) as GroovyRowResult
-    ((Number) row.get('total')).intValue()
   }
 
   private static void restoreProperty(String name, String value) {

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/MultiCompanyIsolationTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/MultiCompanyIsolationTest.groovy
@@ -1,0 +1,402 @@
+package se.alipsa.accounting.service
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertNotNull
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+import groovy.sql.GroovyRowResult
+import groovy.sql.Sql
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+import se.alipsa.accounting.domain.Company
+import se.alipsa.accounting.domain.FiscalYear
+import se.alipsa.accounting.domain.VatCode
+import se.alipsa.accounting.domain.VatPeriod
+import se.alipsa.accounting.domain.VatPeriodicity
+import se.alipsa.accounting.domain.Voucher
+import se.alipsa.accounting.domain.VoucherLine
+import se.alipsa.accounting.domain.report.ReportArchive
+import se.alipsa.accounting.domain.report.ReportSelection
+import se.alipsa.accounting.domain.report.ReportType
+import se.alipsa.accounting.support.AppPaths
+
+import java.nio.file.Path
+import java.time.LocalDate
+
+class MultiCompanyIsolationTest {
+
+  @TempDir
+  Path tempDir
+
+  private DatabaseService databaseService
+  private CompanyService companyService
+  private AuditLogService auditLogService
+  private AccountingPeriodService accountingPeriodService
+  private FiscalYearService fiscalYearService
+  private VoucherService voucherService
+  private VatService vatService
+  private ReportDataService reportDataService
+  private ReportArchiveService reportArchiveService
+  private ReportIntegrityService reportIntegrityService
+  private JournoReportService journoReportService
+  private SieImportExportService sieService
+  private ClosingService closingService
+  private String previousHome
+
+  @BeforeEach
+  void setUp() {
+    previousHome = System.getProperty(AppPaths.HOME_OVERRIDE_PROPERTY)
+    System.setProperty(AppPaths.HOME_OVERRIDE_PROPERTY, tempDir.toString())
+    databaseService = DatabaseService.newForTesting()
+    databaseService.initialize()
+    companyService = new CompanyService(databaseService)
+    auditLogService = new AuditLogService(databaseService)
+    accountingPeriodService = new AccountingPeriodService(databaseService, auditLogService)
+    fiscalYearService = new FiscalYearService(databaseService, accountingPeriodService, auditLogService)
+    voucherService = new VoucherService(databaseService, auditLogService)
+    vatService = new VatService(databaseService, voucherService)
+    AttachmentService attachmentService = new AttachmentService(databaseService, auditLogService)
+    reportIntegrityService = new ReportIntegrityService(voucherService, attachmentService, auditLogService)
+    reportArchiveService = new ReportArchiveService(databaseService)
+    reportDataService = new ReportDataService(databaseService, fiscalYearService, accountingPeriodService)
+    journoReportService = new JournoReportService(
+        reportDataService,
+        reportArchiveService,
+        reportIntegrityService,
+        companyService,
+        auditLogService,
+        databaseService
+    )
+    sieService = new SieImportExportService(
+        databaseService,
+        accountingPeriodService,
+        voucherService,
+        companyService,
+        reportIntegrityService,
+        auditLogService
+    )
+    closingService = new ClosingService(
+        databaseService,
+        accountingPeriodService,
+        fiscalYearService,
+        voucherService,
+        reportIntegrityService
+    )
+  }
+
+  @AfterEach
+  void tearDown() {
+    restoreProperty(AppPaths.HOME_OVERRIDE_PROPERTY, previousHome)
+  }
+
+  @Test
+  void sameBASAccountNumbersCanExistInBothCompanies() {
+    Company companyB = createSecondCompany()
+    FiscalYear fyA = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    FiscalYear fyB = fiscalYearService.createFiscalYear(
+        companyB.id, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    seedAccounts(CompanyService.LEGACY_COMPANY_ID)
+    seedAccounts(companyB.id)
+
+    Voucher vA = voucherService.createAndBook(
+        fyA.id, 'A', LocalDate.of(2026, 1, 15), 'Försäljning A', balancedLines(500.00G))
+    Voucher vB = voucherService.createAndBook(
+        fyB.id, 'A', LocalDate.of(2026, 1, 15), 'Försäljning B', balancedLines(800.00G))
+
+    assertEquals(500.00G, vA.debitTotal())
+    assertEquals(800.00G, vB.debitTotal())
+
+    Map<String, Long> idsA = resolveAccountIds(CompanyService.LEGACY_COMPANY_ID)
+    Map<String, Long> idsB = resolveAccountIds(companyB.id)
+    assertTrue(idsA['1510'] != idsB['1510'], 'Account 1510 ska ha olika id per företag')
+
+    vA.lines.each { VoucherLine line ->
+      assertEquals(idsA[line.accountNumber], line.accountId)
+    }
+    vB.lines.each { VoucherLine line ->
+      assertEquals(idsB[line.accountNumber], line.accountId)
+    }
+  }
+
+  @Test
+  void numberSeriesAreIsolatedPerCompany() {
+    Company companyB = createSecondCompany()
+    FiscalYear fyA = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    FiscalYear fyB = fiscalYearService.createFiscalYear(
+        companyB.id, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    seedAccounts(CompanyService.LEGACY_COMPANY_ID)
+    seedAccounts(companyB.id)
+
+    Voucher v1A = voucherService.createAndBook(
+        fyA.id, 'A', LocalDate.of(2026, 1, 10), 'Första i A', balancedLines(100.00G))
+    Voucher v1B = voucherService.createAndBook(
+        fyB.id, 'A', LocalDate.of(2026, 1, 10), 'Första i B', balancedLines(200.00G))
+    Voucher v2A = voucherService.createAndBook(
+        fyA.id, 'A', LocalDate.of(2026, 1, 11), 'Andra i A', balancedLines(300.00G))
+
+    assertEquals('A-1', v1A.voucherNumber)
+    assertEquals('A-1', v1B.voucherNumber)
+    assertEquals('A-2', v2A.voucherNumber)
+  }
+
+  @Test
+  void vatPeriodsAreIsolatedPerCompany() {
+    Company companyB = createSecondCompany()
+    FiscalYear fyA = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    FiscalYear fyB = fiscalYearService.createFiscalYear(
+        companyB.id, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    seedVatAccounts(CompanyService.LEGACY_COMPANY_ID)
+    seedVatAccounts(companyB.id)
+
+    voucherService.createAndBook(
+        fyA.id, 'A', LocalDate.of(2026, 1, 15), 'Försäljning A', saleLines(1000.00G))
+    voucherService.createAndBook(
+        fyB.id, 'A', LocalDate.of(2026, 1, 15), 'Försäljning B', saleLines(2000.00G))
+
+    List<VatPeriod> periodsA = vatService.listPeriods(fyA.id)
+    List<VatPeriod> periodsB = vatService.listPeriods(fyB.id)
+    VatService.VatReport reportA = vatService.calculateReport(periodsA.first().id)
+    VatService.VatReport reportB = vatService.calculateReport(periodsB.first().id)
+
+    assertEquals(12, periodsA.size())
+    assertEquals(12, periodsB.size())
+    assertEquals(250.00G, reportA.outputVatTotal)
+    assertEquals(500.00G, reportB.outputVatTotal)
+
+    vatService.reportPeriod(periodsA.first().id)
+    vatService.bookTransfer(periodsA.first().id)
+
+    VatPeriod lockedA = vatService.findPeriod(periodsA.first().id)
+    VatPeriod openB = vatService.findPeriod(periodsB.first().id)
+    assertEquals(VatService.LOCKED, lockedA.status)
+    assertEquals(VatService.OPEN, openB.status)
+  }
+
+  @Test
+  void reportsAreIsolatedPerCompany() {
+    Company companyB = createSecondCompany()
+    FiscalYear fyA = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    FiscalYear fyB = fiscalYearService.createFiscalYear(
+        companyB.id, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    seedAccounts(CompanyService.LEGACY_COMPANY_ID)
+    seedAccounts(companyB.id)
+
+    voucherService.createAndBook(
+        fyA.id, 'A', LocalDate.of(2026, 1, 15), 'Försäljning A', balancedLines(500.00G))
+    voucherService.createAndBook(
+        fyB.id, 'A', LocalDate.of(2026, 1, 15), 'Försäljning B', balancedLines(800.00G))
+
+    ReportSelection selA = new ReportSelection(
+        ReportType.VOUCHER_LIST, fyA.id, null, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 31))
+    ReportSelection selB = new ReportSelection(
+        ReportType.VOUCHER_LIST, fyB.id, null, LocalDate.of(2026, 1, 1), LocalDate.of(2026, 1, 31))
+
+    ReportArchive archiveA = journoReportService.generatePdf(selA)
+    ReportArchive archiveB = journoReportService.generatePdf(selB)
+
+    assertNotNull(archiveA)
+    assertNotNull(archiveB)
+    assertTrue(archiveA.id != archiveB.id)
+
+    int archiveCountA = countReportArchives(CompanyService.LEGACY_COMPANY_ID)
+    int archiveCountB = countReportArchives(companyB.id)
+    assertEquals(1, archiveCountA)
+    assertEquals(1, archiveCountB)
+  }
+
+  @Test
+  void sieExportIsIsolatedPerCompany() {
+    Company companyB = createSecondCompany()
+    FiscalYear fyA = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    FiscalYear fyB = fiscalYearService.createFiscalYear(
+        companyB.id, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    seedAccounts(CompanyService.LEGACY_COMPANY_ID)
+    seedAccounts(companyB.id)
+
+    voucherService.createAndBook(
+        fyA.id, 'A', LocalDate.of(2026, 1, 15), 'Försäljning A', balancedLines(500.00G))
+    voucherService.createAndBook(
+        fyB.id, 'A', LocalDate.of(2026, 1, 15), 'Försäljning B', balancedLines(800.00G))
+
+    Path sieA = tempDir.resolve('export-a.sie')
+    Path sieB = tempDir.resolve('export-b.sie')
+    SieExportResult resultA = sieService.exportFiscalYear(fyA.id, sieA)
+    SieExportResult resultB = sieService.exportFiscalYear(fyB.id, sieB)
+
+    assertNotNull(resultA.checksumSha256)
+    assertNotNull(resultB.checksumSha256)
+    assertEquals(1, resultA.voucherCount)
+    assertEquals(1, resultB.voucherCount)
+
+    String contentA = sieA.toFile().getText('CP437')
+    String contentB = sieB.toFile().getText('CP437')
+    assertTrue(contentA.contains('Default company'))
+    assertTrue(contentB.contains('Beta AB'))
+    assertTrue(!contentA.contains('Beta AB'))
+    assertTrue(!contentB.contains('Default company'))
+  }
+
+  @Test
+  void closingInOneCompanyDoesNotAffectOther() {
+    Company companyB = createSecondCompany()
+    FiscalYear fyA = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    FiscalYear fyB = fiscalYearService.createFiscalYear(
+        companyB.id, '2026', LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31))
+    seedClosingAccounts(CompanyService.LEGACY_COMPANY_ID)
+    seedClosingAccounts(companyB.id)
+
+    voucherService.createAndBook(
+        fyA.id, 'A', LocalDate.of(2026, 1, 15), 'Försäljning A',
+        [
+            new VoucherLine(null, null, 0, '1510', null, 'Kundfordran', 1000.00G, 0.00G),
+            new VoucherLine(null, null, 0, '3010', null, 'Försäljning', 0.00G, 1000.00G)
+        ])
+    voucherService.createAndBook(
+        fyB.id, 'A', LocalDate.of(2026, 1, 15), 'Försäljning B',
+        [
+            new VoucherLine(null, null, 0, '1510', null, 'Kundfordran', 2000.00G, 0.00G),
+            new VoucherLine(null, null, 0, '3010', null, 'Försäljning', 0.00G, 2000.00G)
+        ])
+
+    accountingPeriodService.listPeriods(fyA.id).each { period ->
+      accountingPeriodService.lockPeriod(period.id, 'Bokslut A')
+    }
+
+    YearEndClosingResult resultA = closingService.closeFiscalYear(fyA.id)
+
+    assertTrue(resultA.closedFiscalYear.closed)
+    assertEquals('2027', resultA.nextFiscalYear.name)
+
+    FiscalYear fyBAfterClosing = fiscalYearService.findById(fyB.id)
+    assertTrue(!fyBAfterClosing.closed)
+
+    List<FiscalYear> companyBYears = fiscalYearService.listFiscalYears(companyB.id)
+    assertEquals(1, companyBYears.size())
+    assertEquals('2026', companyBYears.first().name)
+
+    databaseService.withSql { Sql sql ->
+      int closingEntriesB = countRows(sql, 'closing_entry',
+          "fiscal_year_id = ${fyB.id}")
+      assertEquals(0, closingEntriesB)
+    }
+  }
+
+  private Company createSecondCompany() {
+    companyService.save(
+        new Company(null, 'Beta AB', '556111-2222', 'SEK', 'sv-SE', VatPeriodicity.MONTHLY, true, null, null))
+  }
+
+  private void seedAccounts(long companyId) {
+    databaseService.withTransaction { Sql sql ->
+      insertAccount(sql, companyId, '1510', 'Kundfordringar', 'ASSET', 'DEBIT', null)
+      insertAccount(sql, companyId, '3010', 'Försäljning', 'INCOME', 'CREDIT', null)
+    }
+  }
+
+  private void seedVatAccounts(long companyId) {
+    databaseService.withTransaction { Sql sql ->
+      insertAccount(sql, companyId, '1510', 'Kundfordringar', 'ASSET', 'DEBIT', null)
+      insertAccount(sql, companyId, '2611', 'Utgående moms 25%', 'LIABILITY', 'CREDIT', VatCode.OUTPUT_25.name())
+      insertAccount(sql, companyId, '2650', 'Redovisningskonto för moms', 'LIABILITY', 'CREDIT', null)
+      insertAccount(sql, companyId, '3010', 'Försäljning', 'INCOME', 'CREDIT', VatCode.OUTPUT_25.name())
+    }
+  }
+
+  private void seedClosingAccounts(long companyId) {
+    databaseService.withTransaction { Sql sql ->
+      insertAccount(sql, companyId, '1510', 'Kundfordringar', 'ASSET', 'DEBIT', null)
+      insertAccount(sql, companyId, '1930', 'Företagskonto', 'ASSET', 'DEBIT', null)
+      insertAccount(sql, companyId, '2099', 'Årets resultat', 'EQUITY', 'CREDIT', null)
+      insertAccount(sql, companyId, '3010', 'Försäljning', 'INCOME', 'CREDIT', null)
+      insertAccount(sql, companyId, '4010', 'Varukostnad', 'EXPENSE', 'DEBIT', null)
+    }
+  }
+
+  private static void insertAccount(
+      Sql sql,
+      long companyId,
+      String accountNumber,
+      String accountName,
+      String accountClass,
+      String normalBalanceSide,
+      String vatCode
+  ) {
+    sql.executeInsert('''
+        insert into account (
+            company_id,
+            account_number,
+            account_name,
+            account_class,
+            normal_balance_side,
+            vat_code,
+            active,
+            manual_review_required,
+            classification_note,
+            created_at,
+            updated_at
+        ) values (?, ?, ?, ?, ?, ?, true, false, null, current_timestamp, current_timestamp)
+    ''', [companyId, accountNumber, accountName, accountClass, normalBalanceSide, vatCode])
+  }
+
+  private static List<VoucherLine> balancedLines(BigDecimal amount) {
+    [
+        new VoucherLine(null, null, 0, null, '1510', null, 'Kundfordran', amount, 0.00G),
+        new VoucherLine(null, null, 0, null, '3010', null, 'Försäljning', 0.00G, amount)
+    ]
+  }
+
+  private static List<VoucherLine> saleLines(BigDecimal baseAmount) {
+    BigDecimal vatAmount = (baseAmount * 0.25G).setScale(2, java.math.RoundingMode.HALF_UP)
+    [
+        new VoucherLine(null, null, 0, null, '1510', null, 'Kundfordran', baseAmount + vatAmount, 0.00G),
+        new VoucherLine(null, null, 0, null, '3010', null, 'Försäljning', 0.00G, baseAmount),
+        new VoucherLine(null, null, 0, null, '2611', null, 'Utgående moms', 0.00G, vatAmount)
+    ]
+  }
+
+  private Map<String, Long> resolveAccountIds(long companyId) {
+    databaseService.withSql { Sql sql ->
+      Map<String, Long> result = [:]
+      sql.eachRow(
+          'select id, account_number from account where company_id = ?',
+          [companyId]
+      ) { row ->
+        result[row.getString('account_number')] = ((Number) row.getLong('id')).longValue()
+      }
+      result
+    }
+  }
+
+  private int countReportArchives(long companyId) {
+    databaseService.withSql { Sql sql ->
+      GroovyRowResult row = sql.firstRow(
+          'select count(*) as total from report_archive where company_id = ?',
+          [companyId]) as GroovyRowResult
+      ((Number) row.get('total')).intValue()
+    }
+  }
+
+  private static int countRows(Sql sql, String tableName, String whereClause) {
+    GroovyRowResult row = sql.firstRow(
+        "select count(*) as total from ${tableName} where ${whereClause}" as String) as GroovyRowResult
+    ((Number) row.get('total')).intValue()
+  }
+
+  private static void restoreProperty(String name, String value) {
+    if (value == null) {
+      System.clearProperty(name)
+      return
+    }
+    System.setProperty(name, value)
+  }
+}


### PR DESCRIPTION
## Summary
- Ny integrationstestklass `MultiCompanyIsolationTest` med 6 tester som systematiskt verifierar att konton, nummerserier, momsperioder, rapporter, SIE-export och bokslut är isolerade mellan företag
- Nytt tvåföretagsacceptanstest (`multiCompanyIsolationCanBeDemonstrated`) som kör hela flödet: skapa A+B, importera konton, bokför, generera rapport i A, exportera SIE i B, kör bokslut i A, verifiera ingen dataläcka
- Fixade bugg i `ReportArchiveService` där lagringsvägen saknade företagsprefix, vilket orsakade unique constraint-fel vid samma rapporttyp i två företag

## Test plan
- [x] `./gradlew build` passerar (alla 140 tester, Spotless, CodeNarc)
- [ ] Verifiera att rapportarkiv med befintlig data fortfarande fungerar (lagringsvägen har nytt `c{id}/` prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)