### PR TITLE
[codex] implementera fas 4 för MCP-moms och bokslut

### DIFF
--- a/app/src/main/groovy/se/alipsa/accounting/mcp/AccountingMcpTools.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/mcp/AccountingMcpTools.groovy
@@ -19,6 +19,8 @@ import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.service.ReportDataService
 import se.alipsa.accounting.service.VatService
 import se.alipsa.accounting.service.VoucherService
+import se.alipsa.accounting.service.YearEndClosingPreview
+import se.alipsa.accounting.service.YearEndClosingResult
 
 import java.security.MessageDigest
 import java.time.LocalDate
@@ -70,7 +72,7 @@ class AccountingMcpTools {
   }
 
   List<Map<String, Object>> listTools() {
-    readOnlyToolDefs() + voucherToolDefs()
+    readOnlyToolDefs() + voucherToolDefs() + vatWriteToolDefs() + yearEndToolDefs()
   }
 
   private static List<Map<String, Object>> readOnlyToolDefs() {
@@ -181,6 +183,46 @@ class AccountingMcpTools {
     ]
   }
 
+  private static List<Map<String, Object>> vatWriteToolDefs() {
+    [
+        toolDef('book_vat_transfer',
+            'Books the VAT transfer voucher for a VAT period. Run get_vat_report first and pass back its report_hash.',
+            ['company_id', 'vat_period_id', 'report_hash'],
+            [
+                company_id: intParam('Company ID'),
+                vat_period_id: intParam('VAT period ID'),
+                report_hash: strParam('Hash returned by get_vat_report for the current VAT report.'),
+                series_code: optStrParam('Optional voucher series code. Defaults to "M".'),
+                settlement_account: optStrParam('Optional settlement account number. Defaults to "2650".')
+            ]
+        ),
+    ]
+  }
+
+  private static List<Map<String, Object>> yearEndToolDefs() {
+    [
+        toolDef('preview_year_end',
+            'Runs year-end closing pre-checks. Returns blocking issues, warnings, totals, net result, and a preview_token.',
+            ['company_id', 'fiscal_year_id'],
+            [
+                company_id: intParam('Company ID'),
+                fiscal_year_id: intParam('Fiscal year ID to preview'),
+                closing_account: optStrParam('Optional closing account number. Defaults to "2099".')
+            ]
+        ),
+        toolDef('close_fiscal_year',
+            'Closes the fiscal year. Requires the preview_token returned by preview_year_end for the same fiscal year and closing account.',
+            ['company_id', 'fiscal_year_id', 'preview_token'],
+            [
+                company_id: intParam('Company ID'),
+                fiscal_year_id: intParam('Fiscal year ID to close'),
+                closing_account: optStrParam('Optional closing account number. Defaults to "2099".'),
+                preview_token: strParam('Token returned by preview_year_end.')
+            ]
+        ),
+    ]
+  }
+
   Map<String, Object> callTool(String name, Map<String, Object> arguments) {
     switch (name) {
       case 'get_company_info':
@@ -199,12 +241,18 @@ class AccountingMcpTools {
         return listVatPeriods(arguments)
       case 'get_vat_report':
         return getVatReport(arguments)
+      case 'book_vat_transfer':
+        return bookVatTransfer(arguments)
       case 'preview_voucher':
         return previewVoucher(arguments)
       case 'post_voucher':
         return postVoucher(arguments)
       case 'create_correction_voucher':
         return createCorrectionVoucher(arguments)
+      case 'preview_year_end':
+        return previewYearEnd(arguments)
+      case 'close_fiscal_year':
+        return closeFiscalYear(arguments)
       default:
         throw new IllegalArgumentException("Unknown MCP tool: ${name}")
     }
@@ -426,6 +474,48 @@ class AccountingMcpTools {
     }
   }
 
+  private Map<String, Object> bookVatTransfer(Map<String, Object> args) {
+    long companyId = requiredLong(args, 'company_id')
+    long vatPeriodId = requiredLong(args, 'vat_period_id')
+    String providedHash = args.get('report_hash') as String
+    if (!providedHash) {
+      return [ok: false, errors: ['report_hash krävs — kör get_vat_report först och skicka med det returnerade report_hash.']]
+    }
+    String seriesCode = optionalString(args, 'series_code', VatService.DEFAULT_TRANSFER_SERIES)
+    String settlementAccount = optionalString(args, 'settlement_account', VatService.DEFAULT_SETTLEMENT_ACCOUNT)
+    try {
+      VatPeriod period = vatService.findPeriod(vatPeriodId)
+      if (period == null) {
+        return [ok: false, errors: ["Okänd momsperiod: ${vatPeriodId}".toString()]]
+      }
+      long expectedCompanyId = companyService.resolveFromFiscalYear(period.fiscalYearId)
+      if (expectedCompanyId != companyId) {
+        return [ok: false, error: "VAT period ${vatPeriodId} does not belong to company ${companyId}."]
+      }
+      VatService.VatReport report = vatService.calculateReport(vatPeriodId)
+      String expectedHash = VatService.calculateReportHash(report)
+      if (providedHash != expectedHash) {
+        return [ok: false, errors: ['report_hash stämmer inte med aktuell momsrapport — kör get_vat_report igen.']]
+      }
+      if (period.status == VatService.OPEN) {
+        vatService.reportPeriod(vatPeriodId)
+      }
+      Voucher voucher = vatService.bookTransfer(vatPeriodId, seriesCode, settlementAccount)
+      [
+          ok: true,
+          voucher_id: voucher.id,
+          voucher_number: voucher.voucherNumber,
+          fiscal_year_id: voucher.fiscalYearId,
+          accounting_date: voucher.accountingDate?.toString(),
+          description: voucher.description,
+          status: voucher.status?.name(),
+          line_count: voucher.lines?.size() ?: 0
+      ]
+    } catch (Exception exception) {
+      [ok: false, errors: [exception.message ?: exception.class.simpleName]]
+    }
+  }
+
   private Map<String, Object> previewVoucher(Map<String, Object> args) {
     long companyId = requiredLong(args, 'company_id')
     long fiscalYearId = requiredLong(args, 'fiscal_year_id')
@@ -538,6 +628,75 @@ class AccountingMcpTools {
     }
   }
 
+  private Map<String, Object> previewYearEnd(Map<String, Object> args) {
+    long companyId = requiredLong(args, 'company_id')
+    long fiscalYearId = requiredLong(args, 'fiscal_year_id')
+    String closingAccount = optionalString(args, 'closing_account', ClosingService.DEFAULT_CLOSING_ACCOUNT)
+    try {
+      long expectedCompanyId = companyService.resolveFromFiscalYear(fiscalYearId)
+      if (expectedCompanyId != companyId) {
+        return [ok: false, error: "Fiscal year ${fiscalYearId} does not belong to company ${companyId}."]
+      }
+      YearEndClosingPreview preview = closingService.previewClosing(fiscalYearId, closingAccount)
+      [
+          ok: true,
+          fiscal_year_id: preview.fiscalYear?.id,
+          fiscal_year_name: preview.fiscalYear?.name,
+          next_fiscal_year_id: preview.nextFiscalYear?.id,
+          next_fiscal_year_name: preview.nextFiscalYear?.name,
+          next_fiscal_year_will_be_created: preview.nextFiscalYearWillBeCreated,
+          closing_account: preview.closingAccountNumber,
+          result_account_count: preview.resultAccountCount,
+          income_total: preview.incomeTotal,
+          expense_total: preview.expenseTotal,
+          net_result: preview.netResult,
+          blocking_issues: preview.blockingIssues,
+          warnings: preview.warnings,
+          ready_to_close: preview.blockingIssues.isEmpty(),
+          preview_token: yearEndPreviewToken(fiscalYearId, preview.closingAccountNumber)
+      ]
+    } catch (Exception exception) {
+      [ok: false, errors: [exception.message ?: exception.class.simpleName]]
+    }
+  }
+
+  private Map<String, Object> closeFiscalYear(Map<String, Object> args) {
+    long companyId = requiredLong(args, 'company_id')
+    long fiscalYearId = requiredLong(args, 'fiscal_year_id')
+    String closingAccount = optionalString(args, 'closing_account', ClosingService.DEFAULT_CLOSING_ACCOUNT)
+    String providedToken = args.get('preview_token') as String
+    if (!providedToken) {
+      return [ok: false, errors: ['preview_token krävs — kör preview_year_end först.']]
+    }
+    String expectedToken = yearEndPreviewToken(fiscalYearId, closingAccount)
+    if (providedToken != expectedToken) {
+      return [ok: false, errors: ['preview_token stämmer inte — kör preview_year_end igen.']]
+    }
+    try {
+      long expectedCompanyId = companyService.resolveFromFiscalYear(fiscalYearId)
+      if (expectedCompanyId != companyId) {
+        return [ok: false, error: "Fiscal year ${fiscalYearId} does not belong to company ${companyId}."]
+      }
+      YearEndClosingResult result = closingService.closeFiscalYear(fiscalYearId, closingAccount)
+      [
+          ok: true,
+          closed_fiscal_year_id: result.closedFiscalYear?.id,
+          closed_fiscal_year_name: result.closedFiscalYear?.name,
+          next_fiscal_year_id: result.nextFiscalYear?.id,
+          next_fiscal_year_name: result.nextFiscalYear?.name,
+          closing_voucher_id: result.closingVoucher?.id,
+          closing_voucher_number: result.closingVoucher?.voucherNumber,
+          result_account_count: result.resultAccountCount,
+          opening_balance_count: result.openingBalanceCount,
+          closing_entry_count: result.closingEntryCount,
+          net_result: result.netResult,
+          warnings: result.warnings
+      ]
+    } catch (Exception exception) {
+      [ok: false, errors: [exception.message ?: exception.class.simpleName]]
+    }
+  }
+
   // ---- helpers ----
 
   private static long requiredLong(Map<String, Object> args, String key) {
@@ -554,6 +713,11 @@ class AccountingMcpTools {
       throw new IllegalArgumentException("Missing required argument: ${key}")
     }
     value.trim()
+  }
+
+  private static String optionalString(Map<String, Object> args, String key, String defaultValue) {
+    String value = args.get(key) as String
+    value?.trim() ?: defaultValue
   }
 
   private static List<Map<String, Object>> linesArg(Map<String, Object> args) {
@@ -590,6 +754,13 @@ class AccountingMcpTools {
         accounting_date: accountingDate,
         description: description,
         lines: canonicalVoucherLines(lines)
+    ])
+  }
+
+  private static String yearEndPreviewToken(long fiscalYearId, String closingAccount) {
+    computePreviewToken([
+        fiscal_year_id: fiscalYearId,
+        closing_account: closingAccount
     ])
   }
 

