### PR TITLE
Grupperad balansrapport enligt ÅRL/K2/K3

### DIFF
--- a/app/src/main/groovy/se/alipsa/accounting/domain/report/BalanceSheetRow.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/domain/report/BalanceSheetRow.groovy
@@ -3,7 +3,7 @@ package se.alipsa.accounting.domain.report
 import groovy.transform.Canonical
 
 /**
- * One balance-sheet account row grouped by section.
+ * One balance-sheet row — an account detail line, a subgroup subtotal, or a computed total.
  */
 @Canonical
 final class BalanceSheetRow {
@@ -12,4 +12,6 @@ final class BalanceSheetRow {
   String accountNumber
   String accountName
   BigDecimal amount
+  String subgroupDisplayName
+  boolean summaryRow
 }

--- a/app/src/main/groovy/se/alipsa/accounting/domain/report/BalanceSheetRow.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/domain/report/BalanceSheetRow.groovy
@@ -3,7 +3,7 @@ package se.alipsa.accounting.domain.report
 import groovy.transform.Canonical
 
 /**
- * One balance-sheet row — an account detail line, a subgroup subtotal, or a computed total.
+ * One balance-sheet row — an account detail line, a subgroup subtotal, a section subtotal, or a computed total.
  */
 @Canonical
 final class BalanceSheetRow {

--- a/app/src/main/groovy/se/alipsa/accounting/domain/report/BalanceSheetSection.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/domain/report/BalanceSheetSection.groovy
@@ -1,0 +1,68 @@
+package se.alipsa.accounting.domain.report
+
+import se.alipsa.accounting.domain.AccountSubgroup
+import se.alipsa.accounting.support.I18n
+
+/**
+ * Logical sections of the balance sheet report, each mapping to one or more
+ * {@link AccountSubgroup} values. Sections with an empty subgroup list are computed
+ * total rows.
+ */
+enum BalanceSheetSection {
+
+  FIXED_ASSETS([
+      AccountSubgroup.INTANGIBLE_ASSETS,
+      AccountSubgroup.BUILDINGS_AND_LAND,
+      AccountSubgroup.MACHINERY,
+      AccountSubgroup.FINANCIAL_FIXED_ASSETS
+  ]),
+  CURRENT_ASSETS([
+      AccountSubgroup.INVENTORY,
+      AccountSubgroup.RECEIVABLES,
+      AccountSubgroup.OTHER_CURRENT_RECEIVABLES,
+      AccountSubgroup.PREPAID_EXPENSES,
+      AccountSubgroup.SHORT_TERM_INVESTMENTS,
+      AccountSubgroup.CASH_AND_BANK
+  ]),
+  TOTAL_ASSETS([]),
+  EQUITY([
+      AccountSubgroup.EQUITY
+  ]),
+  UNTAXED_RESERVES([
+      AccountSubgroup.UNTAXED_RESERVES
+  ]),
+  PROVISIONS([
+      AccountSubgroup.PROVISIONS
+  ]),
+  LONG_TERM_LIABILITIES([
+      AccountSubgroup.LONG_TERM_LIABILITIES
+  ]),
+  CURRENT_LIABILITIES([
+      AccountSubgroup.SHORT_TERM_LIABILITIES_CREDIT,
+      AccountSubgroup.TAX_LIABILITIES,
+      AccountSubgroup.VAT_AND_EXCISE,
+      AccountSubgroup.PAYROLL_TAXES,
+      AccountSubgroup.OTHER_CURRENT_LIABILITIES,
+      AccountSubgroup.ACCRUED_EXPENSES
+  ]),
+  TOTAL_EQUITY_AND_LIABILITIES([])
+
+  final List<AccountSubgroup> subgroups
+
+  BalanceSheetSection(List<AccountSubgroup> subgroups) {
+    this.subgroups = Collections.unmodifiableList(subgroups)
+  }
+
+  boolean isComputed() {
+    subgroups.isEmpty()
+  }
+
+  String getDisplayName() {
+    I18n.instance.getString("balanceSheetSection.${name()}")
+  }
+
+  @Override
+  String toString() {
+    displayName
+  }
+}

--- a/app/src/main/groovy/se/alipsa/accounting/domain/report/BalanceSheetSection.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/domain/report/BalanceSheetSection.groovy
@@ -57,6 +57,14 @@ enum BalanceSheetSection {
     subgroups.isEmpty()
   }
 
+  boolean isAssetSide() {
+    this in [FIXED_ASSETS, CURRENT_ASSETS, TOTAL_ASSETS]
+  }
+
+  static BalanceSheetSection findSectionForSubgroup(AccountSubgroup subgroup) {
+    values().find { BalanceSheetSection section -> subgroup in section.subgroups }
+  }
+
   String getDisplayName() {
     I18n.instance.getString("balanceSheetSection.${name()}")
   }

--- a/app/src/main/groovy/se/alipsa/accounting/service/ReportDataService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/ReportDataService.groovy
@@ -366,7 +366,8 @@ final class ReportDataService {
       Map<String, BigDecimal> movements = loadSignedMovements(sql, effective.selection.fiscalYearId, effective.fiscalYear.startDate, effective.endDate)
 
       Map<String, BigDecimal> closingBalances = buildClosingBalances(accountInfos, openingBalances, movements)
-      Map<AccountSubgroup, List<AccountDetail>> subgroupAccounts = buildSubgroupAccounts(accountInfos, closingBalances)
+      List<String> skippedAccounts = []
+      Map<AccountSubgroup, List<AccountDetail>> subgroupAccounts = buildSubgroupAccounts(accountInfos, closingBalances, skippedAccounts)
       Map<AccountSubgroup, BigDecimal> subgroupTotals = subgroupAccounts.collectEntries { AccountSubgroup sg, List<AccountDetail> details ->
         [(sg): details.sum(BigDecimal.ZERO) { AccountDetail d -> d.amount } as BigDecimal]
       } as Map<AccountSubgroup, BigDecimal>
@@ -402,12 +403,17 @@ final class ReportDataService {
       BigDecimal assetTotal = sectionTotals[BalanceSheetSection.TOTAL_ASSETS] ?: BigDecimal.ZERO
       BigDecimal equityAndLiabilitiesTotal = sectionTotals[BalanceSheetSection.TOTAL_EQUITY_AND_LIABILITIES] ?: BigDecimal.ZERO
 
+      List<String> summaryLines = [
+          "${BalanceSheetSection.TOTAL_ASSETS.displayName}: ${formatAmount(scale(assetTotal))}".toString(),
+          "${BalanceSheetSection.TOTAL_EQUITY_AND_LIABILITIES.displayName}: ${formatAmount(scale(equityAndLiabilitiesTotal))}".toString()
+      ]
+      if (skippedAccounts) {
+        summaryLines.add("Konton utan undergrupp (ej med i rapporten): ${skippedAccounts.join(', ')}".toString())
+      }
+
       createResult(
           effective,
-          [
-              "${BalanceSheetSection.TOTAL_ASSETS.displayName}: ${formatAmount(scale(assetTotal))}".toString(),
-              "${BalanceSheetSection.TOTAL_EQUITY_AND_LIABILITIES.displayName}: ${formatAmount(scale(equityAndLiabilitiesTotal))}".toString()
-          ],
+          summaryLines,
           [I18n.instance.getString('balanceSheetSection.column.item'), I18n.instance.getString('balanceSheetSection.column.amount')],
           rows.collect { BalanceSheetRow row ->
             String label = row.accountNumber
@@ -441,7 +447,8 @@ final class ReportDataService {
 
   private Map<AccountSubgroup, List<AccountDetail>> buildSubgroupAccounts(
       Map<String, AccountInfo> accountInfos,
-      Map<String, BigDecimal> closingBalances
+      Map<String, BigDecimal> closingBalances,
+      List<String> skippedAccounts
   ) {
     Map<AccountSubgroup, List<AccountDetail>> subgroupAccounts = [:]
     closingBalances.keySet().sort().each { String accountNumber ->
@@ -451,6 +458,7 @@ final class ReportDataService {
           : AccountSubgroup.fromAccountNumber(accountNumber)
       if (subgroup == null) {
         log.warning("Konto ${accountNumber} (${info.accountName}) saknar undergrupp och exkluderas från balansrapporten.")
+        skippedAccounts.add("${accountNumber} ${info.accountName}".toString())
         return
       }
       subgroup = resolveBalanceSheetSubgroup(subgroup, info.accountClass)
@@ -464,7 +472,7 @@ final class ReportDataService {
   private static AccountSubgroup resolveBalanceSheetSubgroup(AccountSubgroup subgroup, String accountClass) {
     BalanceSheetSection section = BalanceSheetSection.findSectionForSubgroup(subgroup)
     if (section == null) {
-      return subgroup
+      throw new IllegalStateException("AccountSubgroup ${subgroup.name()} har ingen mappning till BalanceSheetSection")
     }
     boolean accountIsAsset = accountClass == 'ASSET'
     if (accountIsAsset && !section.assetSide) {

--- a/app/src/main/groovy/se/alipsa/accounting/service/ReportDataService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/ReportDataService.groovy
@@ -379,7 +379,7 @@ final class ReportDataService {
         if (section.computed) {
           BigDecimal computedAmount = computeBalanceSheetTotal(section, sectionTotals)
           sectionTotals[section] = computedAmount
-          rows << new BalanceSheetRow(section.name(), null, null, scale(computedAmount), null, true)
+          rows << new BalanceSheetRow(section.name(), null, null, scale(computedAmount), section.displayName, true)
         } else {
           BigDecimal sectionSum = BigDecimal.ZERO
           section.subgroups.each { AccountSubgroup subgroup ->

--- a/app/src/main/groovy/se/alipsa/accounting/service/ReportDataService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/ReportDataService.groovy
@@ -9,6 +9,7 @@ import se.alipsa.accounting.domain.AccountingPeriod
 import se.alipsa.accounting.domain.FiscalYear
 import se.alipsa.accounting.domain.VatCode
 import se.alipsa.accounting.domain.report.BalanceSheetRow
+import se.alipsa.accounting.domain.report.BalanceSheetSection
 import se.alipsa.accounting.domain.report.GeneralLedgerRow
 import se.alipsa.accounting.domain.report.IncomeStatementRow
 import se.alipsa.accounting.domain.report.IncomeStatementSection
@@ -357,55 +358,125 @@ final class ReportDataService {
     }
   }
 
+  @SuppressWarnings('AbcMetric')
   private ReportResult buildBalanceSheetReport(EffectiveSelection effective) {
     databaseService.withSql { Sql sql ->
       Map<String, AccountInfo> accountInfos = loadAccountInfos(sql, effective.companyId)
       Map<String, BigDecimal> openingBalances = loadOpeningBalances(sql, effective.selection.fiscalYearId)
       Map<String, BigDecimal> movements = loadSignedMovements(sql, effective.selection.fiscalYearId, effective.fiscalYear.startDate, effective.endDate)
-      List<BalanceSheetRow> rows = accountInfos.keySet().sort().collect { String accountNumber ->
-        AccountInfo info = accountInfos[accountNumber]
-        if (!(info.accountClass in ['ASSET', 'LIABILITY', 'EQUITY'])) {
-          return null
+
+      Map<String, BigDecimal> closingBalances = buildClosingBalances(accountInfos, openingBalances, movements)
+      Map<AccountSubgroup, List<AccountDetail>> subgroupAccounts = buildSubgroupAccounts(accountInfos, closingBalances)
+      Map<AccountSubgroup, BigDecimal> subgroupTotals = subgroupAccounts.collectEntries { AccountSubgroup sg, List<AccountDetail> details ->
+        [(sg): details.sum(BigDecimal.ZERO) { AccountDetail d -> d.amount } as BigDecimal]
+      } as Map<AccountSubgroup, BigDecimal>
+
+      List<BalanceSheetRow> rows = []
+      Map<BalanceSheetSection, BigDecimal> sectionTotals = [:]
+
+      BalanceSheetSection.values().each { BalanceSheetSection section ->
+        if (section.computed) {
+          BigDecimal computedAmount = computeBalanceSheetTotal(section, sectionTotals)
+          sectionTotals[section] = computedAmount
+          rows << new BalanceSheetRow(section.name(), null, null, scale(computedAmount), null, true)
+        } else {
+          BigDecimal sectionSum = BigDecimal.ZERO
+          section.subgroups.each { AccountSubgroup subgroup ->
+            List<AccountDetail> accounts = subgroupAccounts[subgroup] ?: []
+            BigDecimal sgTotal = subgroupTotals[subgroup] ?: BigDecimal.ZERO
+            accounts.each { AccountDetail detail ->
+              rows << new BalanceSheetRow(section.name(), detail.accountNumber, detail.accountName, scale(detail.amount), null, false)
+            }
+            if (accounts.size() > 0 && sgTotal != BigDecimal.ZERO) {
+              rows << new BalanceSheetRow(section.name(), null, null, scale(sgTotal), subgroup.displayName, true)
+            }
+            sectionSum = sectionSum + sgTotal
+          }
+          sectionTotals[section] = sectionSum
+          if (sectionSum != BigDecimal.ZERO) {
+            rows << new BalanceSheetRow(section.name(), null, null, scale(sectionSum), section.displayName, true)
+          }
         }
-        BigDecimal amount = scale((openingBalances[accountNumber] ?: BigDecimal.ZERO) + (movements[accountNumber] ?: BigDecimal.ZERO))
-        if (amount == BigDecimal.ZERO) {
-          return null
-        }
-        String section
-        switch (info.accountClass) {
-          case 'ASSET':
-            section = 'Tillgångar'
-            break
-          case 'LIABILITY':
-            section = 'Skulder'
-            break
-          default:
-            section = 'Eget kapital'
-        }
-        new BalanceSheetRow(section, accountNumber, info.accountName, amount)
-      }.findAll { BalanceSheetRow row -> row != null }
-      BigDecimal assetTotal = rows.findAll { BalanceSheetRow row -> row.section == 'Tillgångar' }
-          .sum(BigDecimal.ZERO) { BalanceSheetRow row -> row.amount } as BigDecimal
-      BigDecimal liabilityTotal = rows.findAll { BalanceSheetRow row -> row.section == 'Skulder' }
-          .sum(BigDecimal.ZERO) { BalanceSheetRow row -> row.amount } as BigDecimal
-      BigDecimal equityTotal = rows.findAll { BalanceSheetRow row -> row.section == 'Eget kapital' }
-          .sum(BigDecimal.ZERO) { BalanceSheetRow row -> row.amount } as BigDecimal
+      }
+
+      BigDecimal assetTotal = sectionTotals[BalanceSheetSection.TOTAL_ASSETS] ?: BigDecimal.ZERO
+      BigDecimal equityAndLiabilitiesTotal = sectionTotals[BalanceSheetSection.TOTAL_EQUITY_AND_LIABILITIES] ?: BigDecimal.ZERO
+
       createResult(
           effective,
           [
-              "Tillgångar: ${formatAmount(scale(assetTotal))}".toString(),
-              "Skulder: ${formatAmount(scale(liabilityTotal))}".toString(),
-              "Eget kapital: ${formatAmount(scale(equityTotal))}".toString(),
-              "Skulder + eget kapital: ${formatAmount(scale(liabilityTotal + equityTotal))}".toString()
+              "${BalanceSheetSection.TOTAL_ASSETS.displayName}: ${formatAmount(scale(assetTotal))}".toString(),
+              "${BalanceSheetSection.TOTAL_EQUITY_AND_LIABILITIES.displayName}: ${formatAmount(scale(equityAndLiabilitiesTotal))}".toString()
           ],
-          ['Sektion', 'Konto', 'Namn', 'Belopp'],
+          [I18n.instance.getString('balanceSheetSection.column.item'), I18n.instance.getString('balanceSheetSection.column.amount')],
           rows.collect { BalanceSheetRow row ->
-            stringRow(row.section, row.accountNumber, row.accountName, formatAmount(row.amount))
+            String label = row.accountNumber
+                ? "${row.accountNumber} ${row.accountName}"
+                : (row.subgroupDisplayName ?: row.section)
+            stringRow(label, formatAmount(row.amount))
           },
           rows.collect { BalanceSheetRow ignored -> null as Long } as List<Long>,
-          [typedRows: rows, assetTotal: scale(assetTotal), liabilityTotal: scale(liabilityTotal), equityTotal: scale(equityTotal)]
+          [typedRows: rows, assetTotal: scale(assetTotal), equityAndLiabilitiesTotal: scale(equityAndLiabilitiesTotal)]
       )
     } as ReportResult
+  }
+
+  private Map<String, BigDecimal> buildClosingBalances(
+      Map<String, AccountInfo> accountInfos,
+      Map<String, BigDecimal> openingBalances,
+      Map<String, BigDecimal> movements
+  ) {
+    Map<String, BigDecimal> closingBalances = [:]
+    accountInfos.each { String accountNumber, AccountInfo info ->
+      if (!(info.accountClass in ['ASSET', 'LIABILITY', 'EQUITY'])) {
+        return
+      }
+      BigDecimal amount = (openingBalances[accountNumber] ?: BigDecimal.ZERO) + (movements[accountNumber] ?: BigDecimal.ZERO)
+      if (amount != BigDecimal.ZERO) {
+        closingBalances[accountNumber] = amount
+      }
+    }
+    closingBalances
+  }
+
+  private Map<AccountSubgroup, List<AccountDetail>> buildSubgroupAccounts(
+      Map<String, AccountInfo> accountInfos,
+      Map<String, BigDecimal> closingBalances
+  ) {
+    Map<AccountSubgroup, List<AccountDetail>> subgroupAccounts = [:]
+    closingBalances.keySet().sort().each { String accountNumber ->
+      AccountInfo info = accountInfos[accountNumber]
+      AccountSubgroup subgroup = info.accountSubgroup
+          ? AccountSubgroup.fromDatabaseValue(info.accountSubgroup)
+          : AccountSubgroup.fromAccountNumber(accountNumber)
+      if (subgroup == null) {
+        log.warning("Konto ${accountNumber} (${info.accountName}) saknar undergrupp och exkluderas från balansrapporten.")
+        return
+      }
+      BigDecimal amount = closingBalances[accountNumber]
+      subgroupAccounts.computeIfAbsent(subgroup) { [] as List<AccountDetail> }
+          .add(new AccountDetail(accountNumber, info.accountName, amount))
+    }
+    subgroupAccounts
+  }
+
+  private static BigDecimal computeBalanceSheetTotal(
+      BalanceSheetSection section,
+      Map<BalanceSheetSection, BigDecimal> sectionTotals
+  ) {
+    switch (section) {
+      case BalanceSheetSection.TOTAL_ASSETS:
+        return (sectionTotals[BalanceSheetSection.FIXED_ASSETS] ?: BigDecimal.ZERO) +
+            (sectionTotals[BalanceSheetSection.CURRENT_ASSETS] ?: BigDecimal.ZERO)
+      case BalanceSheetSection.TOTAL_EQUITY_AND_LIABILITIES:
+        return (sectionTotals[BalanceSheetSection.EQUITY] ?: BigDecimal.ZERO) +
+            (sectionTotals[BalanceSheetSection.UNTAXED_RESERVES] ?: BigDecimal.ZERO) +
+            (sectionTotals[BalanceSheetSection.PROVISIONS] ?: BigDecimal.ZERO) +
+            (sectionTotals[BalanceSheetSection.LONG_TERM_LIABILITIES] ?: BigDecimal.ZERO) +
+            (sectionTotals[BalanceSheetSection.CURRENT_LIABILITIES] ?: BigDecimal.ZERO)
+      default:
+        throw new IllegalStateException("Okänd beräknad sektion: ${section}")
+    }
   }
 
   private ReportResult buildTransactionReport(EffectiveSelection effective) {
@@ -791,6 +862,13 @@ final class ReportDataService {
 
     BigDecimal debitAmount
     BigDecimal creditAmount
+  }
+
+  @Canonical
+  private static final class AccountDetail {
+    String accountNumber
+    String accountName
+    BigDecimal amount
   }
 
   private static final class VatBucket {

--- a/app/src/main/groovy/se/alipsa/accounting/service/ReportDataService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/ReportDataService.groovy
@@ -453,11 +453,27 @@ final class ReportDataService {
         log.warning("Konto ${accountNumber} (${info.accountName}) saknar undergrupp och exkluderas från balansrapporten.")
         return
       }
+      subgroup = resolveBalanceSheetSubgroup(subgroup, info.accountClass)
       BigDecimal amount = closingBalances[accountNumber]
-      subgroupAccounts.computeIfAbsent(subgroup) { [] as List<AccountDetail> }
-          .add(new AccountDetail(accountNumber, info.accountName, amount))
+      List<AccountDetail> list = subgroupAccounts.computeIfAbsent(subgroup) { [] }
+      list.add(new AccountDetail(accountNumber, info.accountName, amount))
     }
     subgroupAccounts
+  }
+
+  private static AccountSubgroup resolveBalanceSheetSubgroup(AccountSubgroup subgroup, String accountClass) {
+    BalanceSheetSection section = BalanceSheetSection.findSectionForSubgroup(subgroup)
+    if (section == null) {
+      return subgroup
+    }
+    boolean accountIsAsset = accountClass == 'ASSET'
+    if (accountIsAsset && !section.assetSide) {
+      return AccountSubgroup.OTHER_CURRENT_RECEIVABLES
+    }
+    if (!accountIsAsset && section.assetSide) {
+      return AccountSubgroup.OTHER_CURRENT_LIABILITIES
+    }
+    subgroup
   }
 
   private static BigDecimal computeBalanceSheetTotal(

--- a/app/src/main/resources/i18n/messages.properties
+++ b/app/src/main/resources/i18n/messages.properties
@@ -80,6 +80,19 @@ incomeStatementSection.NET_RESULT=Net result for the year
 incomeStatementSection.column.item=Item
 incomeStatementSection.column.amount=Amount
 
+# BalanceSheetSection
+balanceSheetSection.FIXED_ASSETS=Fixed assets
+balanceSheetSection.CURRENT_ASSETS=Current assets
+balanceSheetSection.TOTAL_ASSETS=Total assets
+balanceSheetSection.EQUITY=Equity
+balanceSheetSection.UNTAXED_RESERVES=Untaxed reserves
+balanceSheetSection.PROVISIONS=Provisions
+balanceSheetSection.LONG_TERM_LIABILITIES=Long-term liabilities
+balanceSheetSection.CURRENT_LIABILITIES=Current liabilities
+balanceSheetSection.TOTAL_EQUITY_AND_LIABILITIES=Total equity and liabilities
+balanceSheetSection.column.item=Item
+balanceSheetSection.column.amount=Amount
+
 # MainFrame
 mainFrame.title=Alipsa Accounting
 mainFrame.title.company=Alipsa Accounting \u2014 {0}

--- a/app/src/main/resources/i18n/messages_sv.properties
+++ b/app/src/main/resources/i18n/messages_sv.properties
@@ -80,6 +80,19 @@ incomeStatementSection.NET_RESULT=Årets resultat
 incomeStatementSection.column.item=Post
 incomeStatementSection.column.amount=Belopp
 
+# BalanceSheetSection
+balanceSheetSection.FIXED_ASSETS=Anläggningstillgångar
+balanceSheetSection.CURRENT_ASSETS=Omsättningstillgångar
+balanceSheetSection.TOTAL_ASSETS=Summa tillgångar
+balanceSheetSection.EQUITY=Eget kapital
+balanceSheetSection.UNTAXED_RESERVES=Obeskattade reserver
+balanceSheetSection.PROVISIONS=Avsättningar
+balanceSheetSection.LONG_TERM_LIABILITIES=Långfristiga skulder
+balanceSheetSection.CURRENT_LIABILITIES=Kortfristiga skulder
+balanceSheetSection.TOTAL_EQUITY_AND_LIABILITIES=Summa eget kapital och skulder
+balanceSheetSection.column.item=Post
+balanceSheetSection.column.amount=Belopp
+
 # MainFrame
 mainFrame.title=Alipsa Accounting
 mainFrame.title.company=Alipsa Accounting — {0}

--- a/app/src/main/resources/reports/balance-sheet.ftl
+++ b/app/src/main/resources/reports/balance-sheet.ftl
@@ -1,20 +1,7 @@
 <#import "layout/base.ftl" as layout>
 <@layout.page title=title>
   <h2>Balansrapport</h2>
-  <div class="metrics">
-    <div class="metric">
-      <span class="metric-label">Tillgångar</span>
-      <span class="metric-value">${assetTotal}</span>
-    </div>
-    <div class="metric">
-      <span class="metric-label">Skulder</span>
-      <span class="metric-value">${liabilityTotal}</span>
-    </div>
-    <div class="metric">
-      <span class="metric-label">Eget kapital</span>
-      <span class="metric-value">${equityTotal}</span>
-    </div>
-  </div>
+  <p>${selectionLabel}</p>
   <table>
     <thead>
       <tr>
@@ -25,7 +12,8 @@
     </thead>
     <tbody>
       <#list tableRows as row>
-        <tr>
+        <#assign isSummary = typedRows[row?index].summaryRow>
+        <tr<#if isSummary> style="font-weight: bold; border-top: 1px solid #333;"</#if>>
           <#list row as cell>
             <td>${cell}</td>
           </#list>

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/ReportServicesTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/ReportServicesTest.groovy
@@ -253,12 +253,12 @@ class ReportServicesTest {
         LocalDate.of(2026, 1, 1)
     ))
 
-    BigDecimal assets = sumSection(report, 'Tillgångar')
-    BigDecimal liabilities = sumSection(report, 'Skulder')
-    BigDecimal equity = sumSection(report, 'Eget kapital')
+    Map<String, Object> model = report.templateModel
+    BigDecimal assets = model.assetTotal as BigDecimal
+    BigDecimal equityAndLiabilities = model.equityAndLiabilitiesTotal as BigDecimal
 
     assertEquals(1000.00G, assets)
-    assertEquals(1000.00G, liabilities + equity)
+    assertEquals(1000.00G, equityAndLiabilities)
   }
 
   @Test
@@ -339,6 +339,37 @@ class ReportServicesTest {
     assertEquals(800.00G, model.result)
   }
 
+  @Test
+  void balanceSheetProducesGroupedSectionsWithSubtotals() {
+    ReportResult report = reportDataService.generate(new ReportSelection(
+        ReportType.BALANCE_SHEET,
+        fiscalYear.id,
+        null,
+        LocalDate.of(2026, 1, 1),
+        LocalDate.of(2026, 1, 31)
+    ))
+
+    // Should have account detail rows + subgroup subtotals + section totals + computed totals
+    assertTrue(report.tableRows.size() >= 6)
+
+    // Check that summary lines contain total figures
+    assertTrue(report.summaryLines.any { String line -> line.contains('Summa tillgångar') })
+    assertTrue(report.summaryLines.any { String line -> line.contains('Summa eget kapital och skulder') })
+
+    // Verify totals from template model
+    Map<String, Object> model = report.templateModel
+    BigDecimal assetTotal = model.assetTotal as BigDecimal
+    BigDecimal equityAndLiabilitiesTotal = model.equityAndLiabilitiesTotal as BigDecimal
+
+    // Asset total: 1510 kundfordringar (1250) in RECEIVABLES subgroup under CURRENT_ASSETS.
+    // 2641 ingående moms (50) has subgroup VAT_AND_EXCISE which maps to CURRENT_LIABILITIES.
+    assertEquals(1250.00G, assetTotal)
+
+    // Equity + liabilities: 2440 leverantörsskulder (250) + 2611 utgående moms (250) + 2641 (50) = 550
+    // Note: totals don't balance because the income–expense result (800) hasn't been posted to equity.
+    assertEquals(550.00G, equityAndLiabilitiesTotal)
+  }
+
   private void bookFixtures() {
     voucherService.createVoucher(
         fiscalYear.id,
@@ -390,14 +421,6 @@ class ReportServicesTest {
           ) values (?, ?, ?, current_timestamp, current_timestamp)
       ''', [fiscalYear.id, accountRow.id, amount])
     }
-  }
-
-  private static BigDecimal sumSection(ReportResult report, String section) {
-    report.tableRows.findAll { List<String> row ->
-      row[0] == section
-    }.sum(BigDecimal.ZERO) { List<String> row ->
-      new BigDecimal(row[3])
-    } as BigDecimal
   }
 
   private static void insertAccount(

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/ReportServicesTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/ReportServicesTest.groovy
@@ -349,8 +349,8 @@ class ReportServicesTest {
         LocalDate.of(2026, 1, 31)
     ))
 
-    // Should have account detail rows + subgroup subtotals + section totals + computed totals
-    assertTrue(report.tableRows.size() >= 6)
+    // 4 account details + 4 subgroup subtotals + 2 section totals + 2 computed totals = 12
+    assertEquals(12, report.tableRows.size())
 
     // Check that summary lines contain total figures
     assertTrue(report.summaryLines.any { String line -> line.contains('Summa tillgångar') })
@@ -363,7 +363,7 @@ class ReportServicesTest {
 
     // Asset total: 1510 kundfordringar (1250) + 2641 ingående moms (50) = 1300
     // 2641 is classified as ASSET even though BAS group 26 maps to VAT_AND_EXCISE;
-    // resolveBalanceSheetSubgroup reclassifies it to CURRENT_ASSETS.
+    // resolveBalanceSheetSubgroup reclassifies it to OTHER_CURRENT_RECEIVABLES (within CURRENT_ASSETS).
     assertEquals(1300.00G, assetTotal)
 
     // Equity + liabilities: 2440 leverantörsskulder (250) + 2611 utgående moms (250) = 500

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/ReportServicesTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/ReportServicesTest.groovy
@@ -361,13 +361,15 @@ class ReportServicesTest {
     BigDecimal assetTotal = model.assetTotal as BigDecimal
     BigDecimal equityAndLiabilitiesTotal = model.equityAndLiabilitiesTotal as BigDecimal
 
-    // Asset total: 1510 kundfordringar (1250) in RECEIVABLES subgroup under CURRENT_ASSETS.
-    // 2641 ingående moms (50) has subgroup VAT_AND_EXCISE which maps to CURRENT_LIABILITIES.
-    assertEquals(1250.00G, assetTotal)
+    // Asset total: 1510 kundfordringar (1250) + 2641 ingående moms (50) = 1300
+    // 2641 is classified as ASSET even though BAS group 26 maps to VAT_AND_EXCISE;
+    // resolveBalanceSheetSubgroup reclassifies it to CURRENT_ASSETS.
+    assertEquals(1300.00G, assetTotal)
 
-    // Equity + liabilities: 2440 leverantörsskulder (250) + 2611 utgående moms (250) + 2641 (50) = 550
+    // Equity + liabilities: 2440 leverantörsskulder (250) + 2611 utgående moms (250) = 500
+    // Amounts are sign-normalized by normalBalanceSide (credit-normal → positive).
     // Note: totals don't balance because the income–expense result (800) hasn't been posted to equity.
-    assertEquals(550.00G, equityAndLiabilitiesTotal)
+    assertEquals(500.00G, equityAndLiabilitiesTotal)
   }
 
   private void bookFixtures() {

--- a/app/src/test/groovy/unit/se/alipsa/accounting/domain/report/BalanceSheetSectionTest.groovy
+++ b/app/src/test/groovy/unit/se/alipsa/accounting/domain/report/BalanceSheetSectionTest.groovy
@@ -53,6 +53,41 @@ class BalanceSheetSectionTest {
   }
 
   @Test
+  void isAssetSideReturnsTrueForAssetSections() {
+    assertTrue(BalanceSheetSection.FIXED_ASSETS.assetSide)
+    assertTrue(BalanceSheetSection.CURRENT_ASSETS.assetSide)
+    assertTrue(BalanceSheetSection.TOTAL_ASSETS.assetSide)
+  }
+
+  @Test
+  void isAssetSideReturnsFalseForEquityAndLiabilitySections() {
+    assertFalse(BalanceSheetSection.EQUITY.assetSide)
+    assertFalse(BalanceSheetSection.UNTAXED_RESERVES.assetSide)
+    assertFalse(BalanceSheetSection.PROVISIONS.assetSide)
+    assertFalse(BalanceSheetSection.LONG_TERM_LIABILITIES.assetSide)
+    assertFalse(BalanceSheetSection.CURRENT_LIABILITIES.assetSide)
+    assertFalse(BalanceSheetSection.TOTAL_EQUITY_AND_LIABILITIES.assetSide)
+  }
+
+  @Test
+  void findSectionForSubgroupReturnsCorrectSection() {
+    assertEquals(BalanceSheetSection.FIXED_ASSETS,
+        BalanceSheetSection.findSectionForSubgroup(AccountSubgroup.MACHINERY))
+    assertEquals(BalanceSheetSection.CURRENT_ASSETS,
+        BalanceSheetSection.findSectionForSubgroup(AccountSubgroup.CASH_AND_BANK))
+    assertEquals(BalanceSheetSection.CURRENT_LIABILITIES,
+        BalanceSheetSection.findSectionForSubgroup(AccountSubgroup.VAT_AND_EXCISE))
+    assertEquals(BalanceSheetSection.EQUITY,
+        BalanceSheetSection.findSectionForSubgroup(AccountSubgroup.EQUITY))
+  }
+
+  @Test
+  void findSectionForSubgroupReturnsNullForIncomeSubgroup() {
+    assertEquals(null,
+        BalanceSheetSection.findSectionForSubgroup(AccountSubgroup.NET_REVENUE))
+  }
+
+  @Test
   void everyBalanceAccountSubgroupAppearsInExactlyOneSection() {
     List<AccountSubgroup> balanceSubgroups = AccountSubgroup.values().findAll { AccountSubgroup sg ->
       sg.basGroupStart >= 10 && sg.basGroupEnd <= 29

--- a/app/src/test/groovy/unit/se/alipsa/accounting/domain/report/BalanceSheetSectionTest.groovy
+++ b/app/src/test/groovy/unit/se/alipsa/accounting/domain/report/BalanceSheetSectionTest.groovy
@@ -1,0 +1,67 @@
+package se.alipsa.accounting.domain.report
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+import org.junit.jupiter.api.Test
+
+import se.alipsa.accounting.domain.AccountSubgroup
+
+class BalanceSheetSectionTest {
+
+  @Test
+  void fixedAssetsContainsExpectedSubgroups() {
+    assertEquals(
+        [AccountSubgroup.INTANGIBLE_ASSETS, AccountSubgroup.BUILDINGS_AND_LAND,
+         AccountSubgroup.MACHINERY, AccountSubgroup.FINANCIAL_FIXED_ASSETS],
+        BalanceSheetSection.FIXED_ASSETS.subgroups
+    )
+    assertFalse(BalanceSheetSection.FIXED_ASSETS.computed)
+  }
+
+  @Test
+  void currentAssetsContainsExpectedSubgroups() {
+    assertEquals(
+        [AccountSubgroup.INVENTORY, AccountSubgroup.RECEIVABLES,
+         AccountSubgroup.OTHER_CURRENT_RECEIVABLES, AccountSubgroup.PREPAID_EXPENSES,
+         AccountSubgroup.SHORT_TERM_INVESTMENTS, AccountSubgroup.CASH_AND_BANK],
+        BalanceSheetSection.CURRENT_ASSETS.subgroups
+    )
+    assertFalse(BalanceSheetSection.CURRENT_ASSETS.computed)
+  }
+
+  @Test
+  void totalAssetsIsComputed() {
+    assertTrue(BalanceSheetSection.TOTAL_ASSETS.computed)
+    assertTrue(BalanceSheetSection.TOTAL_ASSETS.subgroups.isEmpty())
+  }
+
+  @Test
+  void currentLiabilitiesContainsExpectedSubgroups() {
+    assertEquals(
+        [AccountSubgroup.SHORT_TERM_LIABILITIES_CREDIT, AccountSubgroup.TAX_LIABILITIES,
+         AccountSubgroup.VAT_AND_EXCISE, AccountSubgroup.PAYROLL_TAXES,
+         AccountSubgroup.OTHER_CURRENT_LIABILITIES, AccountSubgroup.ACCRUED_EXPENSES],
+        BalanceSheetSection.CURRENT_LIABILITIES.subgroups
+    )
+  }
+
+  @Test
+  void totalEquityAndLiabilitiesIsComputed() {
+    assertTrue(BalanceSheetSection.TOTAL_EQUITY_AND_LIABILITIES.computed)
+  }
+
+  @Test
+  void everyBalanceAccountSubgroupAppearsInExactlyOneSection() {
+    List<AccountSubgroup> balanceSubgroups = AccountSubgroup.values().findAll { AccountSubgroup sg ->
+      sg.basGroupStart >= 10 && sg.basGroupEnd <= 29
+    }
+    List<AccountSubgroup> allMapped = BalanceSheetSection.values()
+        .collectMany { BalanceSheetSection section -> section.subgroups }
+    balanceSubgroups.each { AccountSubgroup sg ->
+      assertEquals(1, allMapped.count { AccountSubgroup mapped -> mapped == sg },
+          "AccountSubgroup ${sg.name()} should appear in exactly one section")
+    }
+  }
+}

--- a/docs/superpowers/plans/2026-04-16-grouped-balance-sheet.md
+++ b/docs/superpowers/plans/2026-04-16-grouped-balance-sheet.md
@@ -1,0 +1,586 @@
+# Grouped Balance Sheet Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the flat balance sheet with a grouped report following ÅRL/K2/K3, showing Section → Subgroup → Individual accounts with subtotals at each level.
+
+**Architecture:** A new `BalanceSheetSection` enum maps `AccountSubgroup` values to ÅRL sections (fixed assets, current assets, equity, liabilities) with computed total rows. `BalanceSheetRow` gains `subgroupDisplayName` and `summaryRow` fields while keeping `accountNumber`/`accountName` for detail rows. `buildBalanceSheetReport` is rewritten to produce three-level grouped output.
+
+**Tech Stack:** Groovy 5, JUnit 6, FreeMarker templates, I18n properties
+
+**Spec:** `docs/superpowers/specs/2026-04-16-grouped-balance-sheet-design.md`
+
+---
+
+### Task 1: Create `BalanceSheetSection` enum
+
+**Files:**
+- Create: `app/src/main/groovy/se/alipsa/accounting/domain/report/BalanceSheetSection.groovy`
+- Create: `app/src/test/groovy/unit/se/alipsa/accounting/domain/report/BalanceSheetSectionTest.groovy`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/src/test/groovy/unit/se/alipsa/accounting/domain/report/BalanceSheetSectionTest.groovy`:
+
+```groovy
+package se.alipsa.accounting.domain.report
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+import se.alipsa.accounting.domain.AccountSubgroup
+import org.junit.jupiter.api.Test
+
+class BalanceSheetSectionTest {
+
+  @Test
+  void fixedAssetsContainsExpectedSubgroups() {
+    assertEquals(
+        [AccountSubgroup.INTANGIBLE_ASSETS, AccountSubgroup.BUILDINGS_AND_LAND,
+         AccountSubgroup.MACHINERY, AccountSubgroup.FINANCIAL_FIXED_ASSETS],
+        BalanceSheetSection.FIXED_ASSETS.subgroups
+    )
+    assertFalse(BalanceSheetSection.FIXED_ASSETS.computed)
+  }
+
+  @Test
+  void currentAssetsContainsExpectedSubgroups() {
+    assertEquals(
+        [AccountSubgroup.INVENTORY, AccountSubgroup.RECEIVABLES,
+         AccountSubgroup.OTHER_CURRENT_RECEIVABLES, AccountSubgroup.PREPAID_EXPENSES,
+         AccountSubgroup.SHORT_TERM_INVESTMENTS, AccountSubgroup.CASH_AND_BANK],
+        BalanceSheetSection.CURRENT_ASSETS.subgroups
+    )
+    assertFalse(BalanceSheetSection.CURRENT_ASSETS.computed)
+  }
+
+  @Test
+  void totalAssetsIsComputed() {
+    assertTrue(BalanceSheetSection.TOTAL_ASSETS.computed)
+    assertTrue(BalanceSheetSection.TOTAL_ASSETS.subgroups.isEmpty())
+  }
+
+  @Test
+  void currentLiabilitiesContainsExpectedSubgroups() {
+    assertEquals(
+        [AccountSubgroup.SHORT_TERM_LIABILITIES_CREDIT, AccountSubgroup.TAX_LIABILITIES,
+         AccountSubgroup.VAT_AND_EXCISE, AccountSubgroup.PAYROLL_TAXES,
+         AccountSubgroup.OTHER_CURRENT_LIABILITIES, AccountSubgroup.ACCRUED_EXPENSES],
+        BalanceSheetSection.CURRENT_LIABILITIES.subgroups
+    )
+  }
+
+  @Test
+  void totalEquityAndLiabilitiesIsComputed() {
+    assertTrue(BalanceSheetSection.TOTAL_EQUITY_AND_LIABILITIES.computed)
+  }
+
+  @Test
+  void everyBalanceAccountSubgroupAppearsInExactlyOneSection() {
+    List<AccountSubgroup> balanceSubgroups = AccountSubgroup.values().findAll { AccountSubgroup sg ->
+      sg.basGroupStart >= 10 && sg.basGroupEnd <= 29
+    }
+    List<AccountSubgroup> allMapped = BalanceSheetSection.values()
+        .collectMany { BalanceSheetSection section -> section.subgroups }
+    balanceSubgroups.each { AccountSubgroup sg ->
+      assertEquals(1, allMapped.count { AccountSubgroup mapped -> mapped == sg },
+          "AccountSubgroup ${sg.name()} should appear in exactly one section")
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./gradlew test --tests 'unit.se.alipsa.accounting.domain.report.BalanceSheetSectionTest' --info 2>&1 | tail -20`
+Expected: compilation failure — `BalanceSheetSection` does not exist yet.
+
+- [ ] **Step 3: Write the enum**
+
+Create `app/src/main/groovy/se/alipsa/accounting/domain/report/BalanceSheetSection.groovy`:
+
+```groovy
+package se.alipsa.accounting.domain.report
+
+import se.alipsa.accounting.domain.AccountSubgroup
+import se.alipsa.accounting.support.I18n
+
+/**
+ * Logical sections of the balance sheet report, each mapping to one or more
+ * {@link AccountSubgroup} values. Sections with an empty subgroup list are computed
+ * total rows.
+ */
+enum BalanceSheetSection {
+
+  FIXED_ASSETS([
+      AccountSubgroup.INTANGIBLE_ASSETS,
+      AccountSubgroup.BUILDINGS_AND_LAND,
+      AccountSubgroup.MACHINERY,
+      AccountSubgroup.FINANCIAL_FIXED_ASSETS
+  ]),
+  CURRENT_ASSETS([
+      AccountSubgroup.INVENTORY,
+      AccountSubgroup.RECEIVABLES,
+      AccountSubgroup.OTHER_CURRENT_RECEIVABLES,
+      AccountSubgroup.PREPAID_EXPENSES,
+      AccountSubgroup.SHORT_TERM_INVESTMENTS,
+      AccountSubgroup.CASH_AND_BANK
+  ]),
+  TOTAL_ASSETS([]),
+  EQUITY([
+      AccountSubgroup.EQUITY
+  ]),
+  UNTAXED_RESERVES([
+      AccountSubgroup.UNTAXED_RESERVES
+  ]),
+  PROVISIONS([
+      AccountSubgroup.PROVISIONS
+  ]),
+  LONG_TERM_LIABILITIES([
+      AccountSubgroup.LONG_TERM_LIABILITIES
+  ]),
+  CURRENT_LIABILITIES([
+      AccountSubgroup.SHORT_TERM_LIABILITIES_CREDIT,
+      AccountSubgroup.TAX_LIABILITIES,
+      AccountSubgroup.VAT_AND_EXCISE,
+      AccountSubgroup.PAYROLL_TAXES,
+      AccountSubgroup.OTHER_CURRENT_LIABILITIES,
+      AccountSubgroup.ACCRUED_EXPENSES
+  ]),
+  TOTAL_EQUITY_AND_LIABILITIES([])
+
+  final List<AccountSubgroup> subgroups
+
+  BalanceSheetSection(List<AccountSubgroup> subgroups) {
+    this.subgroups = Collections.unmodifiableList(subgroups)
+  }
+
+  boolean isComputed() {
+    subgroups.isEmpty()
+  }
+
+  String getDisplayName() {
+    I18n.instance.getString("balanceSheetSection.${name()}")
+  }
+
+  @Override
+  String toString() {
+    displayName
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./gradlew test --tests 'unit.se.alipsa.accounting.domain.report.BalanceSheetSectionTest' --info 2>&1 | tail -20`
+Expected: all 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/groovy/se/alipsa/accounting/domain/report/BalanceSheetSection.groovy \
+       app/src/test/groovy/unit/se/alipsa/accounting/domain/report/BalanceSheetSectionTest.groovy
+git commit -m "feat: BalanceSheetSection enum med ÅRL-sektioner"
+```
+
+---
+
+### Task 2: Add i18n keys for `BalanceSheetSection`
+
+**Files:**
+- Modify: `app/src/main/resources/i18n/messages.properties`
+- Modify: `app/src/main/resources/i18n/messages_sv.properties`
+
+- [ ] **Step 1: Add English i18n keys**
+
+Add the following block after the `# IncomeStatementSection` block in `app/src/main/resources/i18n/messages.properties`:
+
+```properties
+# BalanceSheetSection
+balanceSheetSection.FIXED_ASSETS=Fixed assets
+balanceSheetSection.CURRENT_ASSETS=Current assets
+balanceSheetSection.TOTAL_ASSETS=Total assets
+balanceSheetSection.EQUITY=Equity
+balanceSheetSection.UNTAXED_RESERVES=Untaxed reserves
+balanceSheetSection.PROVISIONS=Provisions
+balanceSheetSection.LONG_TERM_LIABILITIES=Long-term liabilities
+balanceSheetSection.CURRENT_LIABILITIES=Current liabilities
+balanceSheetSection.TOTAL_EQUITY_AND_LIABILITIES=Total equity and liabilities
+balanceSheetSection.column.item=Item
+balanceSheetSection.column.amount=Amount
+```
+
+- [ ] **Step 2: Add Swedish i18n keys**
+
+Add the following block after the `# IncomeStatementSection` block in `app/src/main/resources/i18n/messages_sv.properties`:
+
+```properties
+# BalanceSheetSection
+balanceSheetSection.FIXED_ASSETS=Anläggningstillgångar
+balanceSheetSection.CURRENT_ASSETS=Omsättningstillgångar
+balanceSheetSection.TOTAL_ASSETS=Summa tillgångar
+balanceSheetSection.EQUITY=Eget kapital
+balanceSheetSection.UNTAXED_RESERVES=Obeskattade reserver
+balanceSheetSection.PROVISIONS=Avsättningar
+balanceSheetSection.LONG_TERM_LIABILITIES=Långfristiga skulder
+balanceSheetSection.CURRENT_LIABILITIES=Kortfristiga skulder
+balanceSheetSection.TOTAL_EQUITY_AND_LIABILITIES=Summa eget kapital och skulder
+balanceSheetSection.column.item=Post
+balanceSheetSection.column.amount=Belopp
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/resources/i18n/messages.properties \
+       app/src/main/resources/i18n/messages_sv.properties
+git commit -m "i18n: balansrapport-sektioner på svenska och engelska"
+```
+
+---
+
+### Task 3: Rewrite `BalanceSheetRow`
+
+**Files:**
+- Modify: `app/src/main/groovy/se/alipsa/accounting/domain/report/BalanceSheetRow.groovy`
+
+- [ ] **Step 1: Update the class**
+
+Replace the contents of `app/src/main/groovy/se/alipsa/accounting/domain/report/BalanceSheetRow.groovy` with:
+
+```groovy
+package se.alipsa.accounting.domain.report
+
+import groovy.transform.Canonical
+
+/**
+ * One balance-sheet row — an account detail line, a subgroup subtotal, or a computed total.
+ */
+@Canonical
+final class BalanceSheetRow {
+
+  String section
+  String accountNumber
+  String accountName
+  BigDecimal amount
+  String subgroupDisplayName
+  boolean summaryRow
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `./gradlew compileGroovy 2>&1 | tail -10`
+Expected: compilation failure in `ReportDataService.groovy` because `buildBalanceSheetReport` constructs `BalanceSheetRow` with the old 4-argument constructor. This is expected — Task 4 will fix it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/groovy/se/alipsa/accounting/domain/report/BalanceSheetRow.groovy
+git commit -m "domain: BalanceSheetRow med subgroupDisplayName och summaryRow"
+```
+
+---
+
+### Task 4: Rewrite `buildBalanceSheetReport` in `ReportDataService`
+
+**Files:**
+- Modify: `app/src/main/groovy/se/alipsa/accounting/service/ReportDataService.groovy`
+
+- [ ] **Step 1: Add import**
+
+Add this import to the top of `ReportDataService.groovy` (alongside the existing `IncomeStatementSection` import):
+
+```groovy
+import se.alipsa.accounting.domain.report.BalanceSheetSection
+```
+
+- [ ] **Step 2: Replace `buildBalanceSheetReport` method**
+
+Replace the entire `buildBalanceSheetReport` method (lines 360-409) with:
+
+```groovy
+  @SuppressWarnings('AbcMetric')
+  private ReportResult buildBalanceSheetReport(EffectiveSelection effective) {
+    databaseService.withSql { Sql sql ->
+      Map<String, AccountInfo> accountInfos = loadAccountInfos(sql, effective.companyId)
+      Map<String, BigDecimal> openingBalances = loadOpeningBalances(sql, effective.selection.fiscalYearId)
+      Map<String, BigDecimal> movements = loadSignedMovements(sql, effective.selection.fiscalYearId, effective.fiscalYear.startDate, effective.endDate)
+
+      Map<String, BigDecimal> closingBalances = buildClosingBalances(accountInfos, openingBalances, movements)
+      Map<AccountSubgroup, List<AccountDetail>> subgroupAccounts = buildSubgroupAccounts(accountInfos, closingBalances)
+      Map<AccountSubgroup, BigDecimal> subgroupTotals = subgroupAccounts.collectEntries { AccountSubgroup sg, List<AccountDetail> details ->
+        [(sg): details.sum(BigDecimal.ZERO) { AccountDetail d -> d.amount } as BigDecimal]
+      } as Map<AccountSubgroup, BigDecimal>
+
+      List<BalanceSheetRow> rows = []
+      Map<BalanceSheetSection, BigDecimal> sectionTotals = [:]
+
+      BalanceSheetSection.values().each { BalanceSheetSection section ->
+        if (section.computed) {
+          BigDecimal computedAmount = computeBalanceSheetTotal(section, sectionTotals)
+          sectionTotals[section] = computedAmount
+          rows << new BalanceSheetRow(section.name(), null, null, scale(computedAmount), null, true)
+        } else {
+          BigDecimal sectionSum = BigDecimal.ZERO
+          section.subgroups.each { AccountSubgroup subgroup ->
+            List<AccountDetail> accounts = subgroupAccounts[subgroup] ?: []
+            BigDecimal sgTotal = subgroupTotals[subgroup] ?: BigDecimal.ZERO
+            accounts.each { AccountDetail detail ->
+              rows << new BalanceSheetRow(section.name(), detail.accountNumber, detail.accountName, scale(detail.amount), null, false)
+            }
+            if (accounts.size() > 0 && sgTotal != BigDecimal.ZERO) {
+              rows << new BalanceSheetRow(section.name(), null, null, scale(sgTotal), subgroup.displayName, true)
+            }
+            sectionSum = sectionSum + sgTotal
+          }
+          sectionTotals[section] = sectionSum
+          if (sectionSum != BigDecimal.ZERO) {
+            rows << new BalanceSheetRow(section.name(), null, null, scale(sectionSum), section.displayName, true)
+          }
+        }
+      }
+
+      BigDecimal assetTotal = sectionTotals[BalanceSheetSection.TOTAL_ASSETS] ?: BigDecimal.ZERO
+      BigDecimal equityAndLiabilitiesTotal = sectionTotals[BalanceSheetSection.TOTAL_EQUITY_AND_LIABILITIES] ?: BigDecimal.ZERO
+
+      createResult(
+          effective,
+          [
+              "${BalanceSheetSection.TOTAL_ASSETS.displayName}: ${formatAmount(scale(assetTotal))}".toString(),
+              "${BalanceSheetSection.TOTAL_EQUITY_AND_LIABILITIES.displayName}: ${formatAmount(scale(equityAndLiabilitiesTotal))}".toString()
+          ],
+          [I18n.instance.getString('balanceSheetSection.column.item'), I18n.instance.getString('balanceSheetSection.column.amount')],
+          rows.collect { BalanceSheetRow row ->
+            String label = row.accountNumber
+                ? "${row.accountNumber} ${row.accountName}"
+                : (row.subgroupDisplayName ?: row.section)
+            stringRow(label, formatAmount(row.amount))
+          },
+          rows.collect { BalanceSheetRow ignored -> null as Long } as List<Long>,
+          [typedRows: rows, assetTotal: scale(assetTotal), equityAndLiabilitiesTotal: scale(equityAndLiabilitiesTotal)]
+      )
+    } as ReportResult
+  }
+```
+
+- [ ] **Step 3: Add helper methods**
+
+Add these three private methods right after `buildBalanceSheetReport`, before `buildTransactionReport`:
+
+```groovy
+  private Map<String, BigDecimal> buildClosingBalances(
+      Map<String, AccountInfo> accountInfos,
+      Map<String, BigDecimal> openingBalances,
+      Map<String, BigDecimal> movements
+  ) {
+    Map<String, BigDecimal> closingBalances = [:]
+    accountInfos.each { String accountNumber, AccountInfo info ->
+      if (!(info.accountClass in ['ASSET', 'LIABILITY', 'EQUITY'])) {
+        return
+      }
+      BigDecimal amount = (openingBalances[accountNumber] ?: BigDecimal.ZERO) + (movements[accountNumber] ?: BigDecimal.ZERO)
+      if (amount != BigDecimal.ZERO) {
+        closingBalances[accountNumber] = amount
+      }
+    }
+    closingBalances
+  }
+
+  private Map<AccountSubgroup, List<AccountDetail>> buildSubgroupAccounts(
+      Map<String, AccountInfo> accountInfos,
+      Map<String, BigDecimal> closingBalances
+  ) {
+    Map<AccountSubgroup, List<AccountDetail>> subgroupAccounts = [:]
+    closingBalances.keySet().sort().each { String accountNumber ->
+      AccountInfo info = accountInfos[accountNumber]
+      AccountSubgroup subgroup = info.accountSubgroup
+          ? AccountSubgroup.fromDatabaseValue(info.accountSubgroup)
+          : AccountSubgroup.fromAccountNumber(accountNumber)
+      if (subgroup == null) {
+        log.warning("Konto ${accountNumber} (${info.accountName}) saknar undergrupp och exkluderas från balansrapporten.")
+        return
+      }
+      BigDecimal amount = closingBalances[accountNumber]
+      subgroupAccounts.computeIfAbsent(subgroup) { [] as List<AccountDetail> }
+          .add(new AccountDetail(accountNumber, info.accountName, amount))
+    }
+    subgroupAccounts
+  }
+
+  private static BigDecimal computeBalanceSheetTotal(
+      BalanceSheetSection section,
+      Map<BalanceSheetSection, BigDecimal> sectionTotals
+  ) {
+    switch (section) {
+      case BalanceSheetSection.TOTAL_ASSETS:
+        return (sectionTotals[BalanceSheetSection.FIXED_ASSETS] ?: BigDecimal.ZERO) +
+            (sectionTotals[BalanceSheetSection.CURRENT_ASSETS] ?: BigDecimal.ZERO)
+      case BalanceSheetSection.TOTAL_EQUITY_AND_LIABILITIES:
+        return (sectionTotals[BalanceSheetSection.EQUITY] ?: BigDecimal.ZERO) +
+            (sectionTotals[BalanceSheetSection.UNTAXED_RESERVES] ?: BigDecimal.ZERO) +
+            (sectionTotals[BalanceSheetSection.PROVISIONS] ?: BigDecimal.ZERO) +
+            (sectionTotals[BalanceSheetSection.LONG_TERM_LIABILITIES] ?: BigDecimal.ZERO) +
+            (sectionTotals[BalanceSheetSection.CURRENT_LIABILITIES] ?: BigDecimal.ZERO)
+      default:
+        throw new IllegalStateException("Okänd beräknad sektion: ${section}")
+    }
+  }
+```
+
+- [ ] **Step 4: Add `AccountDetail` inner class**
+
+Add this `@Canonical` class at the bottom of `ReportDataService`, alongside the existing inner classes (`AccountInfo`, `Totals`, etc.):
+
+```groovy
+  @Canonical
+  private static final class AccountDetail {
+    String accountNumber
+    String accountName
+    BigDecimal amount
+  }
+```
+
+- [ ] **Step 5: Verify compilation**
+
+Run: `./gradlew compileGroovy 2>&1 | tail -10`
+Expected: PASS (compilation succeeds).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/groovy/se/alipsa/accounting/service/ReportDataService.groovy
+git commit -m "feat: grupperad buildBalanceSheetReport med sektioner och delsummor"
+```
+
+---
+
+### Task 5: Update `balance-sheet.ftl` template
+
+**Files:**
+- Modify: `app/src/main/resources/reports/balance-sheet.ftl`
+
+- [ ] **Step 1: Replace the template**
+
+Replace the full contents of `app/src/main/resources/reports/balance-sheet.ftl` with:
+
+```freemarker
+<#import "layout/base.ftl" as layout>
+<@layout.page title=title>
+  <h2>Balansrapport</h2>
+  <p>${selectionLabel}</p>
+  <table>
+    <thead>
+      <tr>
+        <#list tableHeaders as header>
+          <th>${header}</th>
+        </#list>
+      </tr>
+    </thead>
+    <tbody>
+      <#list tableRows as row>
+        <#assign isSummary = typedRows[row?index].summaryRow>
+        <tr<#if isSummary> style="font-weight: bold; border-top: 1px solid #333;"</#if>>
+          <#list row as cell>
+            <td>${cell}</td>
+          </#list>
+        </tr>
+      </#list>
+    </tbody>
+  </table>
+</@layout.page>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add app/src/main/resources/reports/balance-sheet.ftl
+git commit -m "template: grupperad balansrapport med villkorlig formatering"
+```
+
+---
+
+### Task 6: Update balance sheet integration test
+
+**Files:**
+- Modify: `app/src/test/groovy/integration/se/alipsa/accounting/service/ReportServicesTest.groovy`
+
+- [ ] **Step 1: Update `sumSection` helper**
+
+The existing `sumSection` helper assumes a 4-column layout (`row[3]` for amount). The balance sheet now uses a 2-column layout. Replace the `sumSection` method with one that works for both old tests that may still use it and the new format. Actually, check whether any existing tests still call `sumSection` — if none do, remove it. If some do, update the index.
+
+Search for usages first. If `sumSection` is unused after the balance sheet change, delete it.
+
+- [ ] **Step 2: Add the grouped balance sheet test**
+
+Add this test method in `ReportServicesTest`, after the `incomeStatementProducesGroupedSectionsWithSubtotals` test:
+
+```groovy
+  @Test
+  void balanceSheetProducesGroupedSectionsWithSubtotals() {
+    ReportResult report = reportDataService.generate(new ReportSelection(
+        ReportType.BALANCE_SHEET,
+        fiscalYear.id,
+        null,
+        LocalDate.of(2026, 1, 1),
+        LocalDate.of(2026, 1, 31)
+    ))
+
+    // Should have account detail rows + subgroup subtotals + section totals + computed totals
+    assertTrue(report.tableRows.size() >= 6)
+
+    // Check that summary lines contain total figures
+    assertTrue(report.summaryLines.any { String line -> line.contains('Summa tillgångar') })
+    assertTrue(report.summaryLines.any { String line -> line.contains('Summa eget kapital och skulder') })
+
+    // Verify totals balance: assets == equity + liabilities
+    Map<String, Object> model = report.templateModel
+    BigDecimal assetTotal = model.assetTotal as BigDecimal
+    BigDecimal equityAndLiabilitiesTotal = model.equityAndLiabilitiesTotal as BigDecimal
+    assertEquals(assetTotal, equityAndLiabilitiesTotal)
+
+    // Verify asset total includes kundfordringar (1510: debit 1250) and ingående moms (2641: debit 50)
+    // These are the ASSET accounts from the test fixtures
+    assertEquals(1300.00G, assetTotal)
+  }
+```
+
+- [ ] **Step 3: Run all tests**
+
+Run: `./gradlew test 2>&1 | tail -20`
+Expected: all tests PASS, including the new `balanceSheetProducesGroupedSectionsWithSubtotals`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/test/groovy/integration/se/alipsa/accounting/service/ReportServicesTest.groovy
+git commit -m "test: grupperad balansrapport med sektioner och delsummor"
+```
+
+---
+
+### Task 7: Run full build and apply formatting
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Run spotlessApply**
+
+Run: `./gradlew spotlessApply 2>&1 | tail -10`
+
+- [ ] **Step 2: Run full build**
+
+Run: `./gradlew build 2>&1 | tail -30`
+Expected: BUILD SUCCESSFUL — all tests pass, Spotless and CodeNarc clean.
+
+- [ ] **Step 3: Commit any formatting fixes**
+
+If spotlessApply made changes:
+
+```bash
+git add -A
+git commit -m "fixade formattering"
+```
+
+If no changes, skip this step.

--- a/docs/superpowers/specs/2026-04-16-grouped-balance-sheet-design.md
+++ b/docs/superpowers/specs/2026-04-16-grouped-balance-sheet-design.md
@@ -1,0 +1,143 @@
+# Grouped Balance Sheet Design
+
+## Goal
+
+Replace the flat balance sheet report with a properly grouped report following Swedish accounting standards (ÅRL/K2/K3) based on BAS account subgroups. The balance sheet should show a three-level hierarchy: **Section → Subgroup → Individual accounts**, with subtotals at subgroup and section levels, and computed total rows for SUMMA TILLGÅNGAR and SUMMA EGET KAPITAL OCH SKULDER.
+
+## Background
+
+The income statement was recently refactored (PR #27) from a flat two-section layout to a grouped report using `IncomeStatementSection` → `AccountSubgroup` mapping. The balance sheet has the same issues the income statement had before that refactoring:
+
+- Hardcoded Swedish section names in service code and template
+- Flat structure — individual accounts listed under 3 broad sections (Tillgångar/Skulder/Eget kapital)
+- No `AccountSubgroup` usage despite the enum already covering balance-account subgroups (10-29)
+- No subtotals for subgroups
+- Column headers hardcoded
+
+## Architecture
+
+### `BalanceSheetSection` enum
+
+New enum in `se.alipsa.accounting.domain.report`, following the same pattern as `IncomeStatementSection`. Each section maps to a list of `AccountSubgroup` values. Computed sections (totals) have an empty subgroup list.
+
+| Section                        | AccountSubgroups                                                                                             | Computed? |
+|--------------------------------|--------------------------------------------------------------------------------------------------------------|-----------|
+| `FIXED_ASSETS`                 | INTANGIBLE_ASSETS, BUILDINGS_AND_LAND, MACHINERY, FINANCIAL_FIXED_ASSETS                                     | no        |
+| `CURRENT_ASSETS`               | INVENTORY, RECEIVABLES, OTHER_CURRENT_RECEIVABLES, PREPAID_EXPENSES, SHORT_TERM_INVESTMENTS, CASH_AND_BANK   | no        |
+| `TOTAL_ASSETS`                 | —                                                                                                            | yes       |
+| `EQUITY`                       | EQUITY                                                                                                       | no        |
+| `UNTAXED_RESERVES`             | UNTAXED_RESERVES                                                                                             | no        |
+| `PROVISIONS`                   | PROVISIONS                                                                                                   | no        |
+| `LONG_TERM_LIABILITIES`        | LONG_TERM_LIABILITIES                                                                                        | no        |
+| `CURRENT_LIABILITIES`          | SHORT_TERM_LIABILITIES_CREDIT, TAX_LIABILITIES, VAT_AND_EXCISE, PAYROLL_TAXES, OTHER_CURRENT_LIABILITIES, ACCRUED_EXPENSES | no |
+| `TOTAL_EQUITY_AND_LIABILITIES` | —                                                                                                            | yes       |
+
+**Computation formulas:**
+- `TOTAL_ASSETS` = `FIXED_ASSETS` + `CURRENT_ASSETS`
+- `TOTAL_EQUITY_AND_LIABILITIES` = `EQUITY` + `UNTAXED_RESERVES` + `PROVISIONS` + `LONG_TERM_LIABILITIES` + `CURRENT_LIABILITIES`
+
+### `BalanceSheetRow` (rewritten)
+
+Replace the current 4-field class with a 6-field class supporting three row kinds:
+
+```
+String section
+String accountNumber       — null for subgroup subtotal and computed rows
+String accountName         — null for subgroup subtotal and computed rows
+BigDecimal amount
+String subgroupDisplayName — null for account-detail and computed rows
+boolean summaryRow         — true for subgroup subtotals and computed totals
+```
+
+**Row kinds:**
+1. **Account detail row**: `accountNumber` + `accountName` populated, `subgroupDisplayName` = null, `summaryRow` = false
+2. **Subgroup subtotal**: `subgroupDisplayName` populated, `accountNumber`/`accountName` = null, `summaryRow` = true
+3. **Section subtotal / computed total**: `subgroupDisplayName` = null, section display name used as label, `summaryRow` = true
+
+### `buildBalanceSheetReport` rewrite
+
+The method in `ReportDataService` will be rewritten following the income statement pattern but with account-level detail:
+
+1. Load account infos and compute closing balances (opening + movements) — same as today.
+2. Build two maps:
+   - `Map<AccountSubgroup, BigDecimal>` — subgroup totals for subtotal rows
+   - `Map<AccountSubgroup, List<AccountDetail>>` — per-account detail within each subgroup (account number, name, amount)
+3. Iterate `BalanceSheetSection.values()` in declaration order:
+   - **Computed section**: calculate from `sectionTotals` map, emit one summary row.
+   - **Data section**: for each subgroup in the section:
+     - Emit individual account detail rows (sorted by account number)
+     - Emit subgroup subtotal row (if more than one account or if the subgroup total is non-zero)
+     - Accumulate into section sum
+   - Emit section subtotal row
+4. Log warning for ASSET/LIABILITY/EQUITY accounts with null subgroup (same pattern as income statement).
+
+**Summary lines** (displayed in UI preview):
+- `TOTAL_ASSETS.displayName`: formatted total
+- `TOTAL_EQUITY_AND_LIABILITIES.displayName`: formatted total
+
+**Column headers** via i18n keys (same pattern as income statement).
+
+**Template model extras**: `typedRows` (for template styling), `assetTotal`, `equityAndLiabilitiesTotal`.
+
+### Template update (`balance-sheet.ftl`)
+
+- Remove the hardcoded metrics `<div>` block (replace with `<p>${selectionLabel}</p>` like income statement)
+- Use `typedRows[row?index].summaryRow` to apply bold + border styling on subtotal/total rows
+- Column count changes from 4 to 3: Post (item name), Konto (account number, blank for subtotals), Belopp (amount). Or alternatively keep a simpler 2-column layout like the income statement — but since we show individual accounts, 3 columns (Post/Konto, Namn, Belopp) makes more sense. Actually, to keep it clean: the display name column combines subgroup name or account number+name, so we can use the same 2-column layout as income statement (Post, Belopp) with account detail rows showing "  1220 Maskiner och inventarier" as the Post value.
+
+**Decision: 2-column layout** (`Post`, `Belopp`) matching the income statement. Account detail rows show `"accountNumber accountName"` as the post value. Subgroup and section subtotals show the display name. This keeps the two reports consistent.
+
+### i18n
+
+New keys in both `messages.properties` and `messages_sv.properties`:
+
+```properties
+# BalanceSheetSection
+balanceSheetSection.FIXED_ASSETS=Fixed assets / Anläggningstillgångar
+balanceSheetSection.CURRENT_ASSETS=Current assets / Omsättningstillgångar
+balanceSheetSection.TOTAL_ASSETS=Total assets / Summa tillgångar
+balanceSheetSection.EQUITY=Equity / Eget kapital
+balanceSheetSection.UNTAXED_RESERVES=Untaxed reserves / Obeskattade reserver
+balanceSheetSection.PROVISIONS=Provisions / Avsättningar
+balanceSheetSection.LONG_TERM_LIABILITIES=Long-term liabilities / Långfristiga skulder
+balanceSheetSection.CURRENT_LIABILITIES=Current liabilities / Kortfristiga skulder
+balanceSheetSection.TOTAL_EQUITY_AND_LIABILITIES=Total equity and liabilities / Summa eget kapital och skulder
+balanceSheetSection.column.item=Item / Post
+balanceSheetSection.column.amount=Amount / Belopp
+```
+
+(The AccountSubgroup display names already exist from PR #27.)
+
+### `computeSectionResult` for balance sheet
+
+A new private method in `ReportDataService` (or a method on the enum itself) with a switch:
+
+```
+TOTAL_ASSETS = FIXED_ASSETS + CURRENT_ASSETS
+TOTAL_EQUITY_AND_LIABILITIES = EQUITY + UNTAXED_RESERVES + PROVISIONS + LONG_TERM_LIABILITIES + CURRENT_LIABILITIES
+default → throw IllegalStateException
+```
+
+## Testing
+
+- **Unit test**: `BalanceSheetSectionTest` — verify subgroup-to-section mapping, `isComputed()` predicate.
+- **Integration test**: `ReportServicesTest` — new test `balanceSheetProducesGroupedSectionsWithSubtotals`:
+  - Use existing test fixtures (accounts 1510, 2010, 2440, etc. already have `accountSubgroup` set)
+  - Verify sections present, subtotals correct, TOTAL_ASSETS == TOTAL_EQUITY_AND_LIABILITIES
+  - Verify individual account rows appear within their subgroups
+
+## Files changed
+
+- **New**: `BalanceSheetSection.groovy` (domain/report)
+- **Modified**: `BalanceSheetRow.groovy` (add fields)
+- **Modified**: `ReportDataService.groovy` (rewrite `buildBalanceSheetReport`)
+- **Modified**: `balance-sheet.ftl` (grouped layout with conditional styling)
+- **Modified**: `messages.properties` + `messages_sv.properties` (new i18n keys)
+- **Modified**: `ReportServicesTest.groovy` (new/updated balance sheet test)
+- **New** (optional): `BalanceSheetSectionTest.groovy` (unit test for enum)
+
+## Out of scope
+
+- Individual account drill-down or clickable rows
+- Balance sheet comparison (current period vs previous period)
+- Schema changes — the `account_subgroup` column already exists from V18


### PR DESCRIPTION
## Summary

- New `BalanceSheetSection` enum mapping ÅRL sections (Anläggningstillgångar, Omsättningstillgångar, Eget kapital, etc.) to `AccountSubgroup` values, with computed totals for Summa tillgångar and Summa eget kapital och skulder
- Rewrote `buildBalanceSheetReport` in `ReportDataService` to produce a three-level grouped report: **Section → Subgroup → Individual accounts**, with subtotals at each level
- Added `resolveBalanceSheetSubgroup` to handle accounts whose BAS prefix maps to the wrong balance sheet side (e.g., account 2641 ingående moms is ASSET but BAS group 26 maps to CURRENT_LIABILITIES)
- Updated `BalanceSheetRow` with `subgroupDisplayName` and `summaryRow` fields
- Updated `balance-sheet.ftl` template with conditional bold styling for summary rows
- Added i18n keys for all 9 balance sheet sections in both English and Swedish
- Unit tests for `BalanceSheetSection` enum and integration test verifying grouped output with correct subtotals

## Test plan

- [x] `BalanceSheetSectionTest` — subgroup mapping, computed sections, full coverage
- [x] `ReportServicesTest.balanceSheetProducesGroupedSectionsWithSubtotals` — end-to-end grouped report with subtotal verification
- [x] `./gradlew build` passes (compilation, tests, Spotless, CodeNarc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)