### PR TITLE
Batch 8: fixade releasepaketering

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ Releasebyggen använder `jpackage` och kräver Java 21 med tillhörande paketeri
 - Aktuell plattform: `./gradlew :app:packageCurrentPlatformRelease`
 - Smoke test av aktuell plattform: `./gradlew :app:verifyCurrentPlatformRelease`
 
+Om Gradle hittar fel JDK för jpackage (t.ex. en inbäddad JDK utan jpackage) kan sökvägen sättas explicit:
+
+```
+./gradlew :app:verifyCurrentPlatformRelease -Pjpackage.executable=/path/to/jdk-21/bin/jpackage
+```
+
 Byggartefakter skrivs till `app/build/release/` och använder samma appnamn, versionsnummer och ikonuppsättning för alla tre plattformar.
 
 Linux-releasen producerar en `app-image` plus ett zip-arkiv som även innehåller `.desktop`-filen. Windows-releasen producerar en `exe`-installerare med meny- och skrivbordsgenväg. macOS-releasen producerar `AlipsaAccounting.app`.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,8 @@ def releaseConfig = [
   generatedRoot : layout.buildDirectory.dir('generated/packaging')
 ]
 
+def licenseFilePath = rootProject.file('LICENSE').absolutePath
+
 def linuxDesktopTemplate = releaseConfig.packagingRoot.dir('linux/desktop').file("${releaseConfig.appName}.desktop.template")
 def linuxDesktopEntry = releaseConfig.generatedRoot.map { it.file("linux-desktop/${releaseConfig.appName}.desktop") }
 
@@ -64,14 +66,15 @@ def isMacos = currentPlatform == 'macos'
 def isLinux = currentPlatform == 'linux'
 def mainJarFileName = tasks.named('jar', Jar).flatMap { Jar jarTask -> jarTask.archiveFileName }
 
-def jpackageExecutable = javaToolchains.launcherFor {
-  languageVersion = JavaLanguageVersion.of(21)
-}.map { launcher ->
-  launcher.metadata.installationPath.file('bin/jpackage').asFile.absolutePath
-}
+def jpackageExecutable = project.providers.gradleProperty('jpackage.executable')
+    .orElse(javaToolchains.launcherFor {
+      languageVersion = JavaLanguageVersion.of(21)
+    }.map { launcher ->
+      launcher.metadata.installationPath.file('bin/jpackage').asFile.absolutePath
+    })
 
 def buildJpackageArgs = { String platform, String type, File destinationDir, List<String> extraArgs = [] ->
-  [
+  List<String> args = [
     '--type',
     type,
     '--dest',
@@ -96,11 +99,16 @@ def buildJpackageArgs = { String platform, String type, File destinationDir, Lis
     releaseConfig.generatedRoot.get().dir(platform).asFile.absolutePath,
     '--icon',
     releaseConfig.packagingRoot.dir(platform).file("${releaseConfig.appName}.${platform == 'linux' ? 'png' : platform == 'windows' ? 'ico' : 'icns'}").asFile.absolutePath,
-    '--license-file',
-    rootProject.file('LICENSE').absolutePath,
     '--java-options',
     '-Dfile.encoding=UTF-8'
-  ] + extraArgs
+  ]
+  if (type != 'app-image') {
+    args += [
+      '--license-file',
+      licenseFilePath
+    ]
+  }
+  args + extraArgs
 }
 
 def launcherPathFor = { String platform ->


### PR DESCRIPTION
## Summary
- Fixade konfigurationscache-fel: `rootProject.file('LICENSE')` refererades vid exekvering — löst genom att fånga sökvägen vid konfigurering
- Fixade jpackage `--license-file` som inte stöds för `app-image`-typ — inkluderas nu bara för installerare
- Lade till `jpackage.executable` Gradle-property för att kunna peka ut rätt JDK när Gradle hittar en inbäddad JDK utan jpackage
- Dokumenterade property-overriden i README

## Test plan
- [x] `./gradlew build` passerar
- [x] `./gradlew :app:verifyCurrentPlatformRelease` passerar (macOS)
- [ ] Verifiera att CI-workflow (`build-distributions.yml`) fortfarande fungerar på alla plattformar

🤖 Generated with [Claude Code](https://claude.com/claude-code)