--- a/app/src/main/groovy/se/alipsa/accounting/mcp/AccountingMcpTools.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/mcp/AccountingMcpTools.groovy
@@ -490,7 +490,7 @@ class AccountingMcpTools {
       }
       long expectedCompanyId = companyService.resolveFromFiscalYear(period.fiscalYearId)
       if (expectedCompanyId != companyId) {
-        return [ok: false, error: "VAT period ${vatPeriodId} does not belong to company ${companyId}."]
+        return [ok: false, errors: ["VAT period ${vatPeriodId} does not belong to company ${companyId}.".toString()]]
       }
       VatService.VatReport report = vatService.calculateReport(vatPeriodId)
       String expectedHash = VatService.calculateReportHash(report)
@@ -635,9 +635,10 @@ class AccountingMcpTools {
     try {
       long expectedCompanyId = companyService.resolveFromFiscalYear(fiscalYearId)
       if (expectedCompanyId != companyId) {
-        return [ok: false, error: "Fiscal year ${fiscalYearId} does not belong to company ${companyId}."]
+        return [ok: false, errors: ["Fiscal year ${fiscalYearId} does not belong to company ${companyId}.".toString()]]
       }
       YearEndClosingPreview preview = closingService.previewClosing(fiscalYearId, closingAccount)
+      boolean readyToClose = preview.blockingIssues.isEmpty()
       [
           ok: true,
           fiscal_year_id: preview.fiscalYear?.id,
@@ -652,8 +653,8 @@ class AccountingMcpTools {
           net_result: preview.netResult,
           blocking_issues: preview.blockingIssues,
           warnings: preview.warnings,
-          ready_to_close: preview.blockingIssues.isEmpty(),
-          preview_token: yearEndPreviewToken(fiscalYearId, preview.closingAccountNumber)
+          ready_to_close: readyToClose,
+          preview_token: readyToClose ? yearEndPreviewToken(fiscalYearId, preview.closingAccountNumber) : null
       ]
     } catch (Exception exception) {
       [ok: false, errors: [exception.message ?: exception.class.simpleName]]
@@ -664,6 +665,10 @@ class AccountingMcpTools {
     long companyId = requiredLong(args, 'company_id')
     long fiscalYearId = requiredLong(args, 'fiscal_year_id')
     String closingAccount = optionalString(args, 'closing_account', ClosingService.DEFAULT_CLOSING_ACCOUNT)
+    long expectedCompanyId = companyService.resolveFromFiscalYear(fiscalYearId)
+    if (expectedCompanyId != companyId) {
+      return [ok: false, errors: ["Fiscal year ${fiscalYearId} does not belong to company ${companyId}.".toString()]]
+    }
     String providedToken = args.get('preview_token') as String
     if (!providedToken) {
       return [ok: false, errors: ['preview_token krävs — kör preview_year_end först.']]
@@ -673,10 +678,6 @@ class AccountingMcpTools {
       return [ok: false, errors: ['preview_token stämmer inte — kör preview_year_end igen.']]
     }
     try {
-      long expectedCompanyId = companyService.resolveFromFiscalYear(fiscalYearId)
-      if (expectedCompanyId != companyId) {
-        return [ok: false, error: "Fiscal year ${fiscalYearId} does not belong to company ${companyId}."]
-      }
       YearEndClosingResult result = closingService.closeFiscalYear(fiscalYearId, closingAccount)
       [
           ok: true,

--- a/app/src/main/groovy/se/alipsa/accounting/mcp/AccountingMcpTools.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/mcp/AccountingMcpTools.groovy
@@ -665,19 +665,19 @@ class AccountingMcpTools {
     long companyId = requiredLong(args, 'company_id')
     long fiscalYearId = requiredLong(args, 'fiscal_year_id')
     String closingAccount = optionalString(args, 'closing_account', ClosingService.DEFAULT_CLOSING_ACCOUNT)
-    long expectedCompanyId = companyService.resolveFromFiscalYear(fiscalYearId)
-    if (expectedCompanyId != companyId) {
-      return [ok: false, errors: ["Fiscal year ${fiscalYearId} does not belong to company ${companyId}.".toString()]]
-    }
     String providedToken = args.get('preview_token') as String
     if (!providedToken) {
       return [ok: false, errors: ['preview_token krävs — kör preview_year_end först.']]
     }
-    String expectedToken = yearEndPreviewToken(fiscalYearId, closingAccount)
-    if (providedToken != expectedToken) {
-      return [ok: false, errors: ['preview_token stämmer inte — kör preview_year_end igen.']]
-    }
     try {
+      long expectedCompanyId = companyService.resolveFromFiscalYear(fiscalYearId)
+      if (expectedCompanyId != companyId) {
+        return [ok: false, errors: ["Fiscal year ${fiscalYearId} does not belong to company ${companyId}.".toString()]]
+      }
+      String expectedToken = yearEndPreviewToken(fiscalYearId, closingAccount)
+      if (providedToken != expectedToken) {
+        return [ok: false, errors: ['preview_token stämmer inte — kör preview_year_end igen.']]
+      }
       YearEndClosingResult result = closingService.closeFiscalYear(fiscalYearId, closingAccount)
       [
           ok: true,

--- a/app/src/test/groovy/integration/se/alipsa/accounting/mcp/AccountingMcpToolsTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/mcp/AccountingMcpToolsTest.groovy
@@ -395,6 +395,18 @@ class AccountingMcpToolsTest {
   }
 
   @Test
+  void previewYearEndOmitsTokenWhenBlockingIssuesExist() {
+    Map<String, Object> result = tools.callTool('preview_year_end', [
+        company_id: (Object) 1L,
+        fiscal_year_id: (Object) fiscalYearId
+    ])
+
+    assertTrue((boolean) result.get('ok'))
+    assertFalse((boolean) result.get('ready_to_close'))
+    assertNull(result.get('preview_token'), 'Blockerad årsstängning skall inte ha en preview_token')
+  }
+
+  @Test
   void closeFiscalYearWithoutPreviewTokenIsRejected() {
     insertClosingAccount()
 
@@ -421,6 +433,19 @@ class AccountingMcpToolsTest {
     assertFalse((boolean) result.get('ok'))
     List<String> errors = (List<String>) result.get('errors')
     assertTrue(errors.any { String error -> error.contains('preview_token') })
+  }
+
+  @Test
+  void closeFiscalYearChecksOwnershipBeforePreviewToken() {
+    Map<String, Object> result = tools.callTool('close_fiscal_year', [
+        company_id: (Object) 9999L,
+        fiscal_year_id: (Object) fiscalYearId,
+        preview_token: (Object) 'wrong-token'
+    ])
+
+    assertFalse((boolean) result.get('ok'))
+    List<String> errors = (List<String>) result.get('errors')
+    assertTrue(errors.any { String error -> error.contains('does not belong to company') })
   }
 
   @Test
@@ -627,6 +652,7 @@ class AccountingMcpToolsTest {
     LocalDate periodStart = LocalDate.parse((String) firstPeriod.get('start_date'))
     long salesAccountId = insertAccount('3000', 'Försäljning varor', 'INCOME', 'CREDIT', 'OUTPUT_25')
     long vatAccountId = insertAccount('2610', 'Utgående moms', 'LIABILITY', 'CREDIT', 'OUTPUT_25')
+    long bankAccountId = accountId('1930')
     insertAccount('2650', 'Momsredovisningskonto', 'LIABILITY', 'CREDIT', null)
 
     voucherService.createVoucher(
@@ -637,7 +663,7 @@ class AccountingMcpToolsTest {
         [
             new VoucherLine(null, null, 0, salesAccountId, '3000', 'Försäljning varor', null, 0.00G, 1000.00G),
             new VoucherLine(null, null, 1, vatAccountId, '2610', 'Utgående moms', null, 0.00G, 250.00G),
-            new VoucherLine(null, null, 2, null, '1930', 'Företagskonto', null, 1250.00G, 0.00G)
+            new VoucherLine(null, null, 2, bankAccountId, '1930', 'Företagskonto', null, 1250.00G, 0.00G)
         ]
     )
   }
@@ -662,6 +688,16 @@ class AccountingMcpToolsTest {
           ) values (?, ?, ?, ?, ?, true, false, ?, current_timestamp, current_timestamp)
       """, [CompanyService.LEGACY_COMPANY_ID, accountNumber, accountName, accountClass, normalBalanceSide, vatCode])
       ((Number) keys.first().first()).longValue()
+    }
+  }
+
+  private long accountId(String accountNumber) {
+    databaseService.withSql { groovy.sql.Sql sql ->
+      Map row = sql.firstRow(
+          'select id from account where company_id = ? and account_number = ?',
+          [CompanyService.LEGACY_COMPANY_ID, accountNumber]
+      ) as Map
+      ((Number) row.id).longValue()
     }
   }
 

--- a/app/src/test/groovy/integration/se/alipsa/accounting/mcp/AccountingMcpToolsTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/mcp/AccountingMcpToolsTest.groovy
@@ -268,12 +268,7 @@ class AccountingMcpToolsTest {
 
   @Test
   void getVatReportHashChangesWhenContentChanges() {
-    Map<String, Object> listResult = tools.callTool('list_vat_periods', [
-        'company_id': (Object) 1L,
-        'fiscal_year_id': (Object) fiscalYearId
-    ])
-    List periods = (List) listResult.get('vat_periods')
-    Map firstPeriod = (Map) periods.first()
+    Map firstPeriod = firstVatPeriod()
     long vatPeriodId = ((Number) firstPeriod.get('id')).longValue()
     LocalDate periodStart = LocalDate.parse((String) firstPeriod.get('start_date'))
 
@@ -329,6 +324,125 @@ class AccountingMcpToolsTest {
     String hashAfter = (String) after.get('report_hash')
 
     assertNotEquals(hashBefore, hashAfter, 'VAT report hash skall ändras när bokföring påverkar momsperioden')
+  }
+
+  @Test
+  void bookVatTransferWithoutReportHashIsRejected() {
+    long vatPeriodId = firstVatPeriodId()
+
+    Map<String, Object> result = tools.callTool('book_vat_transfer', [
+        company_id: (Object) 1L,
+        vat_period_id: (Object) vatPeriodId
+    ])
+
+    assertFalse((boolean) result.get('ok'))
+    List<String> errors = (List<String>) result.get('errors')
+    assertTrue(errors.any { String error -> error.contains('report_hash') })
+  }
+
+  @Test
+  void bookVatTransferWithTamperedReportHashIsRejected() {
+    postVatSaleInFirstPeriod()
+    long vatPeriodId = firstVatPeriodId()
+
+    Map<String, Object> result = tools.callTool('book_vat_transfer', [
+        company_id: (Object) 1L,
+        vat_period_id: (Object) vatPeriodId,
+        report_hash: (Object) 'wrong-hash'
+    ])
+
+    assertFalse((boolean) result.get('ok'))
+    List<String> errors = (List<String>) result.get('errors')
+    assertTrue(errors.any { String error -> error.contains('report_hash') })
+  }
+
+  @Test
+  void bookVatTransferWithReportHashBooksVoucherAndLocksPeriod() {
+    postVatSaleInFirstPeriod()
+    long vatPeriodId = firstVatPeriodId()
+    Map<String, Object> report = tools.callTool('get_vat_report', [
+        company_id: (Object) 1L,
+        vat_period_id: (Object) vatPeriodId
+    ])
+    assertTrue((boolean) report.get('ok'))
+
+    Map<String, Object> result = tools.callTool('book_vat_transfer', [
+        company_id: (Object) 1L,
+        vat_period_id: (Object) vatPeriodId,
+        report_hash: (Object) report.get('report_hash')
+    ])
+
+    assertTrue((boolean) result.get('ok'), "Expected ok but got: ${result.get('errors')}")
+    assertNotNull(result.get('voucher_id'))
+    assertTrue(result.get('voucher_number').toString().startsWith('M'))
+    assertEquals('LOCKED', ((Map) firstVatPeriod()).get('status'))
+  }
+
+  @Test
+  void previewYearEndReturnsFiscalYearInfoAndToken() {
+    insertClosingAccount()
+
+    Map<String, Object> result = tools.callTool('preview_year_end', [
+        company_id: (Object) 1L,
+        fiscal_year_id: (Object) fiscalYearId
+    ])
+
+    assertTrue((boolean) result.get('ok'))
+    assertNotNull(result.get('net_result'))
+    assertNotNull(result.get('blocking_issues'))
+    assertNotNull(result.get('warnings'))
+    assertNotNull(result.get('preview_token'), 'preview_year_end skall returnera preview_token')
+  }
+
+  @Test
+  void closeFiscalYearWithoutPreviewTokenIsRejected() {
+    insertClosingAccount()
+
+    Map<String, Object> result = tools.callTool('close_fiscal_year', [
+        company_id: (Object) 1L,
+        fiscal_year_id: (Object) fiscalYearId
+    ])
+
+    assertFalse((boolean) result.get('ok'))
+    List<String> errors = (List<String>) result.get('errors')
+    assertTrue(errors.any { String error -> error.contains('preview_token') })
+  }
+
+  @Test
+  void closeFiscalYearWithTamperedPreviewTokenIsRejected() {
+    insertClosingAccount()
+
+    Map<String, Object> result = tools.callTool('close_fiscal_year', [
+        company_id: (Object) 1L,
+        fiscal_year_id: (Object) fiscalYearId,
+        preview_token: (Object) 'wrong-token'
+    ])
+
+    assertFalse((boolean) result.get('ok'))
+    List<String> errors = (List<String>) result.get('errors')
+    assertTrue(errors.any { String error -> error.contains('preview_token') })
+  }
+
+  @Test
+  void closeFiscalYearWithPreviewTokenClosesYear() {
+    insertClosingAccount()
+    Map<String, Object> preview = tools.callTool('preview_year_end', [
+        company_id: (Object) 1L,
+        fiscal_year_id: (Object) fiscalYearId
+    ])
+    assertTrue((boolean) preview.get('ok'), "Expected ok but got: ${preview.get('errors')}")
+    assertTrue((boolean) preview.get('ready_to_close'), "Expected ready but got blockers: ${preview.get('blocking_issues')}")
+
+    Map<String, Object> result = tools.callTool('close_fiscal_year', [
+        company_id: (Object) 1L,
+        fiscal_year_id: (Object) fiscalYearId,
+        preview_token: (Object) preview.get('preview_token')
+    ])
+
+    assertTrue((boolean) result.get('ok'), "Expected ok but got: ${result.get('errors')}")
+    assertEquals(fiscalYearId, ((Number) result.get('closed_fiscal_year_id')).longValue())
+    assertNotNull(result.get('next_fiscal_year_id'))
+    assertTrue(fiscalYearService.findById(fiscalYearId).closed)
   }
 
   @Test
@@ -493,6 +607,62 @@ class AccountingMcpToolsTest {
     Map<String, Object> argsWithToken = new LinkedHashMap<>(postArgs)
     argsWithToken.put('preview_token', (Object) token)
     tools.callTool('post_voucher', argsWithToken)
+  }
+
+  private Map firstVatPeriod() {
+    Map<String, Object> listResult = tools.callTool('list_vat_periods', [
+        company_id: (Object) 1L,
+        fiscal_year_id: (Object) fiscalYearId
+    ])
+    List periods = (List) listResult.get('vat_periods')
+    (Map) periods.first()
+  }
+
+  private long firstVatPeriodId() {
+    ((Number) firstVatPeriod().get('id')).longValue()
+  }
+
+  private void postVatSaleInFirstPeriod() {
+    Map firstPeriod = firstVatPeriod()
+    LocalDate periodStart = LocalDate.parse((String) firstPeriod.get('start_date'))
+    long salesAccountId = insertAccount('3000', 'Försäljning varor', 'INCOME', 'CREDIT', 'OUTPUT_25')
+    long vatAccountId = insertAccount('2610', 'Utgående moms', 'LIABILITY', 'CREDIT', 'OUTPUT_25')
+    insertAccount('2650', 'Momsredovisningskonto', 'LIABILITY', 'CREDIT', null)
+
+    voucherService.createVoucher(
+        fiscalYearId,
+        'A',
+        periodStart.plusDays(5),
+        'Försäljning med moms',
+        [
+            new VoucherLine(null, null, 0, salesAccountId, '3000', 'Försäljning varor', null, 0.00G, 1000.00G),
+            new VoucherLine(null, null, 1, vatAccountId, '2610', 'Utgående moms', null, 0.00G, 250.00G),
+            new VoucherLine(null, null, 2, null, '1930', 'Företagskonto', null, 1250.00G, 0.00G)
+        ]
+    )
+  }
+
+  private void insertClosingAccount() {
+    insertAccount('2099', 'Årets resultat', 'EQUITY', 'CREDIT', null)
+  }
+
+  private long insertAccount(
+      String accountNumber,
+      String accountName,
+      String accountClass,
+      String normalBalanceSide,
+      String vatCode
+  ) {
+    databaseService.withTransaction { groovy.sql.Sql sql ->
+      List<List<Object>> keys = sql.executeInsert("""
+          insert into account (
+              company_id, account_number, account_name,
+              account_class, normal_balance_side, active,
+              manual_review_required, vat_code, created_at, updated_at
+          ) values (?, ?, ?, ?, ?, true, false, ?, current_timestamp, current_timestamp)
+      """, [CompanyService.LEGACY_COMPANY_ID, accountNumber, accountName, accountClass, normalBalanceSide, vatCode])
+      ((Number) keys.first().first()).longValue()
+    }
   }
 
   private Map<String, Object> balancedVoucherArgs(String description, BigDecimal amount) {

--- a/app/src/test/groovy/integration/se/alipsa/accounting/mcp/AccountingMcpToolsTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/mcp/AccountingMcpToolsTest.groovy
@@ -449,6 +449,19 @@ class AccountingMcpToolsTest {
   }
 
   @Test
+  void closeFiscalYearUnknownFiscalYearReturnsGracefulError() {
+    Map<String, Object> result = tools.callTool('close_fiscal_year', [
+        company_id: (Object) 1L,
+        fiscal_year_id: (Object) 999999L,
+        preview_token: (Object) 'wrong-token'
+    ])
+
+    assertFalse((boolean) result.get('ok'))
+    List<String> errors = (List<String>) result.get('errors')
+    assertFalse(errors.isEmpty())
+  }
+
+  @Test
   void closeFiscalYearWithPreviewTokenClosesYear() {
     insertClosingAccount()
     Map<String, Object> preview = tools.callTool('preview_year_end', [


### PR DESCRIPTION
## Summary

Implements Phase 4 of `req/v1.1.0-ai-impl-plan.md` for the headless MCP accounting flow.

- Adds `book_vat_transfer` with `report_hash` enforcement, current-report hash validation, company ownership checks, automatic reporting of open VAT periods, and transfer booking via `VatService`.
- Adds `preview_year_end` with year-end pre-check output and stateless `preview_token` generation.
- Adds `close_fiscal_year` with mandatory preview-token enforcement before delegating to `ClosingService`.
- Adds integration coverage for VAT transfer hash bypass/tampering/success and year-end preview/close token flows.

## Validation

- `./gradlew spotlessApply`
- `./gradlew test --tests "se.alipsa.accounting.mcp.AccountingMcpToolsTest"`
- `./gradlew build`