### PR TITLE
phase 2: read-only MCP tools

### DIFF
--- a/app/src/main/groovy/se/alipsa/accounting/mcp/AccountingMcpTools.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/mcp/AccountingMcpTools.groovy
@@ -118,13 +118,19 @@ class AccountingMcpTools {
         ),
         toolDef('list_vat_periods',
             'Lists VAT periods for the given fiscal year with status (OPEN, REPORTED, LOCKED).',
-            ['fiscal_year_id'],
-            [fiscal_year_id: intParam('Fiscal year ID')]
+            ['company_id', 'fiscal_year_id'],
+            [
+                company_id: intParam('Company ID'),
+                fiscal_year_id: intParam('Fiscal year ID')
+            ]
         ),
         toolDef('get_vat_report',
             'Calculates the VAT report for the given VAT period. Returns output VAT, input VAT, net payable, and per-code breakdown.',
-            ['vat_period_id'],
-            [vat_period_id: intParam('VAT period ID')]
+            ['company_id', 'vat_period_id'],
+            [
+                company_id: intParam('Company ID'),
+                vat_period_id: intParam('VAT period ID')
+            ]
         ),
     ]
   }
@@ -233,12 +239,17 @@ class AccountingMcpTools {
   }
 
   private Map<String, Object> getTrialBalance(Map<String, Object> args) {
+    long companyId = requiredLong(args, 'company_id')
     long fiscalYearId = requiredLong(args, 'fiscal_year_id')
     Long periodId = args.get('accounting_period_id') != null
         ? ((Number) args.get('accounting_period_id')).longValue()
         : null
     LocalDate startDate = args.get('start_date') ? LocalDate.parse((String) args.get('start_date')) : null
     LocalDate endDate = args.get('end_date') ? LocalDate.parse((String) args.get('end_date')) : null
+    long expectedCompanyId = companyService.resolveFromFiscalYear(fiscalYearId)
+    if (expectedCompanyId != companyId) {
+      return [ok: false, error: "Fiscal year ${fiscalYearId} does not belong to company ${companyId}."]
+    }
     se.alipsa.accounting.domain.report.ReportResult result = reportDataService.generate(
         new ReportSelection(ReportType.TRIAL_BALANCE, fiscalYearId, periodId, startDate, endDate)
     )
@@ -260,13 +271,20 @@ class AccountingMcpTools {
   }
 
   private Map<String, Object> getGeneralLedger(Map<String, Object> args) {
+    long companyId = requiredLong(args, 'company_id')
     long fiscalYearId = requiredLong(args, 'fiscal_year_id')
     Long periodId = args.get('accounting_period_id') != null
         ? ((Number) args.get('accounting_period_id')).longValue()
         : null
     LocalDate startDate = args.get('start_date') ? LocalDate.parse((String) args.get('start_date')) : null
     LocalDate endDate = args.get('end_date') ? LocalDate.parse((String) args.get('end_date')) : null
-    int limit = args.get('limit') != null ? Math.min(((Number) args.get('limit')).intValue(), 5000) : 1000
+    int limit = args.get('limit') != null
+        ? Math.max(1, Math.min(((Number) args.get('limit')).intValue(), 5000))
+        : 1000
+    long expectedCompanyId = companyService.resolveFromFiscalYear(fiscalYearId)
+    if (expectedCompanyId != companyId) {
+      return [ok: false, error: "Fiscal year ${fiscalYearId} does not belong to company ${companyId}."]
+    }
     se.alipsa.accounting.domain.report.ReportResult result = reportDataService.generate(
         new ReportSelection(ReportType.GENERAL_LEDGER, fiscalYearId, periodId, startDate, endDate)
     )
@@ -294,7 +312,12 @@ class AccountingMcpTools {
   }
 
   private Map<String, Object> listVatPeriods(Map<String, Object> args) {
+    long companyId = requiredLong(args, 'company_id')
     long fiscalYearId = requiredLong(args, 'fiscal_year_id')
+    long expectedCompanyId = companyService.resolveFromFiscalYear(fiscalYearId)
+    if (expectedCompanyId != companyId) {
+      return [ok: false, error: "Fiscal year ${fiscalYearId} does not belong to company ${companyId}."]
+    }
     List<VatPeriod> periods = vatService.listPeriods(fiscalYearId)
     [
         ok: true,
@@ -313,11 +336,16 @@ class AccountingMcpTools {
   }
 
   private Map<String, Object> getVatReport(Map<String, Object> args) {
+    long companyId = requiredLong(args, 'company_id')
     long vatPeriodId = requiredLong(args, 'vat_period_id')
     try {
+      VatPeriod period = vatService.findPeriod(vatPeriodId)
+      long expectedCompanyId = companyService.resolveFromFiscalYear(period.fiscalYearId)
+      if (expectedCompanyId != companyId) {
+        return [ok: false, error: "VAT period ${vatPeriodId} does not belong to company ${companyId}."]
+      }
       VatService.VatReport report = vatService.calculateReport(vatPeriodId)
-      String reportHash = report.period?.reportHash
-          ?: computePreviewToken([vat_period_id: vatPeriodId])
+      String reportHash = VatService.calculateReportHash(report)
       [
           ok: true,
           vat_period_id: report.period?.id,

--- a/app/src/main/groovy/se/alipsa/accounting/mcp/AccountingMcpTools.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/mcp/AccountingMcpTools.groovy
@@ -220,6 +220,10 @@ class AccountingMcpTools {
   private Map<String, Object> listVouchers(Map<String, Object> args) {
     long companyId = requiredLong(args, 'company_id')
     long fiscalYearId = requiredLong(args, 'fiscal_year_id')
+    long expectedCompanyId = companyService.resolveFromFiscalYear(fiscalYearId)
+    if (expectedCompanyId != companyId) {
+      return [ok: false, error: "Fiscal year ${fiscalYearId} does not belong to company ${companyId}."]
+    }
     List<se.alipsa.accounting.domain.Voucher> vouchers =
         voucherService.listVouchers(companyId, fiscalYearId, null, null)
     [

--- a/app/src/main/groovy/se/alipsa/accounting/mcp/AccountingMcpTools.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/mcp/AccountingMcpTools.groovy
@@ -1,17 +1,391 @@
 package se.alipsa.accounting.mcp
 
+import groovy.json.JsonOutput
+
+import se.alipsa.accounting.domain.Company
+import se.alipsa.accounting.domain.FiscalYear
+import se.alipsa.accounting.domain.VatPeriod
+import se.alipsa.accounting.domain.report.GeneralLedgerRow
+import se.alipsa.accounting.domain.report.ReportSelection
+import se.alipsa.accounting.domain.report.ReportType
+import se.alipsa.accounting.domain.report.TrialBalanceRow
+import se.alipsa.accounting.service.AccountService
+import se.alipsa.accounting.service.ClosingService
+import se.alipsa.accounting.service.CompanyService
+import se.alipsa.accounting.service.FiscalYearService
+import se.alipsa.accounting.service.ReportDataService
+import se.alipsa.accounting.service.VatService
+import se.alipsa.accounting.service.VoucherService
+
+import java.security.MessageDigest
+import java.time.LocalDate
+
 /**
  * Registry and implementation entrypoint for MCP tools.
  *
- * Phase 1 only exposes the protocol shell. Business tools are added in later phases.
+ * Phase 2 exposes read-only tools that prove service wiring and structured MCP output.
  */
 class AccountingMcpTools {
 
+  private final CompanyService companyService
+  private final FiscalYearService fiscalYearService
+  private final AccountService accountService
+  private final VoucherService voucherService
+  private final VatService vatService
+  private final ClosingService closingService
+  private final ReportDataService reportDataService
+
+  AccountingMcpTools() {
+    this(
+        new CompanyService(),
+        new FiscalYearService(),
+        new AccountService(),
+        new VoucherService(),
+        new VatService(),
+        new ClosingService(),
+        new ReportDataService()
+    )
+  }
+
+  AccountingMcpTools(
+      CompanyService companyService,
+      FiscalYearService fiscalYearService,
+      AccountService accountService,
+      VoucherService voucherService,
+      VatService vatService,
+      ClosingService closingService,
+      ReportDataService reportDataService
+  ) {
+    this.companyService = companyService
+    this.fiscalYearService = fiscalYearService
+    this.accountService = accountService
+    this.voucherService = voucherService
+    this.vatService = vatService
+    this.closingService = closingService
+    this.reportDataService = reportDataService
+  }
+
   List<Map<String, Object>> listTools() {
-    []
+    [
+        toolDef('get_company_info',
+            'Returns the company record for the given company ID.',
+            ['company_id'],
+            [company_id: intParam('Company ID')]
+        ),
+        toolDef('list_fiscal_years',
+            'Lists all fiscal years for the given company.',
+            ['company_id'],
+            [company_id: intParam('Company ID')]
+        ),
+        toolDef('list_accounts',
+            'Returns active accounts in the chart of accounts for the given company. Accepts an optional query string.',
+            ['company_id'],
+            [
+                company_id: intParam('Company ID'),
+                query: optStrParam('Optional search string (account number or name)')
+            ]
+        ),
+        toolDef('list_vouchers',
+            'Returns posted vouchers for the given fiscal year. Returns at most 200 rows.',
+            ['company_id', 'fiscal_year_id'],
+            [
+                company_id: intParam('Company ID'),
+                fiscal_year_id: intParam('Fiscal year ID')
+            ]
+        ),
+        toolDef('get_trial_balance',
+            'Returns trial balance (råbalans) for the given fiscal year with opening balance, period movements and closing balance per account.',
+            ['company_id', 'fiscal_year_id'],
+            [
+                company_id: intParam('Company ID'),
+                fiscal_year_id: intParam('Fiscal year ID'),
+                accounting_period_id: optIntParam('Optional: restrict to a specific accounting period.'),
+                start_date: optStrParam('Optional: restrict start date (ISO YYYY-MM-DD).'),
+                end_date: optStrParam('Optional: restrict end date (ISO YYYY-MM-DD).')
+            ]
+        ),
+        toolDef('get_general_ledger',
+            'Returns the general ledger (huvudbok). One row per posting with running balance. Use limit to manage large years.',
+            ['company_id', 'fiscal_year_id'],
+            [
+                company_id: intParam('Company ID'),
+                fiscal_year_id: intParam('Fiscal year ID'),
+                accounting_period_id: optIntParam('Optional: restrict to a specific accounting period.'),
+                start_date: optStrParam('Optional: restrict start date (ISO YYYY-MM-DD).'),
+                end_date: optStrParam('Optional: restrict end date (ISO YYYY-MM-DD).'),
+                limit: optIntParam('Max rows returned. Default 1000, max 5000.')
+            ]
+        ),
+        toolDef('list_vat_periods',
+            'Lists VAT periods for the given fiscal year with status (OPEN, REPORTED, LOCKED).',
+            ['fiscal_year_id'],
+            [fiscal_year_id: intParam('Fiscal year ID')]
+        ),
+        toolDef('get_vat_report',
+            'Calculates the VAT report for the given VAT period. Returns output VAT, input VAT, net payable, and per-code breakdown.',
+            ['vat_period_id'],
+            [vat_period_id: intParam('VAT period ID')]
+        ),
+    ]
   }
 
   Map<String, Object> callTool(String name, Map<String, Object> arguments) {
-    throw new IllegalArgumentException("Unknown MCP tool: ${name} (${arguments.keySet().join(', ')})")
+    switch (name) {
+      case 'get_company_info':
+        return getCompanyInfo(arguments)
+      case 'list_fiscal_years':
+        return listFiscalYears(arguments)
+      case 'list_accounts':
+        return listAccounts(arguments)
+      case 'list_vouchers':
+        return listVouchers(arguments)
+      case 'get_trial_balance':
+        return getTrialBalance(arguments)
+      case 'get_general_ledger':
+        return getGeneralLedger(arguments)
+      case 'list_vat_periods':
+        return listVatPeriods(arguments)
+      case 'get_vat_report':
+        return getVatReport(arguments)
+      default:
+        throw new IllegalArgumentException("Unknown MCP tool: ${name}")
+    }
+  }
+
+  // ---- read-only tools ----
+
+  private Map<String, Object> getCompanyInfo(Map<String, Object> args) {
+    long companyId = requiredLong(args, 'company_id')
+    Company company = companyService.findById(companyId)
+    if (company == null) {
+      return [ok: false, error: "Company ${companyId} not found."]
+    }
+    [
+        ok: true,
+        company: [
+            id: company.id,
+            name: company.companyName,
+            organization_number: company.organizationNumber,
+            default_currency: company.defaultCurrency,
+            vat_periodicity: company.vatPeriodicity?.name(),
+            active: company.active
+        ]
+    ]
+  }
+
+  private Map<String, Object> listFiscalYears(Map<String, Object> args) {
+    long companyId = requiredLong(args, 'company_id')
+    List<FiscalYear> years = fiscalYearService.listFiscalYears(companyId)
+    [
+        ok: true,
+        fiscal_years: years.collect { FiscalYear y ->
+          [
+              id: y.id,
+              name: y.name,
+              start_date: y.startDate?.toString(),
+              end_date: y.endDate?.toString(),
+              closed: y.closed
+          ]
+        }
+    ]
+  }
+
+  private Map<String, Object> listAccounts(Map<String, Object> args) {
+    long companyId = requiredLong(args, 'company_id')
+    String query = args.get('query') as String
+    List<se.alipsa.accounting.domain.Account> accounts =
+        accountService.searchAccounts(companyId, query, null, true, false)
+    [
+        ok: true,
+        accounts: accounts.collect { se.alipsa.accounting.domain.Account a ->
+          [
+              id: a.id,
+              account_number: a.accountNumber,
+              account_name: a.accountName,
+              account_class: a.accountClass,
+              normal_balance_side: a.normalBalanceSide,
+              vat_code: a.vatCode,
+              active: a.active
+          ]
+        }
+    ]
+  }
+
+  private Map<String, Object> listVouchers(Map<String, Object> args) {
+    long companyId = requiredLong(args, 'company_id')
+    long fiscalYearId = requiredLong(args, 'fiscal_year_id')
+    List<se.alipsa.accounting.domain.Voucher> vouchers =
+        voucherService.listVouchers(companyId, fiscalYearId, null, null)
+    [
+        ok: true,
+        vouchers: vouchers.take(200).collect { se.alipsa.accounting.domain.Voucher v ->
+          [
+              id: v.id,
+              voucher_number: v.voucherNumber,
+              series_code: v.seriesCode,
+              accounting_date: v.accountingDate?.toString(),
+              description: v.description,
+              status: v.status?.name(),
+              line_count: v.lines?.size() ?: 0
+          ]
+        }
+    ]
+  }
+
+  private Map<String, Object> getTrialBalance(Map<String, Object> args) {
+    long fiscalYearId = requiredLong(args, 'fiscal_year_id')
+    Long periodId = args.get('accounting_period_id') != null
+        ? ((Number) args.get('accounting_period_id')).longValue()
+        : null
+    LocalDate startDate = args.get('start_date') ? LocalDate.parse((String) args.get('start_date')) : null
+    LocalDate endDate = args.get('end_date') ? LocalDate.parse((String) args.get('end_date')) : null
+    se.alipsa.accounting.domain.report.ReportResult result = reportDataService.generate(
+        new ReportSelection(ReportType.TRIAL_BALANCE, fiscalYearId, periodId, startDate, endDate)
+    )
+    List<TrialBalanceRow> rows = (List<TrialBalanceRow>) result.templateModel.get('typedRows')
+    [
+        ok: true,
+        fiscal_year_id: fiscalYearId,
+        rows: rows.collect { TrialBalanceRow r ->
+          [
+              account_number: r.accountNumber,
+              account_name: r.accountName,
+              opening_balance: r.openingBalance,
+              debit: r.debitAmount,
+              credit: r.creditAmount,
+              closing_balance: r.closingBalance
+          ]
+        }
+    ]
+  }
+
+  private Map<String, Object> getGeneralLedger(Map<String, Object> args) {
+    long fiscalYearId = requiredLong(args, 'fiscal_year_id')
+    Long periodId = args.get('accounting_period_id') != null
+        ? ((Number) args.get('accounting_period_id')).longValue()
+        : null
+    LocalDate startDate = args.get('start_date') ? LocalDate.parse((String) args.get('start_date')) : null
+    LocalDate endDate = args.get('end_date') ? LocalDate.parse((String) args.get('end_date')) : null
+    int limit = args.get('limit') != null ? Math.min(((Number) args.get('limit')).intValue(), 5000) : 1000
+    se.alipsa.accounting.domain.report.ReportResult result = reportDataService.generate(
+        new ReportSelection(ReportType.GENERAL_LEDGER, fiscalYearId, periodId, startDate, endDate)
+    )
+    List<GeneralLedgerRow> rows = (List<GeneralLedgerRow>) result.templateModel.get('typedRows')
+    boolean truncated = rows.size() > limit
+    [
+        ok: true,
+        fiscal_year_id: fiscalYearId,
+        truncated: truncated,
+        total_rows: rows.size(),
+        rows: rows.take(limit).collect { GeneralLedgerRow r ->
+          [
+              account_number: r.accountNumber,
+              account_name: r.accountName,
+              accounting_date: r.accountingDate?.toString(),
+              voucher_number: r.voucherNumber,
+              description: r.description,
+              debit: r.debitAmount,
+              credit: r.creditAmount,
+              balance: r.balance,
+              voucher_id: r.voucherId
+          ]
+        }
+    ]
+  }
+
+  private Map<String, Object> listVatPeriods(Map<String, Object> args) {
+    long fiscalYearId = requiredLong(args, 'fiscal_year_id')
+    List<VatPeriod> periods = vatService.listPeriods(fiscalYearId)
+    [
+        ok: true,
+        vat_periods: periods.collect { VatPeriod p ->
+          [
+              id: p.id,
+              period_name: p.periodName,
+              start_date: p.startDate?.toString(),
+              end_date: p.endDate?.toString(),
+              status: p.status,
+              reported: p.reported,
+              locked: p.locked
+          ]
+        }
+    ]
+  }
+
+  private Map<String, Object> getVatReport(Map<String, Object> args) {
+    long vatPeriodId = requiredLong(args, 'vat_period_id')
+    try {
+      VatService.VatReport report = vatService.calculateReport(vatPeriodId)
+      String reportHash = report.period?.reportHash
+          ?: computePreviewToken([vat_period_id: vatPeriodId])
+      [
+          ok: true,
+          vat_period_id: report.period?.id,
+          period_name: report.period?.periodName,
+          status: report.period?.status,
+          output_vat_total: report.outputVatTotal,
+          input_vat_total: report.inputVatTotal,
+          net_vat_to_pay: report.netVatToPay,
+          report_hash: reportHash,
+          rows: report.rows.collect { VatService.VatReportRow r ->
+            [
+                vat_code: r.vatCode?.name(),
+                label: r.label,
+                base_amount: r.baseAmount,
+                output_vat: r.outputVatAmount,
+                input_vat: r.inputVatAmount
+            ]
+          }
+      ]
+    } catch (Exception e) {
+      [ok: false, errors: [e.message ?: e.class.simpleName]]
+    }
+  }
+
+  // ---- helpers ----
+
+  private static long requiredLong(Map<String, Object> args, String key) {
+    Object value = args.get(key)
+    if (value == null) {
+      throw new IllegalArgumentException("Missing required argument: ${key}")
+    }
+    ((Number) value).longValue()
+  }
+
+  protected static String computePreviewToken(Map<String, Object> canonicalPayload) {
+    String canonical = JsonOutput.toJson(new TreeMap<>(canonicalPayload))
+    MessageDigest.getInstance('SHA-256')
+        .digest(canonical.bytes)
+        .encodeHex()
+        .toString()
+  }
+
+  private static Map<String, Object> intParam(String description) {
+    [type: 'integer', description: description]
+  }
+
+  private static Map<String, Object> optIntParam(String description) {
+    [type: 'integer', description: description]
+  }
+
+  private static Map<String, Object> optStrParam(String description) {
+    [type: 'string', description: description]
+  }
+
+  private static Map<String, Object> toolDef(
+      String name,
+      String description,
+      List<String> required,
+      Map<String, Object> properties
+  ) {
+    [
+        name: name,
+        description: description,
+        inputSchema: [
+            type: 'object',
+            properties: properties,
+            required: required
+        ]
+    ]
   }
 }

--- a/app/src/main/groovy/se/alipsa/accounting/service/VatService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/VatService.groovy
@@ -474,7 +474,7 @@ final class VatService {
     [message]
   }
 
-  private static String calculateReportHash(VatReport report) {
+  static String calculateReportHash(VatReport report) {
     StringBuilder payload = new StringBuilder()
     payload.append(report.period.id).append('|')
     payload.append(REPORTED).append('|')

--- a/app/src/test/groovy/integration/se/alipsa/accounting/mcp/AccountingMcpToolsTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/mcp/AccountingMcpToolsTest.groovy
@@ -146,6 +146,16 @@ class AccountingMcpToolsTest {
   }
 
   @Test
+  void listVouchersRejectsCrossCompanyFiscalYear() {
+    Map<String, Object> result = tools.callTool('list_vouchers', [
+        'company_id': (Object) 9999L,
+        'fiscal_year_id': (Object) fiscalYearId
+    ])
+    assertFalse((boolean) result.get('ok'))
+    assertTrue(((String) result.get('error')).contains('does not belong to company'))
+  }
+
+  @Test
   void getTrialBalanceReturnsStructuredRows() {
     Map<String, Object> result = tools.callTool('get_trial_balance', [
         'company_id': (Object) 1L,

--- a/app/src/test/groovy/integration/se/alipsa/accounting/mcp/AccountingMcpToolsTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/mcp/AccountingMcpToolsTest.groovy
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 
+import se.alipsa.accounting.domain.VoucherLine
 import se.alipsa.accounting.service.AccountService
 import se.alipsa.accounting.service.AccountingPeriodService
 import se.alipsa.accounting.service.AuditLogService
@@ -29,6 +30,7 @@ class AccountingMcpToolsTest {
   private String previousHome
   private DatabaseService databaseService
   private FiscalYearService fiscalYearService
+  private VoucherService voucherService
   private AccountingMcpTools tools
   private long fiscalYearId
 
@@ -42,7 +44,7 @@ class AccountingMcpToolsTest {
     AuditLogService auditLogService = new AuditLogService(databaseService)
     AccountingPeriodService periodService = new AccountingPeriodService(databaseService, auditLogService)
     fiscalYearService = new FiscalYearService(databaseService, periodService, auditLogService)
-    VoucherService voucherService = new VoucherService(databaseService, auditLogService)
+    voucherService = new VoucherService(databaseService, auditLogService)
 
     tools = new AccountingMcpTools(
         new CompanyService(databaseService),
@@ -154,6 +156,16 @@ class AccountingMcpToolsTest {
   }
 
   @Test
+  void getTrialBalanceRejectsCrossCompanyFiscalYear() {
+    Map<String, Object> result = tools.callTool('get_trial_balance', [
+        'company_id': (Object) 9999L,
+        'fiscal_year_id': (Object) fiscalYearId
+    ])
+    assertFalse((boolean) result.get('ok'))
+    assertTrue(((String) result.get('error')).contains('does not belong to company'))
+  }
+
+  @Test
   void getGeneralLedgerReturnsStructuredRows() {
     Map<String, Object> result = tools.callTool('get_general_ledger', [
         'company_id': (Object) 1L,
@@ -164,24 +176,148 @@ class AccountingMcpToolsTest {
   }
 
   @Test
+  void getGeneralLedgerRejectsCrossCompanyFiscalYear() {
+    Map<String, Object> result = tools.callTool('get_general_ledger', [
+        'company_id': (Object) 9999L,
+        'fiscal_year_id': (Object) fiscalYearId
+    ])
+    assertFalse((boolean) result.get('ok'))
+    assertTrue(((String) result.get('error')).contains('does not belong to company'))
+  }
+
+  @Test
+  void getGeneralLedgerClampsNegativeLimit() {
+    Map<String, Object> result = tools.callTool('get_general_ledger', [
+        'company_id': (Object) 1L,
+        'fiscal_year_id': (Object) fiscalYearId,
+        'limit': (Object) -5
+    ])
+    assertTrue((boolean) result.get('ok'))
+    List rows = (List) result.get('rows')
+    assertTrue(rows.size() <= 1)
+  }
+
+  @Test
   void listVatPeriodsReturnsPeriodsForFiscalYear() {
-    Map<String, Object> result = tools.callTool('list_vat_periods', ['fiscal_year_id': (Object) fiscalYearId])
+    Map<String, Object> result = tools.callTool('list_vat_periods', [
+        'company_id': (Object) 1L,
+        'fiscal_year_id': (Object) fiscalYearId
+    ])
     assertTrue((boolean) result.get('ok'))
     List periods = (List) result.get('vat_periods')
     assertFalse(periods.isEmpty())
   }
 
   @Test
+  void listVatPeriodsRejectsCrossCompanyFiscalYear() {
+    Map<String, Object> result = tools.callTool('list_vat_periods', [
+        'company_id': (Object) 9999L,
+        'fiscal_year_id': (Object) fiscalYearId
+    ])
+    assertFalse((boolean) result.get('ok'))
+    assertTrue(((String) result.get('error')).contains('does not belong to company'))
+  }
+
+  @Test
   void getVatReportReturnsReportStructureWithHash() {
-    Map<String, Object> listResult = tools.callTool('list_vat_periods', ['fiscal_year_id': (Object) fiscalYearId])
+    Map<String, Object> listResult = tools.callTool('list_vat_periods', [
+        'company_id': (Object) 1L,
+        'fiscal_year_id': (Object) fiscalYearId
+    ])
     List periods = (List) listResult.get('vat_periods')
     Map firstPeriod = (Map) periods.first()
     long vatPeriodId = ((Number) firstPeriod.get('id')).longValue()
 
-    Map<String, Object> result = tools.callTool('get_vat_report', ['vat_period_id': (Object) vatPeriodId])
+    Map<String, Object> result = tools.callTool('get_vat_report', [
+        'company_id': (Object) 1L,
+        'vat_period_id': (Object) vatPeriodId
+    ])
     assertTrue((boolean) result.get('ok'))
     assertNotNull(result.get('output_vat_total'))
     assertNotNull(result.get('net_vat_to_pay'))
     assertNotNull(result.get('report_hash'), 'get_vat_report skall returnera report_hash')
+  }
+
+  @Test
+  void getVatReportRejectsCrossCompanyVatPeriod() {
+    Map<String, Object> listResult = tools.callTool('list_vat_periods', [
+        'company_id': (Object) 1L,
+        'fiscal_year_id': (Object) fiscalYearId
+    ])
+    List periods = (List) listResult.get('vat_periods')
+    Map firstPeriod = (Map) periods.first()
+    long vatPeriodId = ((Number) firstPeriod.get('id')).longValue()
+
+    Map<String, Object> result = tools.callTool('get_vat_report', [
+        'company_id': (Object) 9999L,
+        'vat_period_id': (Object) vatPeriodId
+    ])
+    assertFalse((boolean) result.get('ok'))
+    assertTrue(((String) result.get('error')).contains('does not belong to company'))
+  }
+
+  @Test
+  void getVatReportHashChangesWhenContentChanges() {
+    Map<String, Object> listResult = tools.callTool('list_vat_periods', [
+        'company_id': (Object) 1L,
+        'fiscal_year_id': (Object) fiscalYearId
+    ])
+    List periods = (List) listResult.get('vat_periods')
+    Map firstPeriod = (Map) periods.first()
+    long vatPeriodId = ((Number) firstPeriod.get('id')).longValue()
+    LocalDate periodStart = LocalDate.parse((String) firstPeriod.get('start_date'))
+
+    Map<String, Object> before = tools.callTool('get_vat_report', [
+        'company_id': (Object) 1L,
+        'vat_period_id': (Object) vatPeriodId
+    ])
+    assertTrue((boolean) before.get('ok'))
+    String hashBefore = (String) before.get('report_hash')
+
+    // Insert VAT-coded accounts and post a voucher that affects VAT
+    long salesAccountId
+    long vatAccountId
+    databaseService.withTransaction { groovy.sql.Sql sql ->
+      List<List<Object>> keys = sql.executeInsert("""
+          insert into account (
+              company_id, account_number, account_name,
+              account_class, normal_balance_side, active,
+              manual_review_required, vat_code, created_at, updated_at
+          ) values (?, '3000', 'Försäljning varor', 'INCOME', 'CREDIT',
+              true, false, 'OUTPUT_25', current_timestamp, current_timestamp)
+      """, [CompanyService.LEGACY_COMPANY_ID])
+      salesAccountId = ((Number) keys.first().first()).longValue()
+
+      List<List<Object>> keys2 = sql.executeInsert("""
+          insert into account (
+              company_id, account_number, account_name,
+              account_class, normal_balance_side, active,
+              manual_review_required, vat_code, created_at, updated_at
+          ) values (?, '2610', 'Utgående moms', 'LIABILITY', 'CREDIT',
+              true, false, 'OUTPUT_25', current_timestamp, current_timestamp)
+      """, [CompanyService.LEGACY_COMPANY_ID])
+      vatAccountId = ((Number) keys2.first().first()).longValue()
+    }
+
+    voucherService.createVoucher(
+        fiscalYearId,
+        'A',
+        periodStart.plusDays(5),
+        'Försäljning med moms',
+        [
+            new VoucherLine(null, null, 0, salesAccountId, '3000', 'Försäljning varor', null, 0.00G, 1000.00G),
+            new VoucherLine(null, null, 1, vatAccountId, '2610', 'Utgående moms', null, 0.00G, 250.00G),
+            new VoucherLine(null, null, 2, null, '1930', 'Företagskonto', null, 1250.00G, 0.00G)
+        ]
+    )
+
+    Map<String, Object> after = tools.callTool('get_vat_report', [
+        'company_id': (Object) 1L,
+        'vat_period_id': (Object) vatPeriodId
+    ])
+    assertTrue((boolean) after.get('ok'))
+    String hashAfter = (String) after.get('report_hash')
+
+    assertNotEquals(hashBefore, hashAfter, 'VAT report hash skall ändras när bokföring påverkar momsperioden')
   }
 }

--- a/app/src/test/groovy/integration/se/alipsa/accounting/mcp/AccountingMcpToolsTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/mcp/AccountingMcpToolsTest.groovy
@@ -1,0 +1,187 @@
+package se.alipsa.accounting.mcp
+
+import static org.junit.jupiter.api.Assertions.*
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+import se.alipsa.accounting.service.AccountService
+import se.alipsa.accounting.service.AccountingPeriodService
+import se.alipsa.accounting.service.AuditLogService
+import se.alipsa.accounting.service.CompanyService
+import se.alipsa.accounting.service.DatabaseService
+import se.alipsa.accounting.service.FiscalYearService
+import se.alipsa.accounting.service.ReportDataService
+import se.alipsa.accounting.service.VatService
+import se.alipsa.accounting.service.VoucherService
+import se.alipsa.accounting.support.AppPaths
+
+import java.nio.file.Path
+import java.time.LocalDate
+
+class AccountingMcpToolsTest {
+
+  @TempDir
+  Path tempDir
+
+  private String previousHome
+  private DatabaseService databaseService
+  private FiscalYearService fiscalYearService
+  private AccountingMcpTools tools
+  private long fiscalYearId
+
+  @BeforeEach
+  void setUp() {
+    previousHome = System.getProperty(AppPaths.HOME_OVERRIDE_PROPERTY)
+    System.setProperty(AppPaths.HOME_OVERRIDE_PROPERTY, tempDir.toString())
+    databaseService = DatabaseService.newForTesting()
+    databaseService.initialize()
+
+    AuditLogService auditLogService = new AuditLogService(databaseService)
+    AccountingPeriodService periodService = new AccountingPeriodService(databaseService, auditLogService)
+    fiscalYearService = new FiscalYearService(databaseService, periodService, auditLogService)
+    VoucherService voucherService = new VoucherService(databaseService, auditLogService)
+
+    tools = new AccountingMcpTools(
+        new CompanyService(databaseService),
+        fiscalYearService,
+        new AccountService(databaseService),
+        voucherService,
+        new VatService(databaseService, voucherService, auditLogService),
+        new se.alipsa.accounting.service.ClosingService(
+            databaseService,
+            periodService,
+            fiscalYearService,
+            voucherService,
+            new se.alipsa.accounting.service.ReportIntegrityService()
+        ),
+        new ReportDataService(databaseService)
+    )
+
+    databaseService.withTransaction { groovy.sql.Sql sql ->
+      sql.executeInsert("""
+          insert into account (
+              company_id, account_number, account_name,
+              account_class, normal_balance_side, active,
+              manual_review_required, created_at, updated_at
+          ) values (?, '1930', 'Företagskonto', 'ASSET', 'DEBIT',
+              true, false, current_timestamp, current_timestamp)
+      """, [CompanyService.LEGACY_COMPANY_ID])
+
+      sql.executeInsert("""
+          insert into account (
+              company_id, account_number, account_name,
+              account_class, normal_balance_side, active,
+              manual_review_required, created_at, updated_at
+          ) values (?, '2440', 'Leverantörsskulder', 'LIABILITY', 'CREDIT',
+              true, false, current_timestamp, current_timestamp)
+      """, [CompanyService.LEGACY_COMPANY_ID])
+    }
+
+    se.alipsa.accounting.domain.FiscalYear year = fiscalYearService.createFiscalYear(
+        CompanyService.LEGACY_COMPANY_ID, '2026',
+        LocalDate.of(2026, 1, 1), LocalDate.of(2026, 12, 31)
+    )
+    fiscalYearId = year.id
+  }
+
+  @AfterEach
+  void tearDown() {
+    databaseService?.shutdown()
+    if (previousHome == null) {
+      System.clearProperty(AppPaths.HOME_OVERRIDE_PROPERTY)
+    } else {
+      System.setProperty(AppPaths.HOME_OVERRIDE_PROPERTY, previousHome)
+    }
+  }
+
+  @Test
+  void getCompanyInfoReturnsLegacyCompany() {
+    Map<String, Object> result = tools.callTool('get_company_info', ['company_id': (Object) 1L])
+    assertTrue((boolean) result.get('ok'))
+    Map company = (Map) result.get('company')
+    assertEquals(1L, ((Number) company.get('id')).longValue())
+  }
+
+  @Test
+  void getCompanyInfoUnknownIdReturnsError() {
+    Map<String, Object> result = tools.callTool('get_company_info', ['company_id': (Object) 9999L])
+    assertFalse((boolean) result.get('ok'))
+    assertNotNull(result.get('error'))
+  }
+
+  @Test
+  void listFiscalYearsReturnsCreatedYear() {
+    Map<String, Object> result = tools.callTool('list_fiscal_years', ['company_id': (Object) 1L])
+    assertTrue((boolean) result.get('ok'))
+    List years = (List) result.get('fiscal_years')
+    assertEquals(1, years.size())
+    Map year = (Map) years.first()
+    assertEquals('2026', year.get('name'))
+    assertFalse((boolean) year.get('closed'))
+  }
+
+  @Test
+  void listAccountsReturnsActiveAccounts() {
+    Map<String, Object> result = tools.callTool('list_accounts', ['company_id': (Object) 1L])
+    assertTrue((boolean) result.get('ok'))
+    List accounts = (List) result.get('accounts')
+    assertEquals(2, accounts.size())
+    assertTrue(((List<Map>) accounts).any { Map a -> a.get('account_number') == '1930' })
+  }
+
+  @Test
+  void listVouchersReturnsEmptyWhenNonePosted() {
+    Map<String, Object> result = tools.callTool('list_vouchers', [
+        'company_id': (Object) 1L,
+        'fiscal_year_id': (Object) fiscalYearId
+    ])
+    assertTrue((boolean) result.get('ok'))
+    List vouchers = (List) result.get('vouchers')
+    assertTrue(vouchers.isEmpty())
+  }
+
+  @Test
+  void getTrialBalanceReturnsStructuredRows() {
+    Map<String, Object> result = tools.callTool('get_trial_balance', [
+        'company_id': (Object) 1L,
+        'fiscal_year_id': (Object) fiscalYearId
+    ])
+    assertTrue((boolean) result.get('ok'))
+    assertNotNull(result.get('rows'))
+  }
+
+  @Test
+  void getGeneralLedgerReturnsStructuredRows() {
+    Map<String, Object> result = tools.callTool('get_general_ledger', [
+        'company_id': (Object) 1L,
+        'fiscal_year_id': (Object) fiscalYearId
+    ])
+    assertTrue((boolean) result.get('ok'))
+    assertNotNull(result.get('rows'))
+  }
+
+  @Test
+  void listVatPeriodsReturnsPeriodsForFiscalYear() {
+    Map<String, Object> result = tools.callTool('list_vat_periods', ['fiscal_year_id': (Object) fiscalYearId])
+    assertTrue((boolean) result.get('ok'))
+    List periods = (List) result.get('vat_periods')
+    assertFalse(periods.isEmpty())
+  }
+
+  @Test
+  void getVatReportReturnsReportStructureWithHash() {
+    Map<String, Object> listResult = tools.callTool('list_vat_periods', ['fiscal_year_id': (Object) fiscalYearId])
+    List periods = (List) listResult.get('vat_periods')
+    Map firstPeriod = (Map) periods.first()
+    long vatPeriodId = ((Number) firstPeriod.get('id')).longValue()
+
+    Map<String, Object> result = tools.callTool('get_vat_report', ['vat_period_id': (Object) vatPeriodId])
+    assertTrue((boolean) result.get('ok'))
+    assertNotNull(result.get('output_vat_total'))
+    assertNotNull(result.get('net_vat_to_pay'))
+    assertNotNull(result.get('report_hash'), 'get_vat_report skall returnera report_hash')
+  }
+}


### PR DESCRIPTION
Implements Phase 2 of `req/v1.1.0-ai-impl-plan.md`.

**Read-only tools added:**
- `get_company_info` — company record lookup
- `list_fiscal_years` — fiscal years with open/closed status
- `list_accounts` — chart of accounts with optional query
- `list_vouchers` — posted vouchers (max 200 rows)
- `get_trial_balance` — opening/period/closing balance per account
- `get_general_ledger` — posting history with running balance
- `list_vat_periods` — VAT periods with status
- `get_vat_report` — VAT calculation with `report_hash`

**Other changes:**
- `AccountingMcpTools` now has a 7-arg constructor for test injection and a no-arg constructor for production use.
- Added `computePreviewToken` helper (SHA-256) for the upcoming write-tool token enforcement.
- Added `AccountingMcpToolsTest` integration tests covering all read-only tools against a real test database.

**Build:** `./gradlew build` passes (Spotless + CodeNarc + tests).