### PR TITLE
Overview dashboard panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build
 /.codex
 /.lca/
 /.claude/
+/.superpowers/

--- a/app/src/main/groovy/se/alipsa/accounting/service/VoucherService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/VoucherService.groovy
@@ -10,6 +10,7 @@ import se.alipsa.accounting.domain.VoucherStatus
 
 import java.math.RoundingMode
 import java.sql.Date
+import java.sql.Timestamp
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -301,6 +302,7 @@ final class VoucherService {
   int countVouchers(long companyId, long fiscalYearId) {
     CompanyService.requireValidCompanyId(companyId)
     databaseService.withSql { Sql sql ->
+      requireFiscalYearBelongsToCompany(sql, companyId, fiscalYearId)
       GroovyRowResult row = sql.firstRow('''
           select count(*) as cnt
             from voucher
@@ -312,6 +314,9 @@ final class VoucherService {
     }
   }
 
+  /**
+   * Used by backup freshness checks, so the lookup intentionally spans all fiscal years for the company.
+   */
   boolean hasVouchersCreatedAfter(long companyId, LocalDateTime since) {
     CompanyService.requireValidCompanyId(companyId)
     databaseService.withSql { Sql sql ->
@@ -321,7 +326,7 @@ final class VoucherService {
            where company_id = ?
              and status in ('ACTIVE', 'CORRECTION')
              and created_at > ?
-      ''', [companyId, since])
+      ''', [companyId, Timestamp.valueOf(since)])
       ((Number) row.cnt).intValue() > 0
     }
   }
@@ -448,6 +453,13 @@ final class VoucherService {
     ) as GroovyRowResult
     if (((Number) row.get('total')).intValue() != 1) {
       throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
+    }
+  }
+
+  private static void requireFiscalYearBelongsToCompany(Sql sql, long companyId, long fiscalYearId) {
+    long actualCompanyId = CompanyService.resolveFromFiscalYear(sql, fiscalYearId)
+    if (actualCompanyId != companyId) {
+      throw new IllegalArgumentException("Fiscal year ${fiscalYearId} does not belong to company ${companyId}.")
     }
   }
 

--- a/app/src/main/groovy/se/alipsa/accounting/service/VoucherService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/VoucherService.groovy
@@ -11,6 +11,7 @@ import se.alipsa.accounting.domain.VoucherStatus
 import java.math.RoundingMode
 import java.sql.Date
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 /**
  * Handles safe voucher creation, correction and number allocation.
@@ -294,6 +295,34 @@ final class VoucherService {
         voucher.lines = loadLines(sql, voucher.id)
         voucher
       }
+    }
+  }
+
+  int countVouchers(long companyId, long fiscalYearId) {
+    CompanyService.requireValidCompanyId(companyId)
+    databaseService.withSql { Sql sql ->
+      GroovyRowResult row = sql.firstRow('''
+          select count(*) as cnt
+            from voucher
+           where company_id = ?
+             and fiscal_year_id = ?
+             and status in ('ACTIVE', 'CORRECTION')
+      ''', [companyId, fiscalYearId])
+      ((Number) row.cnt).intValue()
+    }
+  }
+
+  boolean hasVouchersCreatedAfter(long companyId, LocalDateTime since) {
+    CompanyService.requireValidCompanyId(companyId)
+    databaseService.withSql { Sql sql ->
+      GroovyRowResult row = sql.firstRow('''
+          select count(*) as cnt
+            from voucher
+           where company_id = ?
+             and status in ('ACTIVE', 'CORRECTION')
+             and created_at > ?
+      ''', [companyId, since])
+      ((Number) row.cnt).intValue() > 0
     }
   }
 

--- a/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
@@ -148,7 +148,7 @@ final class MainFrame implements PropertyChangeListener {
 
   private JLabel statusLabel
   private JLabel companySummaryLabel
-  private JLabel overviewDescriptionLabel
+  private OverviewPanel overviewPanel
   private JLabel companyLabel
   private JComboBox<Company> companyComboBox
   private JComboBox<FiscalYear> fiscalYearComboBox
@@ -275,9 +275,6 @@ final class MainFrame implements PropertyChangeListener {
     tabbedPane.setTitleAt(5, I18n.instance.getString('mainFrame.tab.fiscalYears'))
     tabbedPane.setTitleAt(6, I18n.instance.getString('mainFrame.tab.system'))
     tabbedPane.setTitleAt(7, I18n.instance.getString('mainFrame.tab.settings'))
-    String overviewTitle = escapeHtml(I18n.instance.getString('mainFrame.tab.overview'))
-    String overviewDesc = escapeHtml(I18n.instance.getString('mainFrame.tab.overview.description'))
-    overviewDescriptionLabel.text = "<html><h2>${overviewTitle}</h2><p>${overviewDesc}</p></html>"
   }
 
   private JFrame buildFrame() {
@@ -312,6 +309,11 @@ final class MainFrame implements PropertyChangeListener {
     } as JFrame
     buildMainTabs().each { Map<String, Object> tab ->
       tabbedPane.addTab(tab.title as String, tab.component as JComponent)
+    }
+    tabbedPane.addChangeListener { javax.swing.event.ChangeEvent ignored ->
+      if (tabbedPane.selectedIndex == 0) {
+        overviewPanel.reload()
+      }
     }
     f.contentPane.add(buildStatusBar(), BorderLayout.SOUTH)
     f
@@ -528,16 +530,14 @@ final class MainFrame implements PropertyChangeListener {
   }
 
   private JPanel buildOverviewPanel() {
-    String safeTitle = escapeHtml(I18n.instance.getString('mainFrame.tab.overview'))
-    String safeDescription = escapeHtml(I18n.instance.getString('mainFrame.tab.overview.description'))
-    swing.panel(border: swing.emptyBorder(24, 24, 24, 24)) {
-      borderLayout()
-      overviewDescriptionLabel = label(
-          text: "<html><h2>${safeTitle}</h2><p>${safeDescription}</p></html>",
-          horizontalAlignment: SwingConstants.CENTER,
-          constraints: BorderLayout.CENTER
-      )
-    } as JPanel
+    overviewPanel = new OverviewPanel(
+        voucherService,
+        accountingPeriodService,
+        backupService,
+        startupVerificationService,
+        activeCompanyManager
+    )
+    overviewPanel
   }
 
   private List<Map<String, Object>> buildMainTabs() {

--- a/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
@@ -311,7 +311,7 @@ final class MainFrame implements PropertyChangeListener {
       tabbedPane.addTab(tab.title as String, tab.component as JComponent)
     }
     tabbedPane.addChangeListener { javax.swing.event.ChangeEvent ignored ->
-      if (tabbedPane.selectedIndex == 0) {
+      if (tabbedPane.selectedComponent == overviewPanel) {
         overviewPanel.reload()
       }
     }

--- a/app/src/main/groovy/se/alipsa/accounting/ui/OverviewPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/OverviewPanel.groovy
@@ -30,6 +30,7 @@ import javax.swing.SwingUtilities
 import javax.swing.UIManager
 import javax.swing.border.EtchedBorder
 
+/** Status dashboard shown on the Overview tab: company, fiscal year, vouchers, periods, backup, integrity. */
 final class OverviewPanel extends JPanel implements PropertyChangeListener {
 
   private static final Color GREY = new Color(108, 117, 125)
@@ -230,26 +231,28 @@ final class OverviewPanel extends JPanel implements PropertyChangeListener {
     add(buildStatGrid(), BorderLayout.CENTER)
   }
 
+  private void styleHeaderLabels() {
+    Font titleFont = companyNameLabel.font.deriveFont(Font.BOLD, 14.0f)
+    Font subtitleFont = companyTitleLabel.font.deriveFont(9.0f)
+    Font detailFont = titleFont.deriveFont(11.0f)
+    companyTitleLabel.foreground = GREY
+    companyTitleLabel.font = subtitleFont
+    companyNameLabel.font = titleFont
+    orgNumberLabel.foreground = GREY
+    orgNumberLabel.font = detailFont
+    fiscalYearTitleLabel.foreground = GREY
+    fiscalYearTitleLabel.font = subtitleFont
+    fiscalYearNameLabel.font = titleFont
+    fiscalYearDetailLabel.font = detailFont
+  }
+
   private JPanel buildHeaderStrip() {
+    styleHeaderLabels()
     JPanel strip = new JPanel(new GridBagLayout())
     strip.border = BorderFactory.createCompoundBorder(
         BorderFactory.createEtchedBorder(EtchedBorder.LOWERED),
         BorderFactory.createEmptyBorder(10, 14, 10, 14)
     )
-
-    Font titleFont = companyNameLabel.font.deriveFont(Font.BOLD, 14.0f)
-    Font subtitleFont = companyTitleLabel.font.deriveFont(9.0f)
-
-    companyTitleLabel.foreground = GREY
-    companyTitleLabel.font = subtitleFont
-    companyNameLabel.font = titleFont
-    orgNumberLabel.foreground = GREY
-    orgNumberLabel.font = companyNameLabel.font.deriveFont(11.0f)
-
-    fiscalYearTitleLabel.foreground = GREY
-    fiscalYearTitleLabel.font = subtitleFont
-    fiscalYearNameLabel.font = titleFont
-    fiscalYearDetailLabel.font = companyNameLabel.font.deriveFont(11.0f)
 
     GridBagConstraints gbc = new GridBagConstraints()
     gbc.anchor = GridBagConstraints.WEST

--- a/app/src/main/groovy/se/alipsa/accounting/ui/OverviewPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/OverviewPanel.groovy
@@ -20,23 +20,28 @@ import java.awt.Insets
 import java.beans.PropertyChangeEvent
 import java.beans.PropertyChangeListener
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
+import java.util.concurrent.ExecutionException
 
 import javax.swing.BorderFactory
 import javax.swing.JLabel
 import javax.swing.JPanel
 import javax.swing.JSeparator
 import javax.swing.SwingUtilities
+import javax.swing.SwingWorker
 import javax.swing.UIManager
 import javax.swing.border.EtchedBorder
 
 /** Status dashboard shown on the Overview tab: company, fiscal year, vouchers, periods, backup, integrity. */
 final class OverviewPanel extends JPanel implements PropertyChangeListener {
 
+  private static final String LOCALE_PROPERTY = 'locale'
   private static final Color GREY = new Color(108, 117, 125)
   private static final Color RED = new Color(220, 53, 69)
   private static final Color GREEN = new Color(25, 135, 84)
   private static final int BACKUP_WARN_DAYS = 60
+  private static final DateTimeFormatter BACKUP_DATE_FORMATTER = DateTimeFormatter.ofPattern('yyyy-MM-dd HH:mm')
 
   private final VoucherService voucherService
   private final AccountingPeriodService accountingPeriodService
@@ -45,7 +50,11 @@ final class OverviewPanel extends JPanel implements PropertyChangeListener {
   private final ActiveCompanyManager activeCompanyManager
 
   private boolean integrityChecked = false
+  private boolean integrityCheckStarted = false
   private boolean integrityOk = false
+  private boolean listenersRegistered = false
+  private int reloadRequestId = 0
+  private OverviewSnapshot currentSnapshot = OverviewSnapshot.empty()
 
   // Header strip labels
   private final JLabel companyTitleLabel = new JLabel()
@@ -83,25 +92,111 @@ final class OverviewPanel extends JPanel implements PropertyChangeListener {
     this.backupService = backupService
     this.startupVerificationService = startupVerificationService
     this.activeCompanyManager = activeCompanyManager
-    I18n.instance.addLocaleChangeListener(this)
-    activeCompanyManager.addPropertyChangeListener(this)
+    registerListeners()
     buildUi()
-    reload()
+    applyLocale()
+    renderSnapshot()
+    SwingUtilities.invokeLater { reload() }
+  }
+
+  @Override
+  void addNotify() {
+    super.addNotify()
+    registerListeners()
+  }
+
+  @Override
+  void removeNotify() {
+    unregisterListeners()
+    super.removeNotify()
   }
 
   @Override
   void propertyChange(PropertyChangeEvent evt) {
-    if ('locale' == evt.propertyName) {
-      SwingUtilities.invokeLater { reload() }
-    } else if (ActiveCompanyManager.COMPANY_ID_PROPERTY == evt.propertyName) {
+    if (LOCALE_PROPERTY == evt.propertyName) {
+      SwingUtilities.invokeLater {
+        applyLocale()
+        renderSnapshot()
+      }
+    } else if (ActiveCompanyManager.COMPANY_ID_PROPERTY == evt.propertyName
+        || ActiveCompanyManager.FISCAL_YEAR_PROPERTY == evt.propertyName) {
       SwingUtilities.invokeLater { reload() }
     }
   }
 
   void reload() {
+    if (!SwingUtilities.isEventDispatchThread()) {
+      SwingUtilities.invokeLater { reload() }
+      return
+    }
+
     applyLocale()
+    final int requestId = ++reloadRequestId
     Company company = activeCompanyManager.activeCompany
     FiscalYear fiscalYear = activeCompanyManager.fiscalYear
+
+    if (company == null) {
+      currentSnapshot = OverviewSnapshot.withoutCompany(currentIntegrityStatus())
+      renderSnapshot()
+      return
+    }
+
+    if (fiscalYear == null) {
+      currentSnapshot = OverviewSnapshot.withoutFiscalYear(company, currentIntegrityStatus())
+      renderSnapshot()
+      return
+    }
+
+    currentSnapshot = OverviewSnapshot.loading(company, fiscalYear, currentIntegrityStatus())
+    renderSnapshot()
+
+    final boolean runIntegrityCheck = !integrityChecked && !integrityCheckStarted
+    if (runIntegrityCheck) {
+      integrityCheckStarted = true
+    }
+
+    new SwingWorker<OverviewSnapshot, Void>() {
+      @Override
+      protected OverviewSnapshot doInBackground() {
+        int count = voucherService.countVouchers(company.id, fiscalYear.id)
+        List<AccountingPeriod> periods = accountingPeriodService.listPeriods(fiscalYear.id)
+        int locked = periods.count { AccountingPeriod period -> period.locked } as int
+        List<BackupSummary> backups = backupService.listBackups(1)
+        BackupSummary latestBackup = backups.isEmpty() ? null : backups.first()
+        boolean warn = latestBackup != null && hasStaleBackupWithNewVouchers(company.id, latestBackup.createdAt)
+        Boolean loadedIntegrity = runIntegrityCheck ? startupVerificationService.verify().ok : currentIntegrityStatus()
+        new OverviewSnapshot(company, fiscalYear, count, locked, periods.size(), latestBackup?.createdAt, warn, loadedIntegrity)
+      }
+
+      @Override
+      protected void done() {
+        try {
+          OverviewSnapshot snapshot = get()
+          if (requestId != reloadRequestId) {
+            return
+          }
+          currentSnapshot = snapshot
+          if (runIntegrityCheck && snapshot.integrityOk != null) {
+            integrityOk = snapshot.integrityOk
+            integrityChecked = true
+          }
+          renderSnapshot()
+        } catch (InterruptedException exception) {
+          Thread.currentThread().interrupt()
+        } catch (ExecutionException ignored) {
+          // Keep the last rendered state and allow a future reload to retry.
+        } finally {
+          if (runIntegrityCheck) {
+            integrityCheckStarted = false
+          }
+        }
+      }
+    }.execute()
+  }
+
+  private void renderSnapshot() {
+    Company company = currentSnapshot.company
+    FiscalYear fiscalYear = currentSnapshot.fiscalYear
 
     if (company == null) {
       clearStatCards()
@@ -109,6 +204,7 @@ final class OverviewPanel extends JPanel implements PropertyChangeListener {
       orgNumberLabel.text = ''
       fiscalYearNameLabel.text = I18n.instance.getString('overviewPanel.card.noData')
       fiscalYearDetailLabel.text = ''
+      updateIntegrityCard(currentSnapshot.integrityOk)
       return
     }
 
@@ -119,6 +215,7 @@ final class OverviewPanel extends JPanel implements PropertyChangeListener {
       fiscalYearNameLabel.text = I18n.instance.getString('overviewPanel.card.noData')
       fiscalYearDetailLabel.text = ''
       clearStatCards()
+      updateIntegrityCard(currentSnapshot.integrityOk)
       return
     }
 
@@ -133,39 +230,31 @@ final class OverviewPanel extends JPanel implements PropertyChangeListener {
     }
     fiscalYearDetailLabel.text = "${fiscalYear.startDate} \u2013 ${fiscalYear.endDate}  \u00b7  ${statusText}"
 
-    // Vouchers
-    int count = voucherService.countVouchers(company.id, fiscalYear.id)
-    voucherValueLabel.text = String.valueOf(count)
+    if (currentSnapshot.voucherCount == null) {
+      clearStatCards()
+      updateIntegrityCard(currentSnapshot.integrityOk)
+      return
+    }
+
+    voucherValueLabel.text = String.valueOf(currentSnapshot.voucherCount)
     voucherSubLabel.text = I18n.instance.getString('overviewPanel.card.vouchers.subtitle')
 
-    // Accounting periods
-    List<AccountingPeriod> periods = accountingPeriodService.listPeriods(fiscalYear.id)
-    int locked = periods.count { AccountingPeriod p -> p.locked } as int
-    int total = periods.size()
-    periodsValueLabel.text = "${locked} / ${total}"
+    periodsValueLabel.text = "${currentSnapshot.lockedPeriods} / ${currentSnapshot.totalPeriods}"
     periodsSubLabel.text = I18n.instance.getString('overviewPanel.card.periods.subtitle')
 
-    // Backup
-    updateBackupCard(company.id)
-
-    // Integrity — run once per session
-    if (!integrityChecked) {
-      integrityOk = startupVerificationService.verify().ok
-      integrityChecked = true
-    }
-    updateIntegrityCard()
+    updateBackupCard(currentSnapshot.backupCreatedAt, currentSnapshot.backupWarn)
+    updateIntegrityCard(currentSnapshot.integrityOk)
   }
 
-  private void updateBackupCard(long companyId) {
-    List<BackupSummary> backups = backupService.listBackups(1)
-    if (backups.isEmpty()) {
+  private void updateBackupCard(LocalDateTime createdAt, boolean warn) {
+    if (createdAt == null) {
       backupValueLabel.text = I18n.instance.getString('overviewPanel.card.backup.never')
       backupValueLabel.foreground = GREY
       backupSubLabel.text = ''
+      backupSubLabel.foreground = GREY
       return
     }
-    BackupSummary latest = backups.first()
-    LocalDateTime createdAt = latest.createdAt
+
     LocalDateTime now = LocalDateTime.now()
     long daysAgo = ChronoUnit.DAYS.between(createdAt, now)
 
@@ -178,9 +267,7 @@ final class OverviewPanel extends JPanel implements PropertyChangeListener {
       ageText = I18n.instance.format('overviewPanel.card.backup.daysAgo', daysAgo)
     }
 
-    boolean warn = daysAgo > BACKUP_WARN_DAYS && voucherService.hasVouchersCreatedAfter(companyId, createdAt)
-
-    String dateText = createdAt.toString().replace('T', ' ').substring(0, 16)
+    String dateText = BACKUP_DATE_FORMATTER.format(createdAt)
     if (warn) {
       backupValueLabel.foreground = RED
       backupSubLabel.foreground = RED
@@ -192,9 +279,12 @@ final class OverviewPanel extends JPanel implements PropertyChangeListener {
     backupSubLabel.text = ageText
   }
 
-  private void updateIntegrityCard() {
+  private void updateIntegrityCard(Boolean value) {
     integritySubLabel.text = I18n.instance.getString('overviewPanel.card.integrity.subtitle')
-    if (integrityOk) {
+    if (value == null) {
+      integrityValueLabel.text = I18n.instance.getString('overviewPanel.card.noData')
+      integrityValueLabel.foreground = UIManager.getColor('Label.foreground') ?: Color.BLACK
+    } else if (value) {
       integrityValueLabel.text = I18n.instance.getString('overviewPanel.card.integrity.ok')
       integrityValueLabel.foreground = GREEN
     } else {
@@ -222,6 +312,33 @@ final class OverviewPanel extends JPanel implements PropertyChangeListener {
     periodsCardTitle.text = I18n.instance.getString('overviewPanel.card.periods').toUpperCase(locale)
     backupCardTitle.text = I18n.instance.getString('overviewPanel.card.backup').toUpperCase(locale)
     integrityCardTitle.text = I18n.instance.getString('overviewPanel.card.integrity').toUpperCase(locale)
+  }
+
+  private Boolean currentIntegrityStatus() {
+    integrityChecked ? integrityOk : null
+  }
+
+  private boolean hasStaleBackupWithNewVouchers(long companyId, LocalDateTime createdAt) {
+    long daysAgo = ChronoUnit.DAYS.between(createdAt, LocalDateTime.now())
+    daysAgo > BACKUP_WARN_DAYS && voucherService.hasVouchersCreatedAfter(companyId, createdAt)
+  }
+
+  private void registerListeners() {
+    if (listenersRegistered) {
+      return
+    }
+    I18n.instance.addLocaleChangeListener(this)
+    activeCompanyManager.addPropertyChangeListener(this)
+    listenersRegistered = true
+  }
+
+  private void unregisterListeners() {
+    if (!listenersRegistered) {
+      return
+    }
+    I18n.instance.removeLocaleChangeListener(this)
+    activeCompanyManager.removePropertyChangeListener(this)
+    listenersRegistered = false
   }
 
   private void buildUi() {
@@ -320,5 +437,53 @@ final class OverviewPanel extends JPanel implements PropertyChangeListener {
     card.add(valueLabel)
     card.add(subLabel)
     card
+  }
+
+  private static final class OverviewSnapshot {
+
+    final Company company
+    final FiscalYear fiscalYear
+    final Integer voucherCount
+    final int lockedPeriods
+    final int totalPeriods
+    final LocalDateTime backupCreatedAt
+    final boolean backupWarn
+    final Boolean integrityOk
+
+    OverviewSnapshot(
+        Company company,
+        FiscalYear fiscalYear,
+        Integer voucherCount,
+        int lockedPeriods,
+        int totalPeriods,
+        LocalDateTime backupCreatedAt,
+        boolean backupWarn,
+        Boolean integrityOk
+    ) {
+      this.company = company
+      this.fiscalYear = fiscalYear
+      this.voucherCount = voucherCount
+      this.lockedPeriods = lockedPeriods
+      this.totalPeriods = totalPeriods
+      this.backupCreatedAt = backupCreatedAt
+      this.backupWarn = backupWarn
+      this.integrityOk = integrityOk
+    }
+
+    static OverviewSnapshot empty() {
+      new OverviewSnapshot(null, null, null, 0, 0, null, false, null)
+    }
+
+    static OverviewSnapshot withoutCompany(Boolean integrityOk) {
+      new OverviewSnapshot(null, null, null, 0, 0, null, false, integrityOk)
+    }
+
+    static OverviewSnapshot withoutFiscalYear(Company company, Boolean integrityOk) {
+      new OverviewSnapshot(company, null, null, 0, 0, null, false, integrityOk)
+    }
+
+    static OverviewSnapshot loading(Company company, FiscalYear fiscalYear, Boolean integrityOk) {
+      new OverviewSnapshot(company, fiscalYear, null, 0, 0, null, false, integrityOk)
+    }
   }
 }

--- a/app/src/main/groovy/se/alipsa/accounting/ui/OverviewPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/OverviewPanel.groovy
@@ -1,0 +1,321 @@
+package se.alipsa.accounting.ui
+
+import se.alipsa.accounting.domain.AccountingPeriod
+import se.alipsa.accounting.domain.Company
+import se.alipsa.accounting.domain.FiscalYear
+import se.alipsa.accounting.service.AccountingPeriodService
+import se.alipsa.accounting.service.BackupService
+import se.alipsa.accounting.service.BackupSummary
+import se.alipsa.accounting.service.StartupVerificationService
+import se.alipsa.accounting.service.VoucherService
+import se.alipsa.accounting.support.I18n
+
+import java.awt.BorderLayout
+import java.awt.Color
+import java.awt.Font
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.GridLayout
+import java.awt.Insets
+import java.beans.PropertyChangeEvent
+import java.beans.PropertyChangeListener
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+import javax.swing.BorderFactory
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JSeparator
+import javax.swing.SwingUtilities
+import javax.swing.UIManager
+import javax.swing.border.EtchedBorder
+
+final class OverviewPanel extends JPanel implements PropertyChangeListener {
+
+  private static final Color GREY = new Color(108, 117, 125)
+  private static final Color RED = new Color(220, 53, 69)
+  private static final Color GREEN = new Color(25, 135, 84)
+  private static final int BACKUP_WARN_DAYS = 60
+
+  private final VoucherService voucherService
+  private final AccountingPeriodService accountingPeriodService
+  private final BackupService backupService
+  private final StartupVerificationService startupVerificationService
+  private final ActiveCompanyManager activeCompanyManager
+
+  private boolean integrityChecked = false
+  private boolean integrityOk = false
+
+  // Header strip labels
+  private final JLabel companyTitleLabel = new JLabel()
+  private final JLabel companyNameLabel = new JLabel()
+  private final JLabel orgNumberLabel = new JLabel()
+  private final JLabel fiscalYearTitleLabel = new JLabel()
+  private final JLabel fiscalYearNameLabel = new JLabel()
+  private final JLabel fiscalYearDetailLabel = new JLabel()
+
+  // Stat card title labels
+  private final JLabel voucherCardTitle = new JLabel()
+  private final JLabel periodsCardTitle = new JLabel()
+  private final JLabel backupCardTitle = new JLabel()
+  private final JLabel integrityCardTitle = new JLabel()
+
+  // Stat card value labels
+  private final JLabel voucherValueLabel = new JLabel()
+  private final JLabel voucherSubLabel = new JLabel()
+  private final JLabel periodsValueLabel = new JLabel()
+  private final JLabel periodsSubLabel = new JLabel()
+  private final JLabel backupValueLabel = new JLabel()
+  private final JLabel backupSubLabel = new JLabel()
+  private final JLabel integrityValueLabel = new JLabel()
+  private final JLabel integritySubLabel = new JLabel()
+
+  OverviewPanel(
+      VoucherService voucherService,
+      AccountingPeriodService accountingPeriodService,
+      BackupService backupService,
+      StartupVerificationService startupVerificationService,
+      ActiveCompanyManager activeCompanyManager
+  ) {
+    this.voucherService = voucherService
+    this.accountingPeriodService = accountingPeriodService
+    this.backupService = backupService
+    this.startupVerificationService = startupVerificationService
+    this.activeCompanyManager = activeCompanyManager
+    I18n.instance.addLocaleChangeListener(this)
+    activeCompanyManager.addPropertyChangeListener(this)
+    buildUi()
+    reload()
+  }
+
+  @Override
+  void propertyChange(PropertyChangeEvent evt) {
+    if ('locale' == evt.propertyName) {
+      SwingUtilities.invokeLater { reload() }
+    } else if (ActiveCompanyManager.COMPANY_ID_PROPERTY == evt.propertyName) {
+      SwingUtilities.invokeLater { reload() }
+    }
+  }
+
+  void reload() {
+    applyLocale()
+    Company company = activeCompanyManager.activeCompany
+    FiscalYear fiscalYear = activeCompanyManager.fiscalYear
+
+    if (company == null) {
+      clearStatCards()
+      companyNameLabel.text = I18n.instance.getString('overviewPanel.card.noData')
+      orgNumberLabel.text = ''
+      fiscalYearNameLabel.text = I18n.instance.getString('overviewPanel.card.noData')
+      fiscalYearDetailLabel.text = ''
+      return
+    }
+
+    companyNameLabel.text = company.companyName ?: ''
+    orgNumberLabel.text = company.organizationNumber ?: ''
+
+    if (fiscalYear == null) {
+      fiscalYearNameLabel.text = I18n.instance.getString('overviewPanel.card.noData')
+      fiscalYearDetailLabel.text = ''
+      clearStatCards()
+      return
+    }
+
+    fiscalYearNameLabel.text = fiscalYear.name ?: ''
+    String statusText
+    if (fiscalYear.closed) {
+      statusText = I18n.instance.getString('overviewPanel.status.closed')
+      fiscalYearDetailLabel.foreground = GREY
+    } else {
+      statusText = I18n.instance.getString('overviewPanel.status.open')
+      fiscalYearDetailLabel.foreground = GREEN
+    }
+    fiscalYearDetailLabel.text = "${fiscalYear.startDate} \u2013 ${fiscalYear.endDate}  \u00b7  ${statusText}"
+
+    // Vouchers
+    int count = voucherService.countVouchers(company.id, fiscalYear.id)
+    voucherValueLabel.text = String.valueOf(count)
+    voucherSubLabel.text = I18n.instance.getString('overviewPanel.card.vouchers.subtitle')
+
+    // Accounting periods
+    List<AccountingPeriod> periods = accountingPeriodService.listPeriods(fiscalYear.id)
+    int locked = periods.count { AccountingPeriod p -> p.locked } as int
+    int total = periods.size()
+    periodsValueLabel.text = "${locked} / ${total}"
+    periodsSubLabel.text = I18n.instance.getString('overviewPanel.card.periods.subtitle')
+
+    // Backup
+    updateBackupCard(company.id)
+
+    // Integrity — run once per session
+    if (!integrityChecked) {
+      integrityOk = startupVerificationService.verify().ok
+      integrityChecked = true
+    }
+    updateIntegrityCard()
+  }
+
+  private void updateBackupCard(long companyId) {
+    List<BackupSummary> backups = backupService.listBackups(1)
+    if (backups.isEmpty()) {
+      backupValueLabel.text = I18n.instance.getString('overviewPanel.card.backup.never')
+      backupValueLabel.foreground = GREY
+      backupSubLabel.text = ''
+      return
+    }
+    BackupSummary latest = backups.first()
+    LocalDateTime createdAt = latest.createdAt
+    LocalDateTime now = LocalDateTime.now()
+    long daysAgo = ChronoUnit.DAYS.between(createdAt, now)
+
+    String ageText
+    if (daysAgo == 0) {
+      ageText = I18n.instance.getString('overviewPanel.card.backup.today')
+    } else if (daysAgo == 1) {
+      ageText = I18n.instance.getString('overviewPanel.card.backup.yesterday')
+    } else {
+      ageText = I18n.instance.format('overviewPanel.card.backup.daysAgo', daysAgo)
+    }
+
+    boolean warn = daysAgo > BACKUP_WARN_DAYS && voucherService.hasVouchersCreatedAfter(companyId, createdAt)
+
+    String dateText = createdAt.toString().replace('T', ' ').substring(0, 16)
+    if (warn) {
+      backupValueLabel.foreground = RED
+      backupSubLabel.foreground = RED
+    } else {
+      backupValueLabel.foreground = UIManager.getColor('Label.foreground') ?: Color.BLACK
+      backupSubLabel.foreground = GREY
+    }
+    backupValueLabel.text = dateText
+    backupSubLabel.text = ageText
+  }
+
+  private void updateIntegrityCard() {
+    integritySubLabel.text = I18n.instance.getString('overviewPanel.card.integrity.subtitle')
+    if (integrityOk) {
+      integrityValueLabel.text = I18n.instance.getString('overviewPanel.card.integrity.ok')
+      integrityValueLabel.foreground = GREEN
+    } else {
+      integrityValueLabel.text = I18n.instance.getString('overviewPanel.card.integrity.failed')
+      integrityValueLabel.foreground = RED
+    }
+  }
+
+  private void clearStatCards() {
+    String dash = I18n.instance.getString('overviewPanel.card.noData')
+    [voucherValueLabel, periodsValueLabel, backupValueLabel, integrityValueLabel].each { JLabel l ->
+      l.text = dash
+      l.foreground = UIManager.getColor('Label.foreground') ?: Color.BLACK
+    }
+    [voucherSubLabel, periodsSubLabel, backupSubLabel, integritySubLabel].each { JLabel l ->
+      l.text = ''
+    }
+  }
+
+  private void applyLocale() {
+    Locale locale = I18n.instance.locale
+    companyTitleLabel.text = I18n.instance.getString('overviewPanel.header.company').toUpperCase(locale)
+    fiscalYearTitleLabel.text = I18n.instance.getString('overviewPanel.header.fiscalYear').toUpperCase(locale)
+    voucherCardTitle.text = I18n.instance.getString('overviewPanel.card.vouchers').toUpperCase(locale)
+    periodsCardTitle.text = I18n.instance.getString('overviewPanel.card.periods').toUpperCase(locale)
+    backupCardTitle.text = I18n.instance.getString('overviewPanel.card.backup').toUpperCase(locale)
+    integrityCardTitle.text = I18n.instance.getString('overviewPanel.card.integrity').toUpperCase(locale)
+  }
+
+  private void buildUi() {
+    setLayout(new BorderLayout(0, 12))
+    setBorder(BorderFactory.createEmptyBorder(16, 16, 16, 16))
+    add(buildHeaderStrip(), BorderLayout.NORTH)
+    add(buildStatGrid(), BorderLayout.CENTER)
+  }
+
+  private JPanel buildHeaderStrip() {
+    JPanel strip = new JPanel(new GridBagLayout())
+    strip.border = BorderFactory.createCompoundBorder(
+        BorderFactory.createEtchedBorder(EtchedBorder.LOWERED),
+        BorderFactory.createEmptyBorder(10, 14, 10, 14)
+    )
+
+    Font titleFont = companyNameLabel.font.deriveFont(Font.BOLD, 14.0f)
+    Font subtitleFont = companyTitleLabel.font.deriveFont(9.0f)
+
+    companyTitleLabel.foreground = GREY
+    companyTitleLabel.font = subtitleFont
+    companyNameLabel.font = titleFont
+    orgNumberLabel.foreground = GREY
+    orgNumberLabel.font = companyNameLabel.font.deriveFont(11.0f)
+
+    fiscalYearTitleLabel.foreground = GREY
+    fiscalYearTitleLabel.font = subtitleFont
+    fiscalYearNameLabel.font = titleFont
+    fiscalYearDetailLabel.font = companyNameLabel.font.deriveFont(11.0f)
+
+    GridBagConstraints gbc = new GridBagConstraints()
+    gbc.anchor = GridBagConstraints.WEST
+    gbc.fill = GridBagConstraints.BOTH
+
+    // Company column
+    JPanel companyPanel = new JPanel(new GridLayout(3, 1, 0, 2))
+    companyPanel.opaque = false
+    companyPanel.add(companyTitleLabel)
+    companyPanel.add(companyNameLabel)
+    companyPanel.add(orgNumberLabel)
+
+    gbc.gridx = 0
+    gbc.gridy = 0
+    gbc.weightx = 1.0
+    gbc.weighty = 1.0
+    gbc.insets = new Insets(0, 0, 0, 0)
+    strip.add(companyPanel, gbc)
+
+    // Vertical separator
+    JSeparator sep = new JSeparator(JSeparator.VERTICAL)
+    gbc.gridx = 1
+    gbc.weightx = 0.0
+    gbc.fill = GridBagConstraints.VERTICAL
+    gbc.insets = new Insets(0, 16, 0, 16)
+    strip.add(sep, gbc)
+
+    // Fiscal year column
+    JPanel fyPanel = new JPanel(new GridLayout(3, 1, 0, 2))
+    fyPanel.opaque = false
+    fyPanel.add(fiscalYearTitleLabel)
+    fyPanel.add(fiscalYearNameLabel)
+    fyPanel.add(fiscalYearDetailLabel)
+
+    gbc.gridx = 2
+    gbc.weightx = 1.0
+    gbc.fill = GridBagConstraints.BOTH
+    gbc.insets = new Insets(0, 0, 0, 0)
+    strip.add(fyPanel, gbc)
+
+    strip
+  }
+
+  private JPanel buildStatGrid() {
+    JPanel grid = new JPanel(new GridLayout(2, 2, 8, 8))
+    grid.add(buildStatCard(voucherCardTitle, voucherValueLabel, voucherSubLabel, 22.0f))
+    grid.add(buildStatCard(periodsCardTitle, periodsValueLabel, periodsSubLabel, 22.0f))
+    grid.add(buildStatCard(backupCardTitle, backupValueLabel, backupSubLabel, 13.0f))
+    grid.add(buildStatCard(integrityCardTitle, integrityValueLabel, integritySubLabel, 13.0f))
+    grid
+  }
+
+  private static JPanel buildStatCard(JLabel titleLabel, JLabel valueLabel, JLabel subLabel, float valueFontSize) {
+    JPanel card = new JPanel(new GridLayout(3, 1, 0, 2))
+    card.border = BorderFactory.createCompoundBorder(
+        BorderFactory.createEtchedBorder(EtchedBorder.LOWERED),
+        BorderFactory.createEmptyBorder(8, 12, 8, 12)
+    )
+    titleLabel.foreground = GREY
+    titleLabel.font = titleLabel.font.deriveFont(9.0f)
+    valueLabel.font = valueLabel.font.deriveFont(Font.BOLD, valueFontSize)
+    subLabel.font = subLabel.font.deriveFont(10.0f)
+    subLabel.foreground = GREY
+    card.add(titleLabel)
+    card.add(valueLabel)
+    card.add(subLabel)
+    card
+  }
+}

--- a/app/src/main/resources/i18n/messages.properties
+++ b/app/src/main/resources/i18n/messages.properties
@@ -197,7 +197,6 @@ mainFrame.menu.help.reportIssue=Report issue...
 mainFrame.menu.help.about=About
 mainFrame.issueTracker.error=Could not open the issue tracker in the browser.
 mainFrame.tab.overview=Overview
-mainFrame.tab.overview.description=Overview and status for accounting will be shown here.
 mainFrame.tab.vouchers=Vouchers
 mainFrame.tab.vat=VAT
 mainFrame.tab.reports=Reports
@@ -205,6 +204,27 @@ mainFrame.tab.chartOfAccounts=Chart of accounts
 mainFrame.tab.fiscalYears=Fiscal years
 mainFrame.tab.system=System
 mainFrame.tab.settings=Settings
+
+# OverviewPanel
+overviewPanel.header.company=Company
+overviewPanel.header.fiscalYear=Current Fiscal Year
+overviewPanel.status.open=Open
+overviewPanel.status.closed=Closed
+overviewPanel.card.vouchers=Vouchers
+overviewPanel.card.vouchers.subtitle=active this year
+overviewPanel.card.periods=Accounting Periods
+overviewPanel.card.periods.subtitle=locked
+overviewPanel.card.backup=Last Backup
+overviewPanel.card.backup.today=today
+overviewPanel.card.backup.yesterday=yesterday
+overviewPanel.card.backup.daysAgo={0} days ago
+overviewPanel.card.backup.never=Never
+overviewPanel.card.integrity=Integrity
+overviewPanel.card.integrity.ok=\u2713 OK
+overviewPanel.card.integrity.failed=\u2717 Failed
+overviewPanel.card.integrity.subtitle=verified at startup
+overviewPanel.card.noData=\u2014
+
 mainFrame.button.editCompanySettings=Edit company settings
 mainFrame.button.updateAvailable=⬆ Update available
 mainFrame.button.updateVersion=⬆ Update to {0}

--- a/app/src/main/resources/i18n/messages_sv.properties
+++ b/app/src/main/resources/i18n/messages_sv.properties
@@ -197,7 +197,6 @@ mainFrame.menu.help.reportIssue=Rapportera fel...
 mainFrame.menu.help.about=Om
 mainFrame.issueTracker.error=Kunde inte öppna felrapporteringssidan i webbläsaren.
 mainFrame.tab.overview=Översikt
-mainFrame.tab.overview.description=Översikt och status för bokföringen kommer här.
 mainFrame.tab.vouchers=Verifikationer
 mainFrame.tab.vat=Moms
 mainFrame.tab.reports=Rapporter
@@ -205,6 +204,27 @@ mainFrame.tab.chartOfAccounts=Kontoplan
 mainFrame.tab.fiscalYears=Räkenskapsår
 mainFrame.tab.system=System
 mainFrame.tab.settings=Inställningar
+
+# OverviewPanel
+overviewPanel.header.company=F\u00f6retag
+overviewPanel.header.fiscalYear=Aktuellt r\u00e4kenskaps\u00e5r
+overviewPanel.status.open=\u00d6ppen
+overviewPanel.status.closed=St\u00e4ngd
+overviewPanel.card.vouchers=Verifikationer
+overviewPanel.card.vouchers.subtitle=aktiva detta \u00e5r
+overviewPanel.card.periods=Bokf\u00f6ringsperioder
+overviewPanel.card.periods.subtitle=l\u00e5sta
+overviewPanel.card.backup=Senaste s\u00e4kerhetskopia
+overviewPanel.card.backup.today=idag
+overviewPanel.card.backup.yesterday=ig\u00e5r
+overviewPanel.card.backup.daysAgo={0} dagar sedan
+overviewPanel.card.backup.never=Aldrig
+overviewPanel.card.integrity=Integritet
+overviewPanel.card.integrity.ok=\u2713 OK
+overviewPanel.card.integrity.failed=\u2717 Misslyckades
+overviewPanel.card.integrity.subtitle=verifierad vid start
+overviewPanel.card.noData=\u2014
+
 mainFrame.button.editCompanySettings=Redigera företagsuppgifter
 mainFrame.button.updateAvailable=⬆ Uppdatering tillgänglig
 mainFrame.button.updateVersion=⬆ Uppdatera till {0}

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/VoucherServiceCountTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/VoucherServiceCountTest.groovy
@@ -2,6 +2,7 @@ package se.alipsa.accounting.service
 
 import static org.junit.jupiter.api.Assertions.assertEquals
 import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertThrows
 import static org.junit.jupiter.api.Assertions.assertTrue
 
 import groovy.sql.Sql
@@ -120,5 +121,14 @@ class VoucherServiceCountTest {
 
     LocalDateTime future = LocalDateTime.now().plusSeconds(5)
     assertFalse(voucherService.hasVouchersCreatedAfter(CompanyService.LEGACY_COMPANY_ID, future))
+  }
+
+  @Test
+  void countVouchersRejectsUnknownFiscalYear() {
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException) {
+      voucherService.countVouchers(CompanyService.LEGACY_COMPANY_ID, Long.MAX_VALUE)
+    }
+
+    assertEquals("Okänt räkenskapsår: ${Long.MAX_VALUE}", exception.message)
   }
 }

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/VoucherServiceCountTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/VoucherServiceCountTest.groovy
@@ -1,0 +1,124 @@
+package se.alipsa.accounting.service
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+import groovy.sql.Sql
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+import se.alipsa.accounting.domain.FiscalYear
+import se.alipsa.accounting.domain.VoucherLine
+import se.alipsa.accounting.support.AppPaths
+
+import java.nio.file.Path
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class VoucherServiceCountTest {
+
+  @TempDir
+  Path tempDir
+
+  private DatabaseService databaseService
+  private AuditLogService auditLogService
+  private AccountingPeriodService accountingPeriodService
+  private FiscalYearService fiscalYearService
+  private VoucherService voucherService
+  private String previousHome
+
+  @BeforeEach
+  void setUp() {
+    previousHome = System.getProperty(AppPaths.HOME_OVERRIDE_PROPERTY)
+    System.setProperty(AppPaths.HOME_OVERRIDE_PROPERTY, tempDir.toString())
+    databaseService = DatabaseService.newForTesting()
+    databaseService.initialize()
+    auditLogService = new AuditLogService(databaseService)
+    accountingPeriodService = new AccountingPeriodService(databaseService, auditLogService)
+    fiscalYearService = new FiscalYearService(databaseService, accountingPeriodService, auditLogService)
+    voucherService = new VoucherService(databaseService, auditLogService)
+    seedAccounts()
+  }
+
+  private void seedAccounts() {
+    databaseService.withTransaction { Sql sql ->
+      [
+          ['1930', 'Bank', 'ASSET', 'DEBIT'],
+          ['3010', 'Income', 'INCOME', 'CREDIT']
+      ].each { List<String> row ->
+        sql.executeInsert('''
+            insert into account (
+                company_id, account_number, account_name, account_class,
+                normal_balance_side, vat_code, active, manual_review_required,
+                classification_note, created_at, updated_at
+            ) values (1, ?, ?, ?, ?, null, true, false, null, current_timestamp, current_timestamp)
+        ''', [row[0], row[1], row[2], row[3]])
+      }
+    }
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (previousHome == null) {
+      System.clearProperty(AppPaths.HOME_OVERRIDE_PROPERTY)
+    } else {
+      System.setProperty(AppPaths.HOME_OVERRIDE_PROPERTY, previousHome)
+    }
+  }
+
+  @Test
+  void countVouchersReturnsZeroForEmptyYear() {
+    FiscalYear year = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID, '2025', LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31))
+
+    assertEquals(0, voucherService.countVouchers(CompanyService.LEGACY_COMPANY_ID, year.id))
+  }
+
+  @Test
+  void countVouchersCountsActiveAndCorrectionVouchers() {
+    FiscalYear year = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID, '2025', LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31))
+
+    List<VoucherLine> lines = [
+        new VoucherLine(null, null, 0, null, '1930', null, 'Bank', 100.00G, 0.00G),
+        new VoucherLine(null, null, 0, null, '3010', null, 'Income', 0.00G, 100.00G)
+    ]
+    voucherService.createVoucher(year.id, 'A', LocalDate.of(2025, 3, 1), 'First', lines)
+    voucherService.createVoucher(year.id, 'A', LocalDate.of(2025, 4, 1), 'Second', lines)
+
+    assertEquals(2, voucherService.countVouchers(CompanyService.LEGACY_COMPANY_ID, year.id))
+  }
+
+  @Test
+  void hasVouchersCreatedAfterReturnsTrueWhenVoucherExistsAfterTimestamp() {
+    FiscalYear year = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID, '2025', LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31))
+    LocalDateTime before = LocalDateTime.now().minusSeconds(1)
+
+    List<VoucherLine> lines = [
+        new VoucherLine(null, null, 0, null, '1930', null, 'Bank', 100.00G, 0.00G),
+        new VoucherLine(null, null, 0, null, '3010', null, 'Income', 0.00G, 100.00G)
+    ]
+    voucherService.createVoucher(year.id, 'A', LocalDate.of(2025, 3, 1), 'Test', lines)
+
+    assertTrue(voucherService.hasVouchersCreatedAfter(CompanyService.LEGACY_COMPANY_ID, before))
+  }
+
+  @Test
+  void hasVouchersCreatedAfterReturnsFalseWhenNoVouchersAfterTimestamp() {
+    FiscalYear year = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID, '2025', LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31))
+    List<VoucherLine> lines = [
+        new VoucherLine(null, null, 0, null, '1930', null, 'Bank', 100.00G, 0.00G),
+        new VoucherLine(null, null, 0, null, '3010', null, 'Income', 0.00G, 100.00G)
+    ]
+    voucherService.createVoucher(year.id, 'A', LocalDate.of(2025, 3, 1), 'Test', lines)
+
+    LocalDateTime future = LocalDateTime.now().plusSeconds(5)
+    assertFalse(voucherService.hasVouchersCreatedAfter(CompanyService.LEGACY_COMPANY_ID, future))
+  }
+}

--- a/docs/superpowers/plans/2026-04-18-overview-dashboard.md
+++ b/docs/superpowers/plans/2026-04-18-overview-dashboard.md
@@ -1,0 +1,757 @@
+# Overview Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the placeholder Overview tab with a minimal status dashboard showing company, fiscal year, voucher count, accounting periods, last backup, and integrity status.
+
+**Architecture:** A new `OverviewPanel` Swing component receives services via constructor injection, registers as a `PropertyChangeListener` on `ActiveCompanyManager`, and is refreshed on tab selection via a `ChangeListener` added in `MainFrame`. Two new query methods are added to `VoucherService` for counting vouchers and checking whether vouchers were created after a timestamp. No new service classes are needed.
+
+**Tech Stack:** Groovy, Java Swing (`GridBagLayout`, `GridLayout`), JUnit 6, H2 embedded DB
+
+---
+
+## File Map
+
+| Action | File |
+|--------|------|
+| Modify | `app/src/main/groovy/se/alipsa/accounting/service/VoucherService.groovy` |
+| Create | `app/src/test/groovy/integration/se/alipsa/accounting/service/VoucherServiceCountTest.groovy` |
+| Modify | `app/src/main/resources/i18n/messages.properties` |
+| Modify | `app/src/main/resources/i18n/messages_sv.properties` |
+| Create | `app/src/main/groovy/se/alipsa/accounting/ui/OverviewPanel.groovy` |
+| Modify | `app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy` |
+
+---
+
+### Task 1: VoucherService — add `countVouchers` and `hasVouchersCreatedAfter`
+
+**Files:**
+- Modify: `app/src/main/groovy/se/alipsa/accounting/service/VoucherService.groovy`
+- Create: `app/src/test/groovy/integration/se/alipsa/accounting/service/VoucherServiceCountTest.groovy`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `app/src/test/groovy/integration/se/alipsa/accounting/service/VoucherServiceCountTest.groovy`:
+
+```groovy
+package se.alipsa.accounting.service
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+import se.alipsa.accounting.domain.FiscalYear
+import se.alipsa.accounting.domain.VoucherLine
+import se.alipsa.accounting.support.AppPaths
+
+import java.nio.file.Path
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class VoucherServiceCountTest {
+
+  @TempDir
+  Path tempDir
+
+  private DatabaseService databaseService
+  private AuditLogService auditLogService
+  private AccountingPeriodService accountingPeriodService
+  private FiscalYearService fiscalYearService
+  private VoucherService voucherService
+  private String previousHome
+
+  @BeforeEach
+  void setUp() {
+    previousHome = System.getProperty(AppPaths.HOME_OVERRIDE_PROPERTY)
+    System.setProperty(AppPaths.HOME_OVERRIDE_PROPERTY, tempDir.toString())
+    databaseService = DatabaseService.newForTesting()
+    databaseService.initialize()
+    auditLogService = new AuditLogService(databaseService)
+    accountingPeriodService = new AccountingPeriodService(databaseService, auditLogService)
+    fiscalYearService = new FiscalYearService(databaseService, accountingPeriodService, auditLogService)
+    voucherService = new VoucherService(databaseService, auditLogService)
+  }
+
+  @AfterEach
+  void tearDown() {
+    if (previousHome == null) {
+      System.clearProperty(AppPaths.HOME_OVERRIDE_PROPERTY)
+    } else {
+      System.setProperty(AppPaths.HOME_OVERRIDE_PROPERTY, previousHome)
+    }
+  }
+
+  @Test
+  void countVouchersReturnsZeroForEmptyYear() {
+    FiscalYear year = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID, '2025', LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31))
+
+    assertEquals(0, voucherService.countVouchers(CompanyService.LEGACY_COMPANY_ID, year.id))
+  }
+
+  @Test
+  void countVouchersCountsActiveAndCorrectionVouchers() {
+    FiscalYear year = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID, '2025', LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31))
+
+    List<VoucherLine> lines = [
+        new VoucherLine(null, null, 0, null, '1930', null, 'Bank', 100.00G, 0.00G),
+        new VoucherLine(null, null, 0, null, '3010', null, 'Income', 0.00G, 100.00G)
+    ]
+    voucherService.createVoucher(year.id, 'A', LocalDate.of(2025, 3, 1), 'First', lines)
+    voucherService.createVoucher(year.id, 'A', LocalDate.of(2025, 4, 1), 'Second', lines)
+
+    assertEquals(2, voucherService.countVouchers(CompanyService.LEGACY_COMPANY_ID, year.id))
+  }
+
+  @Test
+  void hasVouchersCreatedAfterReturnsTrueWhenVoucherExistsAfterTimestamp() {
+    FiscalYear year = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID, '2025', LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31))
+    LocalDateTime before = LocalDateTime.now().minusSeconds(1)
+
+    List<VoucherLine> lines = [
+        new VoucherLine(null, null, 0, null, '1930', null, 'Bank', 100.00G, 0.00G),
+        new VoucherLine(null, null, 0, null, '3010', null, 'Income', 0.00G, 100.00G)
+    ]
+    voucherService.createVoucher(year.id, 'A', LocalDate.of(2025, 3, 1), 'Test', lines)
+
+    assertTrue(voucherService.hasVouchersCreatedAfter(CompanyService.LEGACY_COMPANY_ID, before))
+  }
+
+  @Test
+  void hasVouchersCreatedAfterReturnsFalseWhenNoVouchersAfterTimestamp() {
+    FiscalYear year = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID, '2025', LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31))
+    List<VoucherLine> lines = [
+        new VoucherLine(null, null, 0, null, '1930', null, 'Bank', 100.00G, 0.00G),
+        new VoucherLine(null, null, 0, null, '3010', null, 'Income', 0.00G, 100.00G)
+    ]
+    voucherService.createVoucher(year.id, 'A', LocalDate.of(2025, 3, 1), 'Test', lines)
+
+    LocalDateTime future = LocalDateTime.now().plusSeconds(5)
+    assertFalse(voucherService.hasVouchersCreatedAfter(CompanyService.LEGACY_COMPANY_ID, future))
+  }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+./gradlew test --tests "*.VoucherServiceCountTest" 2>&1 | tail -20
+```
+
+Expected: compilation error — `countVouchers` and `hasVouchersCreatedAfter` do not exist yet.
+
+- [ ] **Step 3: Add `LocalDateTime` import and the two methods to `VoucherService`**
+
+At the top of `VoucherService.groovy`, add `import java.time.LocalDateTime` after the existing `import java.time.LocalDate` line.
+
+Add these two methods after `listVouchers` (around line 299):
+
+```groovy
+  int countVouchers(long companyId, long fiscalYearId) {
+    CompanyService.requireValidCompanyId(companyId)
+    databaseService.withSql { Sql sql ->
+      GroovyRowResult row = sql.firstRow('''
+          select count(*) as cnt
+            from voucher
+           where company_id = ?
+             and fiscal_year_id = ?
+             and status in ('ACTIVE', 'CORRECTION')
+      ''', [companyId, fiscalYearId])
+      ((Number) row.cnt).intValue()
+    }
+  }
+
+  boolean hasVouchersCreatedAfter(long companyId, LocalDateTime since) {
+    CompanyService.requireValidCompanyId(companyId)
+    databaseService.withSql { Sql sql ->
+      GroovyRowResult row = sql.firstRow('''
+          select count(*) as cnt
+            from voucher
+           where company_id = ?
+             and status in ('ACTIVE', 'CORRECTION')
+             and created_at > ?
+      ''', [companyId, since])
+      ((Number) row.cnt).intValue() > 0
+    }
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+./gradlew test --tests "*.VoucherServiceCountTest" 2>&1 | tail -20
+```
+
+Expected: all 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/groovy/se/alipsa/accounting/service/VoucherService.groovy \
+        app/src/test/groovy/integration/se/alipsa/accounting/service/VoucherServiceCountTest.groovy
+git commit -m "lägg till countVouchers och hasVouchersCreatedAfter i VoucherService"
+```
+
+---
+
+### Task 2: i18n — add `overviewPanel.*` keys, remove obsolete description key
+
+**Files:**
+- Modify: `app/src/main/resources/i18n/messages.properties`
+- Modify: `app/src/main/resources/i18n/messages_sv.properties`
+
+- [ ] **Step 1: Add keys to `messages.properties`**
+
+Remove the line:
+```
+mainFrame.tab.overview.description=Overview and status for accounting will be shown here.
+```
+
+Add the following block after the `mainFrame.tab.*` section (after line 201):
+
+```properties
+# OverviewPanel
+overviewPanel.header.company=Company
+overviewPanel.header.fiscalYear=Current Fiscal Year
+overviewPanel.status.open=Open
+overviewPanel.status.closed=Closed
+overviewPanel.card.vouchers=Vouchers
+overviewPanel.card.vouchers.subtitle=active this year
+overviewPanel.card.periods=Accounting Periods
+overviewPanel.card.periods.subtitle=locked
+overviewPanel.card.backup=Last Backup
+overviewPanel.card.backup.today=today
+overviewPanel.card.backup.yesterday=yesterday
+overviewPanel.card.backup.daysAgo={0} days ago
+overviewPanel.card.backup.never=Never
+overviewPanel.card.integrity=Integrity
+overviewPanel.card.integrity.ok=\u2713 OK
+overviewPanel.card.integrity.failed=\u2717 Failed
+overviewPanel.card.integrity.subtitle=verified at startup
+overviewPanel.card.noData=\u2014
+```
+
+- [ ] **Step 2: Add keys to `messages_sv.properties`**
+
+Remove the Swedish description line (equivalent of `mainFrame.tab.overview.description`).
+
+Add the following block in the same location as step 1:
+
+```properties
+# OverviewPanel
+overviewPanel.header.company=F\u00f6retag
+overviewPanel.header.fiscalYear=Aktuellt r\u00e4kenskaps\u00e5r
+overviewPanel.status.open=\u00d6ppen
+overviewPanel.status.closed=St\u00e4ngd
+overviewPanel.card.vouchers=Verifikationer
+overviewPanel.card.vouchers.subtitle=aktiva detta \u00e5r
+overviewPanel.card.periods=Bokf\u00f6ringsperioder
+overviewPanel.card.periods.subtitle=l\u00e5sta
+overviewPanel.card.backup=Senaste s\u00e4kerhetskopia
+overviewPanel.card.backup.today=idag
+overviewPanel.card.backup.yesterday=ig\u00e5r
+overviewPanel.card.backup.daysAgo={0} dagar sedan
+overviewPanel.card.backup.never=Aldrig
+overviewPanel.card.integrity=Integritet
+overviewPanel.card.integrity.ok=\u2713 OK
+overviewPanel.card.integrity.failed=\u2717 Misslyckades
+overviewPanel.card.integrity.subtitle=verifierad vid start
+overviewPanel.card.noData=\u2014
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/resources/i18n/messages.properties \
+        app/src/main/resources/i18n/messages_sv.properties
+git commit -m "lägg till i18n-nycklar för OverviewPanel, ta bort föråldrad beskrivningsnyckel"
+```
+
+---
+
+### Task 3: Create `OverviewPanel`
+
+**Files:**
+- Create: `app/src/main/groovy/se/alipsa/accounting/ui/OverviewPanel.groovy`
+
+- [ ] **Step 1: Create the file**
+
+Create `app/src/main/groovy/se/alipsa/accounting/ui/OverviewPanel.groovy`:
+
+```groovy
+package se.alipsa.accounting.ui
+
+import se.alipsa.accounting.domain.AccountingPeriod
+import se.alipsa.accounting.domain.Company
+import se.alipsa.accounting.domain.FiscalYear
+import se.alipsa.accounting.service.AccountingPeriodService
+import se.alipsa.accounting.service.BackupService
+import se.alipsa.accounting.service.BackupSummary
+import se.alipsa.accounting.service.StartupVerificationService
+import se.alipsa.accounting.service.VoucherService
+import se.alipsa.accounting.support.I18n
+
+import java.awt.BorderLayout
+import java.awt.Color
+import java.awt.Font
+import java.awt.GridBagConstraints
+import java.awt.GridBagLayout
+import java.awt.GridLayout
+import java.awt.Insets
+import java.beans.PropertyChangeEvent
+import java.beans.PropertyChangeListener
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+import javax.swing.*
+import javax.swing.border.EtchedBorder
+
+final class OverviewPanel extends JPanel implements PropertyChangeListener {
+
+  private static final Color GREY = new Color(108, 117, 125)
+  private static final Color RED = new Color(220, 53, 69)
+  private static final Color GREEN = new Color(25, 135, 84)
+  private static final int BACKUP_WARN_DAYS = 60
+
+  private final VoucherService voucherService
+  private final AccountingPeriodService accountingPeriodService
+  private final BackupService backupService
+  private final StartupVerificationService startupVerificationService
+  private final ActiveCompanyManager activeCompanyManager
+
+  private boolean integrityChecked = false
+  private boolean integrityOk = false
+
+  // Header strip labels
+  private final JLabel companyTitleLabel = new JLabel()
+  private final JLabel companyNameLabel = new JLabel()
+  private final JLabel orgNumberLabel = new JLabel()
+  private final JLabel fiscalYearTitleLabel = new JLabel()
+  private final JLabel fiscalYearNameLabel = new JLabel()
+  private final JLabel fiscalYearDetailLabel = new JLabel()
+
+  // Stat card title labels (need locale update)
+  private final JLabel voucherCardTitle = new JLabel()
+  private final JLabel periodsCardTitle = new JLabel()
+  private final JLabel backupCardTitle = new JLabel()
+  private final JLabel integrityCardTitle = new JLabel()
+
+  // Stat card value labels
+  private final JLabel voucherValueLabel = new JLabel()
+  private final JLabel voucherSubLabel = new JLabel()
+  private final JLabel periodsValueLabel = new JLabel()
+  private final JLabel periodsSubLabel = new JLabel()
+  private final JLabel backupValueLabel = new JLabel()
+  private final JLabel backupSubLabel = new JLabel()
+  private final JLabel integrityValueLabel = new JLabel()
+  private final JLabel integritySubLabel = new JLabel()
+
+  OverviewPanel(
+      VoucherService voucherService,
+      AccountingPeriodService accountingPeriodService,
+      BackupService backupService,
+      StartupVerificationService startupVerificationService,
+      ActiveCompanyManager activeCompanyManager
+  ) {
+    this.voucherService = voucherService
+    this.accountingPeriodService = accountingPeriodService
+    this.backupService = backupService
+    this.startupVerificationService = startupVerificationService
+    this.activeCompanyManager = activeCompanyManager
+    I18n.instance.addLocaleChangeListener(this)
+    activeCompanyManager.addPropertyChangeListener(this)
+    buildUi()
+    reload()
+  }
+
+  @Override
+  void propertyChange(PropertyChangeEvent evt) {
+    if ('locale' == evt.propertyName) {
+      SwingUtilities.invokeLater { applyLocale() }
+    } else if (ActiveCompanyManager.COMPANY_ID_PROPERTY == evt.propertyName) {
+      SwingUtilities.invokeLater { reload() }
+    }
+  }
+
+  void reload() {
+    applyLocale()
+    Company company = activeCompanyManager.activeCompany
+    FiscalYear fiscalYear = activeCompanyManager.fiscalYear
+
+    if (company == null) {
+      clearStatCards()
+      companyNameLabel.text = I18n.instance.getString('overviewPanel.card.noData')
+      orgNumberLabel.text = ''
+      fiscalYearNameLabel.text = I18n.instance.getString('overviewPanel.card.noData')
+      fiscalYearDetailLabel.text = ''
+      return
+    }
+
+    companyNameLabel.text = company.companyName ?: ''
+    orgNumberLabel.text = company.organizationNumber ?: ''
+
+    if (fiscalYear == null) {
+      fiscalYearNameLabel.text = I18n.instance.getString('overviewPanel.card.noData')
+      fiscalYearDetailLabel.text = ''
+      clearStatCards()
+      return
+    }
+
+    fiscalYearNameLabel.text = fiscalYear.name ?: ''
+    String statusText
+    if (fiscalYear.closed) {
+      statusText = I18n.instance.getString('overviewPanel.status.closed')
+      fiscalYearDetailLabel.foreground = GREY
+    } else {
+      statusText = I18n.instance.getString('overviewPanel.status.open')
+      fiscalYearDetailLabel.foreground = GREEN
+    }
+    fiscalYearDetailLabel.text = "${fiscalYear.startDate} \u2013 ${fiscalYear.endDate}  \u00b7  ${statusText}"
+
+    // Vouchers
+    int count = voucherService.countVouchers(company.id, fiscalYear.id)
+    voucherValueLabel.text = String.valueOf(count)
+    voucherSubLabel.text = I18n.instance.getString('overviewPanel.card.vouchers.subtitle')
+
+    // Accounting periods
+    List<AccountingPeriod> periods = accountingPeriodService.listPeriods(fiscalYear.id)
+    int locked = periods.count { AccountingPeriod p -> p.locked } as int
+    int total = periods.size()
+    periodsValueLabel.text = "${locked} / ${total}"
+    periodsSubLabel.text = I18n.instance.getString('overviewPanel.card.periods.subtitle')
+
+    // Backup
+    updateBackupCard(company.id)
+
+    // Integrity — run once per session
+    if (!integrityChecked) {
+      integrityOk = startupVerificationService.verify().ok
+      integrityChecked = true
+    }
+    updateIntegrityCard()
+  }
+
+  private void updateBackupCard(long companyId) {
+    List<BackupSummary> backups = backupService.listBackups(1)
+    if (backups.isEmpty()) {
+      backupValueLabel.text = I18n.instance.getString('overviewPanel.card.backup.never')
+      backupValueLabel.foreground = GREY
+      backupSubLabel.text = ''
+      return
+    }
+    BackupSummary latest = backups.first()
+    LocalDateTime createdAt = latest.createdAt
+    LocalDateTime now = LocalDateTime.now()
+    long daysAgo = ChronoUnit.DAYS.between(createdAt, now)
+
+    String ageText
+    if (daysAgo == 0) {
+      ageText = I18n.instance.getString('overviewPanel.card.backup.today')
+    } else if (daysAgo == 1) {
+      ageText = I18n.instance.getString('overviewPanel.card.backup.yesterday')
+    } else {
+      ageText = I18n.instance.format('overviewPanel.card.backup.daysAgo', daysAgo)
+    }
+
+    boolean warn = daysAgo > BACKUP_WARN_DAYS && voucherService.hasVouchersCreatedAfter(companyId, createdAt)
+
+    String dateText = createdAt.toString().replace('T', ' ').substring(0, 16)
+    if (warn) {
+      backupValueLabel.foreground = RED
+      backupSubLabel.foreground = RED
+      backupSubLabel.text = ageText
+    } else {
+      backupValueLabel.foreground = UIManager.getColor('Label.foreground') ?: Color.BLACK
+      backupSubLabel.foreground = GREY
+      backupSubLabel.text = ageText
+    }
+    backupValueLabel.text = dateText
+  }
+
+  private void updateIntegrityCard() {
+    integritySubLabel.text = I18n.instance.getString('overviewPanel.card.integrity.subtitle')
+    if (integrityOk) {
+      integrityValueLabel.text = I18n.instance.getString('overviewPanel.card.integrity.ok')
+      integrityValueLabel.foreground = GREEN
+    } else {
+      integrityValueLabel.text = I18n.instance.getString('overviewPanel.card.integrity.failed')
+      integrityValueLabel.foreground = RED
+    }
+  }
+
+  private void clearStatCards() {
+    String dash = I18n.instance.getString('overviewPanel.card.noData')
+    [voucherValueLabel, periodsValueLabel, backupValueLabel, integrityValueLabel].each { JLabel l ->
+      l.text = dash
+      l.foreground = UIManager.getColor('Label.foreground') ?: Color.BLACK
+    }
+    [voucherSubLabel, periodsSubLabel, backupSubLabel, integritySubLabel].each { JLabel l ->
+      l.text = ''
+    }
+  }
+
+  private void applyLocale() {
+    companyTitleLabel.text = I18n.instance.getString('overviewPanel.header.company').toUpperCase(I18n.instance.locale)
+    fiscalYearTitleLabel.text = I18n.instance.getString('overviewPanel.header.fiscalYear').toUpperCase(I18n.instance.locale)
+    voucherCardTitle.text = I18n.instance.getString('overviewPanel.card.vouchers').toUpperCase(I18n.instance.locale)
+    periodsCardTitle.text = I18n.instance.getString('overviewPanel.card.periods').toUpperCase(I18n.instance.locale)
+    backupCardTitle.text = I18n.instance.getString('overviewPanel.card.backup').toUpperCase(I18n.instance.locale)
+    integrityCardTitle.text = I18n.instance.getString('overviewPanel.card.integrity').toUpperCase(I18n.instance.locale)
+  }
+
+  private void buildUi() {
+    setLayout(new BorderLayout(0, 12))
+    setBorder(BorderFactory.createEmptyBorder(16, 16, 16, 16))
+
+    add(buildHeaderStrip(), BorderLayout.NORTH)
+    add(buildStatGrid(), BorderLayout.CENTER)
+  }
+
+  private JPanel buildHeaderStrip() {
+    JPanel strip = new JPanel(new GridBagLayout())
+    strip.border = BorderFactory.createCompoundBorder(
+        BorderFactory.createEtchedBorder(EtchedBorder.LOWERED),
+        BorderFactory.createEmptyBorder(10, 14, 10, 14)
+    )
+
+    Font titleFont = companyNameLabel.font.deriveFont(Font.BOLD, 14.0f)
+    Font subtitleFont = companyTitleLabel.font.deriveFont(9.0f)
+
+    companyTitleLabel.foreground = GREY
+    companyTitleLabel.font = subtitleFont
+    companyNameLabel.font = titleFont
+    orgNumberLabel.foreground = GREY
+    orgNumberLabel.font = companyNameLabel.font.deriveFont(11.0f)
+
+    fiscalYearTitleLabel.foreground = GREY
+    fiscalYearTitleLabel.font = subtitleFont
+    fiscalYearNameLabel.font = titleFont
+    fiscalYearDetailLabel.font = companyNameLabel.font.deriveFont(11.0f)
+
+    GridBagConstraints gbc = new GridBagConstraints()
+    gbc.insets = new Insets(0, 0, 0, 0)
+    gbc.anchor = GridBagConstraints.WEST
+    gbc.fill = GridBagConstraints.BOTH
+
+    // Company column
+    JPanel companyPanel = new JPanel(new GridLayout(3, 1, 0, 2))
+    companyPanel.opaque = false
+    companyPanel.add(companyTitleLabel)
+    companyPanel.add(companyNameLabel)
+    companyPanel.add(orgNumberLabel)
+
+    gbc.gridx = 0; gbc.gridy = 0; gbc.weightx = 1.0; gbc.weighty = 1.0
+    strip.add(companyPanel, gbc)
+
+    // Vertical separator
+    JSeparator sep = new JSeparator(JSeparator.VERTICAL)
+    gbc.gridx = 1; gbc.weightx = 0; gbc.fill = GridBagConstraints.VERTICAL
+    gbc.insets = new Insets(0, 16, 0, 16)
+    strip.add(sep, gbc)
+
+    // Fiscal year column
+    JPanel fyPanel = new JPanel(new GridLayout(3, 1, 0, 2))
+    fyPanel.opaque = false
+    fyPanel.add(fiscalYearTitleLabel)
+    fyPanel.add(fiscalYearNameLabel)
+    fyPanel.add(fiscalYearDetailLabel)
+
+    gbc.gridx = 2; gbc.weightx = 1.0; gbc.fill = GridBagConstraints.BOTH
+    gbc.insets = new Insets(0, 0, 0, 0)
+    strip.add(fyPanel, gbc)
+
+    strip
+  }
+
+  private JPanel buildStatGrid() {
+    JPanel grid = new JPanel(new GridLayout(2, 2, 8, 8))
+
+    grid.add(buildStatCard(voucherCardTitle, voucherValueLabel, voucherSubLabel, 22.0f))
+    grid.add(buildStatCard(periodsCardTitle, periodsValueLabel, periodsSubLabel, 22.0f))
+    grid.add(buildStatCard(backupCardTitle, backupValueLabel, backupSubLabel, 13.0f))
+    grid.add(buildStatCard(integrityCardTitle, integrityValueLabel, integritySubLabel, 13.0f))
+
+    grid
+  }
+
+  private static JPanel buildStatCard(JLabel titleLabel, JLabel valueLabel, JLabel subLabel, float valueFontSize) {
+    JPanel card = new JPanel(new GridLayout(3, 1, 0, 2))
+    card.border = BorderFactory.createCompoundBorder(
+        BorderFactory.createEtchedBorder(EtchedBorder.LOWERED),
+        BorderFactory.createEmptyBorder(8, 12, 8, 12)
+    )
+    titleLabel.foreground = new Color(108, 117, 125)
+    titleLabel.font = titleLabel.font.deriveFont(9.0f)
+    valueLabel.font = valueLabel.font.deriveFont(Font.BOLD, valueFontSize)
+    subLabel.font = subLabel.font.deriveFont(10.0f)
+    subLabel.foreground = new Color(108, 117, 125)
+    card.add(titleLabel)
+    card.add(valueLabel)
+    card.add(subLabel)
+    card
+  }
+}
+```
+
+- [ ] **Step 2: Compile to check for errors**
+
+```bash
+./gradlew compileGroovy 2>&1 | tail -30
+```
+
+Expected: BUILD SUCCESSFUL with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/groovy/se/alipsa/accounting/ui/OverviewPanel.groovy
+git commit -m "lägg till OverviewPanel med företagsinfo, statistikkort och backupvarning"
+```
+
+---
+
+### Task 4: Wire `OverviewPanel` into `MainFrame`
+
+**Files:**
+- Modify: `app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy`
+
+Four changes are needed:
+1. Remove `overviewDescriptionLabel` field declaration (line 151)
+2. Replace `buildOverviewPanel()` to return an `OverviewPanel` and store it in a field
+3. Remove the `overviewDescriptionLabel` update lines from `applyTabLocale()` (lines 278-280)
+4. Add a `ChangeListener` on `tabbedPane` to call `overviewPanel.reload()` on tab 0 selection
+
+- [ ] **Step 1: Remove `overviewDescriptionLabel` field**
+
+In `MainFrame.groovy`, remove the line:
+```groovy
+  private JLabel overviewDescriptionLabel
+```
+
+- [ ] **Step 2: Add `overviewPanel` field**
+
+After the line `private JLabel companySummaryLabel` (line 150), add:
+```groovy
+  private OverviewPanel overviewPanel
+```
+
+- [ ] **Step 3: Replace `buildOverviewPanel()`**
+
+Replace the entire method:
+```groovy
+  private JPanel buildOverviewPanel() {
+    String safeTitle = escapeHtml(I18n.instance.getString('mainFrame.tab.overview'))
+    String safeDescription = escapeHtml(I18n.instance.getString('mainFrame.tab.overview.description'))
+    swing.panel(border: swing.emptyBorder(24, 24, 24, 24)) {
+      borderLayout()
+      overviewDescriptionLabel = label(
+          text: "<html><h2>${safeTitle}</h2><p>${safeDescription}</p></html>",
+          horizontalAlignment: SwingConstants.CENTER,
+          constraints: BorderLayout.CENTER
+      )
+    } as JPanel
+  }
+```
+
+With:
+```groovy
+  private JPanel buildOverviewPanel() {
+    overviewPanel = new OverviewPanel(
+        voucherService,
+        accountingPeriodService,
+        backupService,
+        startupVerificationService,
+        activeCompanyManager
+    )
+    overviewPanel
+  }
+```
+
+- [ ] **Step 4: Clean up `applyTabLocale()`**
+
+Remove these three lines from `applyTabLocale()`:
+```groovy
+    String overviewTitle = escapeHtml(I18n.instance.getString('mainFrame.tab.overview'))
+    String overviewDesc = escapeHtml(I18n.instance.getString('mainFrame.tab.overview.description'))
+    overviewDescriptionLabel.text = "<html><h2>${overviewTitle}</h2><p>${overviewDesc}</p></html>"
+```
+
+- [ ] **Step 5: Add tab ChangeListener after tabs are added in `buildFrame()`**
+
+In `buildFrame()`, after the loop `buildMainTabs().each { ... }` (around line 313-315), add:
+
+```groovy
+    tabbedPane.addChangeListener { javax.swing.event.ChangeEvent ignored ->
+      if (tabbedPane.selectedIndex == 0) {
+        overviewPanel.reload()
+      }
+    }
+```
+
+- [ ] **Step 6: Check that `startupVerificationService` and `backupService` are fields in MainFrame**
+
+Confirm in `MainFrame.groovy` that `startupVerificationService` and `backupService` are declared as fields and initialized. Search for:
+```bash
+grep -n "startupVerificationService\|backupService" app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy | head -10
+```
+
+Both should already exist (they are used by `SystemDocumentationPanel`).
+
+- [ ] **Step 7: Build to verify**
+
+```bash
+./gradlew build 2>&1 | tail -30
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 8: Run spotless**
+
+```bash
+./gradlew spotlessApply
+```
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
+git commit -m "ersätt platshållarvy med OverviewPanel i MainFrame"
+```
+
+---
+
+### Task 5: Final build and verify
+
+- [ ] **Step 1: Full build**
+
+```bash
+./gradlew build 2>&1 | tail -30
+```
+
+Expected: BUILD SUCCESSFUL, all tests pass.
+
+- [ ] **Step 2: Manual smoke test**
+
+Run the application:
+```bash
+./gradlew run
+```
+
+Check:
+- Overview tab shows company name and org number in header strip
+- Fiscal year name, date range, and open/closed status shown
+- Voucher count matches what you see in the Vouchers tab
+- Accounting periods locked/total is correct
+- Backup card shows date or "Never"
+- Integrity card shows ✓ OK or ✗ Failed
+- Switching company updates all cards
+- Switching language (EN ↔ SV) updates all labels
+

--- a/docs/superpowers/specs/2026-04-18-overview-dashboard-design.md
+++ b/docs/superpowers/specs/2026-04-18-overview-dashboard-design.md
@@ -1,0 +1,91 @@
+# Overview Dashboard Design
+
+**Date:** 2026-04-18  
+**Status:** Approved
+
+## What we're building
+
+Replace the placeholder Overview tab with a minimal status dashboard. The dashboard answers one question: "Is everything in order?" It shows six data points arranged as a company/fiscal-year header strip above a 2×2 stat card grid.
+
+## Data points
+
+| Item | Source | Notes |
+|---|---|---|
+| Company name + org number | `ActiveCompanyManager.activeCompany` | — |
+| Current fiscal year name, date range, open/closed | `ActiveCompanyManager.fiscalYear` | — |
+| Voucher count | `VoucherService.countVouchers(companyId, fiscalYearId)` | New `select count(*)` method |
+| Accounting periods locked / total | `AccountingPeriodService.listPeriods(fiscalYearId)` | Count locked in-panel |
+| Last backup date/time | `BackupService.listBackups(1).find()` | — |
+| Integrity status | `StartupVerificationService.verify()` | Run once on first load; cached in panel |
+
+## Layout
+
+**Header strip** (full width, single card):
+- Left half: company name (large) + org number (small grey)
+- Vertical separator
+- Right half: fiscal year name (large) + date range and open/closed status (small grey)
+
+**2×2 stat grid** below the header:
+- Top-left: Vouchers
+- Top-right: Accounting Periods (locked / total)
+- Bottom-left: Last Backup
+- Bottom-right: Integrity
+
+Swing implementation: `GridBagLayout` for the header strip; `GridLayout(2, 2)` for the stat cards. Each stat card is a `JPanel` with an `EtchedBorder`, a small grey label for the title, and a larger bold label for the value.
+
+## Color rules
+
+| Condition | Display |
+|---|---|
+| Backup age > 60 days AND vouchers created after last backup | Date and age label shown in red |
+| Never backed up | "Never" shown in grey (informational, not an error) |
+| Integrity check failed | Value shown in red with ✗ prefix |
+| Fiscal year closed | "Closed" shown in grey (informational) |
+| No active fiscal year | All stat card values show "—" |
+| All clear | All values in default colour |
+
+The 60-day threshold exists so that creating a single voucher does not immediately trigger a warning. Both conditions must be true (age > 60 days AND unprotected vouchers) before the backup card turns red.
+
+## Service additions
+
+Two new methods, both in existing service classes:
+
+**`VoucherService.countVouchers(long companyId, long fiscalYearId): int`**  
+`select count(*) from voucher where fiscal_year_id = ? and status in ('ACTIVE', 'CORRECTION')` — joined to company via fiscal_year.
+
+**`VoucherService.hasVouchersCreatedAfter(long companyId, LocalDateTime since): boolean`**  
+`select count(*) from voucher where ... and created_at > ?` — used for the backup warning rule.
+
+## Refresh behaviour
+
+- **On company change**: `propertyChange` on `ActiveCompanyManager.COMPANY_ID_PROPERTY` triggers full reload.
+- **On tab selected**: `ChangeListener` on the `JTabbedPane` reloads when the Overview tab becomes visible. Catches vouchers or backups created while on another tab.
+- **Integrity check**: runs once on first panel load; result cached in the panel for the session. Does not re-run on tab switch (hash chain verification is expensive).
+
+## New class
+
+**`OverviewPanel`** (`ui/OverviewPanel.groovy`)  
+- `final class OverviewPanel extends JPanel implements PropertyChangeListener`
+- Constructor args: `VoucherService`, `AccountingPeriodService`, `BackupService`, `StartupVerificationService`, `ActiveCompanyManager`
+- Replaces `buildOverviewPanel()` in `MainFrame`
+
+No new service class is needed.
+
+## i18n
+
+New keys in `messages.properties` and `messages_sv.properties` under the `overviewPanel.*` namespace covering all labels, stat titles, and status values (Open/Closed, OK/Failed, Never, days-ago formatting).
+
+## Age display format
+
+Backup age is shown as a secondary label beneath the date:
+- Same day → "today"
+- 1 day → "yesterday"
+- 2–N days → "N days ago"
+- No backup → label omitted
+
+## Out of scope
+
+- Quick-action buttons
+- Charts or graphs
+- Auto-refresh timer
+- Drill-down navigation from dashboard cards


### PR DESCRIPTION
## Summary

- Replaces the placeholder Overview tab with a minimal status dashboard
- New `OverviewPanel` shows company/fiscal-year header strip and a 2×2 stat grid (vouchers, accounting periods, last backup, integrity)
- Backup card turns red only when backup is >60 days old AND vouchers have been created since then; never-backed-up shows grey (informational)
- Integrity check runs once on first panel load and is cached for the session
- Panel reloads on company change (`PropertyChangeListener`) and on tab selection (`ChangeListener` on `JTabbedPane`)
- Two new `VoucherService` methods: `countVouchers(companyId, fiscalYearId)` and `hasVouchersCreatedAfter(companyId, since)`

## Test Plan

- [ ] Build passes: `./gradlew build`
- [ ] New `VoucherServiceCountTest` (4 tests) passes
- [ ] Start app with `./gradlew run`, verify Overview tab shows company name, org number, fiscal year, voucher count, locked periods, backup date/age, and integrity status
- [ ] Switch company — all cards update
- [ ] Switch language (EN ↔ SV) — all labels update
- [ ] Backup card shows "Never" in grey when no backups exist
- [ ] Switching away from Overview tab and back triggers a reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)