### PR TITLE
Stöd för kvartalsmoms

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Det är inte ett komplett affärssystem — fakturering, lönehantering, bankint
 - **Kontoplan** — BAS-baserad kontoplan med import från Excel och automatisk klassificering. Kontoplanen är företagsspecifik — två företag kan ha samma BAS-kontonummer utan konflikt.
 - **Räkenskapsår och perioder** — skapa år, dela in i perioder och lås perioder när de är klara.
 - **Verifikationer** — registrera, bokför och korrigera verifikationer med bilagor.
-- **Moms** — beräkna, rapportera och bokför momsöverföring per period. Stöder månads- och årsmoms. Kvartalsmoms stöds inte i v1.0.0.
+- **Moms** — beräkna, rapportera och bokför momsöverföring per period. Stöder månads-, kvartals- och årsmoms.
 - **Rapporter** — generera verifikationslista, huvudbok, provbalans, resultat- och balansrapport, transaktionsrapport och momsrapport som PDF eller CSV. Rapporter arkiveras med checksumma.
 - **SIE4** — importera och exportera bokföringsdata via SIE4 med dubblettskydd och integritetskontroll.
 - **Bokslut** — stäng räkenskapsår med bokslutsverifikation och automatisk generering av nästa års ingående balanser.
@@ -32,7 +32,6 @@ Följande funktioner ingår inte i v1.0.0:
 - Årsredovisningsflöden
 - Anläggningsregister (planerat till v1.1.0)
 - Förbättrad kraschsäker bilagehantering (planerat till v1.1.0)
-- Kvartalsmoms (månads- och årsmoms stöds)
 
 ## Förutsättningar
 

--- a/app/src/main/groovy/se/alipsa/accounting/domain/VatPeriodicity.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/domain/VatPeriodicity.groovy
@@ -8,6 +8,7 @@ import se.alipsa.accounting.support.I18n
 enum VatPeriodicity {
 
   MONTHLY,
+  QUARTERLY,
   ANNUAL
 
   String getDisplayName() {

--- a/app/src/main/groovy/se/alipsa/accounting/service/DatabaseService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/DatabaseService.groovy
@@ -39,7 +39,8 @@ final class DatabaseService {
       new MigrationDefinition(12, 'V12__closing_entry.sql', '/db/migrations/V12__closing_entry.sql'),
       new MigrationDefinition(13, 'V13__multi_company_foundation.sql', '/db/migrations/V13__multi_company_foundation.sql'),
       new MigrationDefinition(14, 'V14__company_chain_heads.sql', '/db/migrations/V14__company_chain_heads.sql'),
-      new MigrationDefinition(15, 'V15__account_id_normalization.sql', '/db/migrations/V15__account_id_normalization.sql')
+      new MigrationDefinition(15, 'V15__account_id_normalization.sql', '/db/migrations/V15__account_id_normalization.sql'),
+      new MigrationDefinition(16, 'V16__quarterly_vat.sql', '/db/migrations/V16__quarterly_vat.sql')
   ]
 
   static DatabaseService newForTesting() {

--- a/app/src/main/groovy/se/alipsa/accounting/service/SystemDocumentationService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/SystemDocumentationService.groovy
@@ -100,7 +100,7 @@ final class SystemDocumentationService {
         '- Verifikationer bokförs med nummerserier per företag, räkenskapsår och serie.',
         '- Bokförda verifikationer är append-only och korrigeras genom korrigeringsverifikation.',
         '- Momsperioder kan rapporteras och låsas för att blockera otillåtna ändringar.',
-        '- Månads- och årsmoms stöds. Kvartalsmoms ingår inte i v1.0.0.',
+        '- Månads-, kvartals- och årsmoms stöds.',
         '- Årsbokslut stänger resultatkonton mot konto 2099 och skapar nästa års ingående balanser.',
         '',
         '## Import och export',

--- a/app/src/main/groovy/se/alipsa/accounting/service/VatService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/VatService.groovy
@@ -199,12 +199,18 @@ final class VatService {
     }
 
     if (periodicity == VatPeriodicity.QUARTERLY) {
-      List<List<GroovyRowResult>> quarters = groupByQuarter(accountingPeriods)
+      List<List<GroovyRowResult>> quarters = groupByCalendarQuarter(accountingPeriods)
       quarters.eachWithIndex { List<GroovyRowResult> quarter, int index ->
         GroovyRowResult first = quarter.first()
         GroovyRowResult last = quarter.last()
-        insertVatPeriod(sql, fiscalYearId, index + 1,
-            "Q${index + 1} ${SqlValueMapper.toLocalDate(first.get('startDate'))} - ${SqlValueMapper.toLocalDate(last.get('endDate'))}".toString(),
+        LocalDate start = SqlValueMapper.toLocalDate(first.get('startDate'))
+        LocalDate end = SqlValueMapper.toLocalDate(last.get('endDate'))
+        int calendarQuarter = (start.monthValue - 1).intdiv(3) as int + 1
+        String label = "Q${calendarQuarter} ${start.year}"
+        if (isPartialQuarter(start, end, calendarQuarter)) {
+          label = "${label} (del)"
+        }
+        insertVatPeriod(sql, fiscalYearId, index + 1, label,
             first.get('startDate'), last.get('endDate'))
       }
       return
@@ -237,19 +243,22 @@ final class VatService {
     ''', [fiscalYearId, periodIndex, periodName, startDate, endDate, OPEN])
   }
 
-  private static List<List<GroovyRowResult>> groupByQuarter(List<GroovyRowResult> accountingPeriods) {
+  private static List<List<GroovyRowResult>> groupByCalendarQuarter(List<GroovyRowResult> accountingPeriods) {
     List<List<GroovyRowResult>> quarters = []
     List<GroovyRowResult> current = []
     int currentQuarter = -1
+    int currentYear = -1
     accountingPeriods.each { GroovyRowResult row ->
       LocalDate start = SqlValueMapper.toLocalDate(row.get('startDate'))
       int quarter = (start.monthValue - 1).intdiv(3) as int
-      if (quarter != currentQuarter) {
+      int year = start.year
+      if (quarter != currentQuarter || year != currentYear) {
         if (!current.isEmpty()) {
           quarters << current
         }
         current = []
         currentQuarter = quarter
+        currentYear = year
       }
       current << row
     }
@@ -257,6 +266,13 @@ final class VatService {
       quarters << current
     }
     quarters
+  }
+
+  private static boolean isPartialQuarter(LocalDate start, LocalDate end, int calendarQuarter) {
+    int firstMonth = (calendarQuarter - 1) * 3 + 1
+    LocalDate quarterStart = LocalDate.of(start.year, firstMonth, 1)
+    LocalDate quarterEnd = quarterStart.plusMonths(3).minusDays(1)
+    start != quarterStart || end != quarterEnd
   }
 
   private static VatPeriodicity loadPeriodicity(Sql sql, long companyId) {

--- a/app/src/main/groovy/se/alipsa/accounting/service/VatService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/VatService.groovy
@@ -15,6 +15,7 @@ import java.math.RoundingMode
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.sql.Date
+import java.time.LocalDate
 
 /**
  * Calculates VAT reports, manages VAT periods and books VAT transfer vouchers.
@@ -191,57 +192,71 @@ final class VatService {
     if (periodicity == VatPeriodicity.ANNUAL) {
       GroovyRowResult first = accountingPeriods.first()
       GroovyRowResult last = accountingPeriods.last()
-      sql.executeInsert('''
-          insert into vat_period (
-              fiscal_year_id,
-              period_index,
-              period_name,
-              start_date,
-              end_date,
-              status,
-              report_hash,
-              reported_at,
-              locked_at,
-              transfer_voucher_id,
-              created_at,
-              updated_at
-          ) values (?, ?, ?, ?, ?, ?, null, null, null, null, current_timestamp, current_timestamp)
-      ''', [
-          fiscalYearId,
-          1,
+      insertVatPeriod(sql, fiscalYearId, 1,
           "${SqlValueMapper.toLocalDate(first.get('startDate'))} - ${SqlValueMapper.toLocalDate(last.get('endDate'))}".toString(),
-          first.get('startDate'),
-          last.get('endDate'),
-          OPEN
-      ])
+          first.get('startDate'), last.get('endDate'))
+      return
+    }
+
+    if (periodicity == VatPeriodicity.QUARTERLY) {
+      List<List<GroovyRowResult>> quarters = groupByQuarter(accountingPeriods)
+      quarters.eachWithIndex { List<GroovyRowResult> quarter, int index ->
+        GroovyRowResult first = quarter.first()
+        GroovyRowResult last = quarter.last()
+        insertVatPeriod(sql, fiscalYearId, index + 1,
+            "Q${index + 1} ${SqlValueMapper.toLocalDate(first.get('startDate'))} - ${SqlValueMapper.toLocalDate(last.get('endDate'))}".toString(),
+            first.get('startDate'), last.get('endDate'))
+      }
       return
     }
 
     accountingPeriods.each { GroovyRowResult row ->
-      sql.executeInsert('''
-          insert into vat_period (
-              fiscal_year_id,
-              period_index,
-              period_name,
-              start_date,
-              end_date,
-              status,
-              report_hash,
-              reported_at,
-              locked_at,
-              transfer_voucher_id,
-              created_at,
-              updated_at
-          ) values (?, ?, ?, ?, ?, ?, null, null, null, null, current_timestamp, current_timestamp)
-      ''', [
-          fiscalYearId,
+      insertVatPeriod(sql, fiscalYearId,
           ((Number) row.get('periodIndex')).intValue(),
           row.get('periodName') as String,
-          row.get('startDate'),
-          row.get('endDate'),
-          OPEN
-      ])
+          row.get('startDate'), row.get('endDate'))
     }
+  }
+
+  private static void insertVatPeriod(Sql sql, long fiscalYearId, int periodIndex, String periodName, Object startDate, Object endDate) {
+    sql.executeInsert('''
+        insert into vat_period (
+            fiscal_year_id,
+            period_index,
+            period_name,
+            start_date,
+            end_date,
+            status,
+            report_hash,
+            reported_at,
+            locked_at,
+            transfer_voucher_id,
+            created_at,
+            updated_at
+        ) values (?, ?, ?, ?, ?, ?, null, null, null, null, current_timestamp, current_timestamp)
+    ''', [fiscalYearId, periodIndex, periodName, startDate, endDate, OPEN])
+  }
+
+  private static List<List<GroovyRowResult>> groupByQuarter(List<GroovyRowResult> accountingPeriods) {
+    List<List<GroovyRowResult>> quarters = []
+    List<GroovyRowResult> current = []
+    int currentQuarter = -1
+    accountingPeriods.each { GroovyRowResult row ->
+      LocalDate start = SqlValueMapper.toLocalDate(row.get('startDate'))
+      int quarter = (start.monthValue - 1).intdiv(3) as int
+      if (quarter != currentQuarter) {
+        if (!current.isEmpty()) {
+          quarters << current
+        }
+        current = []
+        currentQuarter = quarter
+      }
+      current << row
+    }
+    if (!current.isEmpty()) {
+      quarters << current
+    }
+    quarters
   }
 
   private static VatPeriodicity loadPeriodicity(Sql sql, long companyId) {

--- a/app/src/main/resources/db/migrations/V16__quarterly_vat.sql
+++ b/app/src/main/resources/db/migrations/V16__quarterly_vat.sql
@@ -1,0 +1,4 @@
+alter table company drop constraint if exists ck_company_vat_periodicity;
+
+alter table company add constraint ck_company_vat_periodicity
+    check (vat_periodicity in ('MONTHLY', 'QUARTERLY', 'ANNUAL'));

--- a/app/src/main/resources/docs/user-manual.md
+++ b/app/src/main/resources/docs/user-manual.md
@@ -30,7 +30,7 @@ Programmet kan hantera flera företag i samma installation. Varje företag har s
 ## Moms, rapporter och SIE
 
 - Stäng och rapportera momsperioder i fliken `Moms`.
-- v1.0.0 stöder månads- och årsmoms. Kvartalsmoms stöds inte i denna version.
+- Stöder månads-, kvartals- och årsmoms.
 - Generera PDF- och CSV-rapporter i fliken `Rapporter`.
 - Importera och exportera SIE4 under `Arkiv -> SIE import/export...`.
 - CSV-export använder semikolon som avgränsare för att fungera bra med svensk Excel-standard.

--- a/app/src/main/resources/i18n/messages.properties
+++ b/app/src/main/resources/i18n/messages.properties
@@ -19,6 +19,7 @@ vatCode.OUTSIDE_SCOPE=Outside VAT scope
 
 # VatPeriodicity
 vatPeriodicity.MONTHLY=Monthly
+vatPeriodicity.QUARTERLY=Quarterly
 vatPeriodicity.ANNUAL=Annually
 
 # ReportType

--- a/app/src/main/resources/i18n/messages_sv.properties
+++ b/app/src/main/resources/i18n/messages_sv.properties
@@ -19,6 +19,7 @@ vatCode.OUTSIDE_SCOPE=Utanför momsens tillämpningsområde
 
 # VatPeriodicity
 vatPeriodicity.MONTHLY=Månadsvis
+vatPeriodicity.QUARTERLY=Kvartalsvis
 vatPeriodicity.ANNUAL=Årsvis
 
 # ReportType

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/BackupServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/BackupServiceTest.groovy
@@ -76,7 +76,7 @@ class BackupServiceTest {
       assertEquals(1, count(sql, 'voucher'))
       assertEquals(1, count(sql, 'attachment'))
       assertEquals(1, count(sql, 'report_archive'))
-      assertEquals(15, countSchemaVersion(sql))
+      assertEquals(16, countSchemaVersion(sql))
     }
   }
 

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/DatabaseServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/DatabaseServiceTest.groovy
@@ -75,7 +75,7 @@ class DatabaseServiceTest {
       ''') as GroovyRowResult
     }
 
-    assertEquals(15, ((Number) result.version).intValue())
+    assertEquals(16, ((Number) result.version).intValue())
     assertEquals(1, ((Number) result.company).intValue())
     assertEquals(1, ((Number) result.companySettings).intValue())
     assertEquals(1, ((Number) result.fiscalYear).intValue())

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/VatServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/VatServiceTest.groovy
@@ -264,6 +264,42 @@ class VatServiceTest {
     assertEquals('2027-01-01 - 2027-12-31', periods.first().periodName)
   }
 
+  @Test
+  void quarterlyVatSettingCreatesFourVatPeriodsForFiscalYear() {
+    companySettingsService.save(
+        new se.alipsa.accounting.domain.CompanySettings(
+            null,
+            'Konsultfirma',
+            '930501-5678',
+            'SEK',
+            'sv-SE',
+            VatPeriodicity.QUARTERLY
+        )
+    )
+    FiscalYear quarterlyYear = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID,
+        '2027',
+        LocalDate.of(2027, 1, 1),
+        LocalDate.of(2027, 12, 31)
+    )
+
+    List<VatPeriod> periods = vatService.listPeriods(quarterlyYear.id)
+
+    assertEquals(4, periods.size())
+    assertEquals(LocalDate.of(2027, 1, 1), periods[0].startDate)
+    assertEquals(LocalDate.of(2027, 3, 31), periods[0].endDate)
+    assertTrue(periods[0].periodName.contains('Q1'))
+    assertEquals(LocalDate.of(2027, 4, 1), periods[1].startDate)
+    assertEquals(LocalDate.of(2027, 6, 30), periods[1].endDate)
+    assertTrue(periods[1].periodName.contains('Q2'))
+    assertEquals(LocalDate.of(2027, 7, 1), periods[2].startDate)
+    assertEquals(LocalDate.of(2027, 9, 30), periods[2].endDate)
+    assertTrue(periods[2].periodName.contains('Q3'))
+    assertEquals(LocalDate.of(2027, 10, 1), periods[3].startDate)
+    assertEquals(LocalDate.of(2027, 12, 31), periods[3].endDate)
+    assertTrue(periods[3].periodName.contains('Q4'))
+  }
+
   private List<Voucher> bookVatFixtures() {
     [
         bookSaleVoucher(),

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/VatServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/VatServiceTest.groovy
@@ -288,16 +288,91 @@ class VatServiceTest {
     assertEquals(4, periods.size())
     assertEquals(LocalDate.of(2027, 1, 1), periods[0].startDate)
     assertEquals(LocalDate.of(2027, 3, 31), periods[0].endDate)
-    assertTrue(periods[0].periodName.contains('Q1'))
+    assertEquals('Q1 2027', periods[0].periodName)
     assertEquals(LocalDate.of(2027, 4, 1), periods[1].startDate)
     assertEquals(LocalDate.of(2027, 6, 30), periods[1].endDate)
-    assertTrue(periods[1].periodName.contains('Q2'))
+    assertEquals('Q2 2027', periods[1].periodName)
     assertEquals(LocalDate.of(2027, 7, 1), periods[2].startDate)
     assertEquals(LocalDate.of(2027, 9, 30), periods[2].endDate)
-    assertTrue(periods[2].periodName.contains('Q3'))
+    assertEquals('Q3 2027', periods[2].periodName)
     assertEquals(LocalDate.of(2027, 10, 1), periods[3].startDate)
     assertEquals(LocalDate.of(2027, 12, 31), periods[3].endDate)
-    assertTrue(periods[3].periodName.contains('Q4'))
+    assertEquals('Q4 2027', periods[3].periodName)
+  }
+
+  @Test
+  void quarterlyVatForBrokenFiscalYearProducesCalendarQuarterPeriodsWithPartialEdges() {
+    companySettingsService.save(
+        new se.alipsa.accounting.domain.CompanySettings(
+            null,
+            'Brutet AB',
+            '556677-8899',
+            'SEK',
+            'sv-SE',
+            VatPeriodicity.QUARTERLY
+        )
+    )
+    FiscalYear brokenYear = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID,
+        '2028/2029 brutet',
+        LocalDate.of(2028, 7, 15),
+        LocalDate.of(2029, 7, 14)
+    )
+
+    List<VatPeriod> periods = vatService.listPeriods(brokenYear.id)
+
+    assertEquals(5, periods.size())
+    assertEquals(LocalDate.of(2028, 7, 15), periods[0].startDate)
+    assertEquals(LocalDate.of(2028, 9, 30), periods[0].endDate)
+    assertEquals('Q3 2028 (del)', periods[0].periodName)
+    assertEquals(LocalDate.of(2028, 10, 1), periods[1].startDate)
+    assertEquals(LocalDate.of(2028, 12, 31), periods[1].endDate)
+    assertEquals('Q4 2028', periods[1].periodName)
+    assertEquals(LocalDate.of(2029, 1, 1), periods[2].startDate)
+    assertEquals(LocalDate.of(2029, 3, 31), periods[2].endDate)
+    assertEquals('Q1 2029', periods[2].periodName)
+    assertEquals(LocalDate.of(2029, 4, 1), periods[3].startDate)
+    assertEquals(LocalDate.of(2029, 6, 30), periods[3].endDate)
+    assertEquals('Q2 2029', periods[3].periodName)
+    assertEquals(LocalDate.of(2029, 7, 1), periods[4].startDate)
+    assertEquals(LocalDate.of(2029, 7, 14), periods[4].endDate)
+    assertEquals('Q3 2029 (del)', periods[4].periodName)
+  }
+
+  @Test
+  void quarterlyVatForQuarterAlignedBrokenFiscalYearProducesFourFullQuarters() {
+    companySettingsService.save(
+        new se.alipsa.accounting.domain.CompanySettings(
+            null,
+            'Kvartalslinjerat AB',
+            '556600-1122',
+            'SEK',
+            'sv-SE',
+            VatPeriodicity.QUARTERLY
+        )
+    )
+    FiscalYear alignedYear = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID,
+        '2027/2028 april',
+        LocalDate.of(2027, 4, 1),
+        LocalDate.of(2028, 3, 31)
+    )
+
+    List<VatPeriod> periods = vatService.listPeriods(alignedYear.id)
+
+    assertEquals(4, periods.size())
+    assertEquals(LocalDate.of(2027, 4, 1), periods[0].startDate)
+    assertEquals(LocalDate.of(2027, 6, 30), periods[0].endDate)
+    assertEquals('Q2 2027', periods[0].periodName)
+    assertEquals(LocalDate.of(2027, 7, 1), periods[1].startDate)
+    assertEquals(LocalDate.of(2027, 9, 30), periods[1].endDate)
+    assertEquals('Q3 2027', periods[1].periodName)
+    assertEquals(LocalDate.of(2027, 10, 1), periods[2].startDate)
+    assertEquals(LocalDate.of(2027, 12, 31), periods[2].endDate)
+    assertEquals('Q4 2027', periods[2].periodName)
+    assertEquals(LocalDate.of(2028, 1, 1), periods[3].startDate)
+    assertEquals(LocalDate.of(2028, 3, 31), periods[3].endDate)
+    assertEquals('Q1 2028', periods[3].periodName)
   }
 
   private List<Voucher> bookVatFixtures() {

--- a/createDist.sh
+++ b/createDist.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+./release.sh --no-release

--- a/req/v1.0.0-release-ready.md
+++ b/req/v1.0.0-release-ready.md
@@ -197,7 +197,7 @@ Den dokumenterade releaseverifieringen ska fungera på riktigt.
 - `./gradlew :app:verifyCurrentPlatformRelease` passerar.
 - README beskriver ett verifierat releaseflöde.
 
-### C. Momsperiodicitet måste vara tydligt färdigställd (avgränsad)
+### C. Momsperiodicitet måste vara tydligt färdigställd (genomförd)
 
 #### Mål
 
@@ -219,7 +219,7 @@ Kvartalsmoms bör stödjas i `v1.0.0` eftersom det är ett vanligt upplägg för
 
 #### Beslut
 
-v1.0.0 stöder månads- och årsmoms. Kvartalsmoms ingår inte i denna version. Begränsningen är dokumenterad i README och användarmanual.
+v1.0.0 stöder månads-, kvartals- och årsmoms.
 
 #### Definition of Done
 


### PR DESCRIPTION
## Summary

- Lägger till `QUARTERLY` i `VatPeriodicity` — kvartalsmoms är den vanligaste perioditeten för små svenska företag (omsättning under 40 MSEK).
- Ny migration V16 uppdaterar databasconstraint för `company.vat_periodicity`.
- `VatService` grupperar redovisningsperioder i kvartal (Q1–Q4) vid periodgenerering.
- I18n-strängar tillagda för svenska och engelska.
- UI fungerar automatiskt via `VatPeriodicity.values()` i company-dialogerna.
- Dokumentation uppdaterad: README, användarmanual, systemdokumentation och release-ready-plan.

## Test plan

- [x] `quarterlyVatSettingCreatesFourVatPeriodsForFiscalYear` — verifierar att 4 perioder (Q1–Q4) skapas med korrekta datum
- [x] `allVatPeriodicityValuesHaveDisplayNames` — verifierar i18n-nycklar finns för alla enum-värden
- [x] Schema-versionstest uppdaterade (15→16)
- [x] `./gradlew clean build` passerar (136 tester)

🤖 Generated with [Claude Code](https://claude.com/claude-code)