### PR TITLE
[codex] lägg till MCP-skill och distribution

### DIFF
--- a/.github/workflows/build-distributions.yml
+++ b/.github/workflows/build-distributions.yml
@@ -14,12 +14,12 @@ jobs:
             artifact: app/build/release/linux/alipsa-accounting-*.zip
           - os: windows-latest
             platform: windows
-            tasks: packageWindowsInstaller
-            artifact: app/build/release/windows-installer/*
+            tasks: packageWindowsReleaseZip
+            artifact: app/build/release/windows-release/alipsa-accounting-*-windows.zip
           - os: macos-latest
             platform: macos
-            tasks: packageMacosAppImage
-            artifact: app/build/release/macos/AlipsaAccounting-macos.zip
+            tasks: packageMacosReleaseZip
+            artifact: app/build/release/macos-release/alipsa-accounting-*-macos.zip
 
     runs-on: ${{ matrix.os }}
 
@@ -38,11 +38,6 @@ jobs:
 
       - name: Build distribution
         run: ./gradlew ${{ matrix.tasks }}
-
-      - name: Collect macOS app into zip
-        if: matrix.platform == 'macos'
-        working-directory: app/build/release/macos
-        run: zip -r AlipsaAccounting-macos.zip AlipsaAccounting.app
 
       - uses: actions/upload-artifact@v7
         with:

--- a/README.md
+++ b/README.md
@@ -130,13 +130,14 @@ Kör alla kommandon från rotmappen.
 
 ### Nedladdningar
 
-Varje release publiceras på [GitHub Releases](https://github.com/Alipsa/accounting/releases) med tre distributioner:
+Varje release publiceras på [GitHub Releases](https://github.com/Alipsa/accounting/releases) med tre användardistributioner och ett generiskt uppdateringsarkiv:
 
-| Fil                                     | Plattform                                             |
-|-----------------------------------------|-------------------------------------------------------|
-| `alipsa-accounting-<version>-linux.zip` | Linux — app-image och `.desktop`-fil                  |
-| `AlipsaAccounting-<version>.exe`        | Windows — installerare med meny- och skrivbordsgenväg |
-| `AlipsaAccounting-macos.zip`            | macOS — `AlipsaAccounting.app`                        |
+| Fil                                       | Plattform                                                             |
+|-------------------------------------------|-----------------------------------------------------------------------|
+| `alipsa-accounting-<version>-linux.zip`   | Linux — app-image, `.desktop`-fil och `skill/accounting-mcp.md`       |
+| `alipsa-accounting-<version>-windows.zip` | Windows — exe-installerare och `skill/accounting-mcp.md`              |
+| `alipsa-accounting-<version>-macos.zip`   | macOS — `AlipsaAccounting.app` och `skill/accounting-mcp.md`          |
+| `app-<version>.zip`                       | Generiskt arkiv som används av den inbyggda automatiska uppdateraren  |
 
 Varje distributionsfil åtföljs av två verifieringsfiler:
 

--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ The application can perform a background update check against GitHub Releases on
 Releasebyggen använder `jpackage` och kräver Java 21 med tillhörande paketeringsverktyg på respektive plattform.
 
 - Linux: `./gradlew :app:packageLinuxReleaseZip`
-- Windows: `./gradlew :app:packageWindowsInstaller`
-- macOS: `./gradlew :app:packageMacosAppImage`
+- Windows: `./gradlew :app:packageWindowsRelease`
+- macOS: `./gradlew :app:packageMacosRelease`
 - Aktuell plattform: `./gradlew :app:packageCurrentPlatformRelease`
 - Smoke test av aktuell plattform: `./gradlew :app:verifyCurrentPlatformRelease`
 
@@ -186,6 +186,22 @@ Om Gradle hittar fel JDK för jpackage (t.ex. en inbäddad JDK utan jpackage) ka
 Byggartefakter skrivs till `app/build/release/` och använder samma appnamn, versionsnummer och ikonuppsättning för alla tre plattformar.
 
 Linux-releasen producerar en `app-image` plus ett zip-arkiv som även innehåller `.desktop`-filen. Windows-releasen producerar en `exe`-installerare med meny- och skrivbordsgenväg. macOS-releasen producerar `AlipsaAccounting.app`.
+
+Releasebygget placerar MCP-skillen som `skill/accounting-mcp.md` under respektive plattforms artefaktkatalog. Claude Code och Codex läser inte automatiskt den katalogen; länka eller kopiera den därför till klientens skill-katalog efter installation:
+
+```
+# Claude Code
+ln -s /path/to/release/skill ~/.claude/skills/accounting
+
+# Codex
+ln -s /path/to/release/skill ~/.agents/skills/accounting
+
+# Windows PowerShell, Claude Code
+New-Item -ItemType Junction -Path "$HOME\.claude\skills\accounting" -Target "C:\path\to\release\skill"
+
+# Windows PowerShell, Codex
+New-Item -ItemType Junction -Path "$HOME\.agents\skills\accounting" -Target "C:\path\to\release\skill"
+```
 
 Applikationen använder plattformsspecifika standardvägar för data och loggar:
 

--- a/README.md
+++ b/README.md
@@ -185,9 +185,9 @@ Om Gradle hittar fel JDK för jpackage (t.ex. en inbäddad JDK utan jpackage) ka
 
 Byggartefakter skrivs till `app/build/release/` och använder samma appnamn, versionsnummer och ikonuppsättning för alla tre plattformar.
 
-Linux-releasen producerar en `app-image` plus ett zip-arkiv som även innehåller `.desktop`-filen. Windows-releasen producerar en `exe`-installerare med meny- och skrivbordsgenväg. macOS-releasen producerar `AlipsaAccounting.app`.
+Alla tre plattformsreleaserna producerar ett zip-arkiv som innehåller `skill/accounting-mcp.md`. Linux-arkivet innehåller app-imagen och installationsskripten. Windows-arkivet innehåller exe-installeraren med meny- och skrivbordsgenväg. macOS-arkivet innehåller `AlipsaAccounting.app`.
 
-Releasebygget placerar MCP-skillen som `skill/accounting-mcp.md` under respektive plattforms artefaktkatalog. Claude Code och Codex läser inte automatiskt den katalogen; länka eller kopiera den därför till klientens skill-katalog efter installation:
+Claude Code och Codex läser inte automatiskt `skill/`-katalogen; extrahera arkivet och länka eller kopiera den till klientens skill-katalog:
 
 ```
 # Claude Code

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,6 +43,16 @@ application {
   mainClass = 'se.alipsa.accounting.AlipsaAccounting'
 }
 
+distributions {
+  main {
+    contents {
+      from(rootProject.file('skill')) {
+        into('skill')
+      }
+    }
+  }
+}
+
 def releaseConfig = [
   appName       : 'AlipsaAccounting',
   displayName   : 'Alipsa Accounting',
@@ -352,6 +362,9 @@ tasks.register('packageLinuxReleaseZip', Zip) {
   from(linuxUninstallScript) {
     filePermissions { unix(0755) }
   }
+  from(rootProject.file('skill')) {
+    into('skill')
+  }
 }
 
 tasks.register('packageWindowsAppImage', Exec) {
@@ -365,6 +378,16 @@ tasks.register('packageWindowsAppImage', Exec) {
         *buildJpackageArgs('windows', 'app-image', outputDir)
         )
   }
+}
+
+tasks.register('copySkillToWindowsAppImage', Copy) {
+  onlyIf { isWindows }
+  from(rootProject.file('skill'))
+  into(releaseConfig.releaseRoot.map { it.dir('windows/skill') })
+}
+
+tasks.named('packageWindowsAppImage') {
+  finalizedBy 'copySkillToWindowsAppImage'
 }
 
 tasks.register('packageWindowsInstaller', Exec) {
@@ -396,6 +419,16 @@ tasks.register('packageMacosAppImage', Exec) {
         *buildJpackageArgs('macos', 'app-image', outputDir)
         )
   }
+}
+
+tasks.register('copySkillToMacosAppImage', Copy) {
+  onlyIf { isMacos }
+  from(rootProject.file('skill'))
+  into(releaseConfig.releaseRoot.map { it.dir('macos/skill') })
+}
+
+tasks.named('packageMacosAppImage') {
+  finalizedBy 'copySkillToMacosAppImage'
 }
 
 tasks.register('verifyLinuxAppImage', Exec) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -425,14 +425,39 @@ tasks.register('copySkillToMacosAppImage', Copy) {
   into(releaseConfig.releaseRoot.map { it.dir('macos/skill') })
 }
 
-tasks.register('packageWindowsRelease') {
+tasks.register('packageWindowsReleaseZip', Zip) {
   onlyIf { isWindows }
   dependsOn 'packageWindowsInstaller'
+  archiveBaseName = releaseConfig.packageName
+  archiveVersion = releaseConfig.version
+  archiveClassifier = 'windows'
+  destinationDirectory = releaseConfig.releaseRoot.map { it.dir('windows-release') }
+  from(releaseConfig.releaseRoot.map { it.dir('windows-installer') }) {
+    include '*.exe'
+  }
+  from(rootProject.file('skill')) {
+    into('skill')
+  }
+}
+
+tasks.register('packageWindowsRelease') {
+  onlyIf { isWindows }
+  dependsOn 'packageWindowsReleaseZip'
+}
+
+tasks.register('packageMacosReleaseZip', Zip) {
+  onlyIf { isMacos }
+  dependsOn 'copySkillToMacosAppImage'
+  archiveBaseName = releaseConfig.packageName
+  archiveVersion = releaseConfig.version
+  archiveClassifier = 'macos'
+  destinationDirectory = releaseConfig.releaseRoot.map { it.dir('macos-release') }
+  from(releaseConfig.releaseRoot.map { it.dir('macos') })
 }
 
 tasks.register('packageMacosRelease') {
   onlyIf { isMacos }
-  dependsOn 'copySkillToMacosAppImage'
+  dependsOn 'packageMacosReleaseZip'
 }
 
 tasks.register('verifyLinuxAppImage', Exec) {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -382,17 +382,14 @@ tasks.register('packageWindowsAppImage', Exec) {
 
 tasks.register('copySkillToWindowsAppImage', Copy) {
   onlyIf { isWindows }
+  dependsOn 'packageWindowsAppImage'
   from(rootProject.file('skill'))
   into(releaseConfig.releaseRoot.map { it.dir('windows/skill') })
 }
 
-tasks.named('packageWindowsAppImage') {
-  finalizedBy 'copySkillToWindowsAppImage'
-}
-
 tasks.register('packageWindowsInstaller', Exec) {
   onlyIf { isWindows }
-  dependsOn 'installDist', 'prepareWindowsPackagingResources'
+  dependsOn 'installDist', 'prepareWindowsPackagingResources', 'copySkillToWindowsAppImage'
   doFirst {
     File outputDir = releaseConfig.releaseRoot.get().dir('windows-installer').asFile
     clearDirectory(outputDir)
@@ -423,12 +420,19 @@ tasks.register('packageMacosAppImage', Exec) {
 
 tasks.register('copySkillToMacosAppImage', Copy) {
   onlyIf { isMacos }
+  dependsOn 'packageMacosAppImage'
   from(rootProject.file('skill'))
   into(releaseConfig.releaseRoot.map { it.dir('macos/skill') })
 }
 
-tasks.named('packageMacosAppImage') {
-  finalizedBy 'copySkillToMacosAppImage'
+tasks.register('packageWindowsRelease') {
+  onlyIf { isWindows }
+  dependsOn 'packageWindowsInstaller'
+}
+
+tasks.register('packageMacosRelease') {
+  onlyIf { isMacos }
+  dependsOn 'copySkillToMacosAppImage'
 }
 
 tasks.register('verifyLinuxAppImage', Exec) {
@@ -444,7 +448,7 @@ tasks.register('verifyLinuxAppImage', Exec) {
 
 tasks.register('verifyWindowsAppImage', Exec) {
   onlyIf { isWindows }
-  dependsOn 'packageWindowsAppImage'
+  dependsOn 'copySkillToWindowsAppImage'
   doFirst {
     File launcher = launcherPathFor('windows')
     File verifyHome = releaseConfig.releaseRoot.get().dir('verify/windows-home').asFile
@@ -455,7 +459,7 @@ tasks.register('verifyWindowsAppImage', Exec) {
 
 tasks.register('verifyMacosAppImage', Exec) {
   onlyIf { isMacos }
-  dependsOn 'packageMacosAppImage'
+  dependsOn 'copySkillToMacosAppImage'
   doFirst {
     File launcher = launcherPathFor('macos')
     File verifyHome = releaseConfig.releaseRoot.get().dir('verify/macos-home').asFile
@@ -466,7 +470,7 @@ tasks.register('verifyMacosAppImage', Exec) {
 
 tasks.register('packageCurrentPlatformRelease') {
   dependsOn(
-      isWindows ? 'packageWindowsInstaller' : isMacos ? 'packageMacosAppImage' : 'packageLinuxReleaseZip'
+      isWindows ? 'packageWindowsRelease' : isMacos ? 'packageMacosRelease' : 'packageLinuxReleaseZip'
       )
 }
 

--- a/packaging/macos/installer-resources/README.txt
+++ b/packaging/macos/installer-resources/README.txt
@@ -1,8 +1,8 @@
 macOS packaging resources for Alipsa Accounting.
 Code signing and notarization are future release steps handled outside the Gradle build.
 
-The MCP skill is distributed next to the release artifact as skill/accounting-mcp.md.
-To enable it in Claude Code or Codex, link or copy that skill directory to:
+The MCP skill is bundled inside the release zip as skill/accounting-mcp.md alongside AlipsaAccounting.app.
+To enable it in Claude Code or Codex, extract the zip and link or copy that skill directory to:
 
 - Claude Code: ~/.claude/skills/accounting
 - Codex: ~/.agents/skills/accounting

--- a/packaging/macos/installer-resources/README.txt
+++ b/packaging/macos/installer-resources/README.txt
@@ -1,2 +1,8 @@
 macOS packaging resources for Alipsa Accounting.
 Code signing and notarization are future release steps handled outside the Gradle build.
+
+The MCP skill is distributed next to the release artifact as skill/accounting-mcp.md.
+To enable it in Claude Code or Codex, link or copy that skill directory to:
+
+- Claude Code: ~/.claude/skills/accounting
+- Codex: ~/.agents/skills/accounting

--- a/packaging/windows/installer-resources/README.txt
+++ b/packaging/windows/installer-resources/README.txt
@@ -1,2 +1,8 @@
 Windows installer resources for Alipsa Accounting.
 Signing is handled as a separate release step outside the Gradle build.
+
+The MCP skill is distributed next to the release artifact as skill/accounting-mcp.md.
+To enable it in Claude Code or Codex, create a junction or copy that skill directory to:
+
+- Claude Code: %USERPROFILE%\.claude\skills\accounting
+- Codex: %USERPROFILE%\.agents\skills\accounting

--- a/packaging/windows/installer-resources/README.txt
+++ b/packaging/windows/installer-resources/README.txt
@@ -1,8 +1,8 @@
 Windows installer resources for Alipsa Accounting.
 Signing is handled as a separate release step outside the Gradle build.
 
-The MCP skill is distributed next to the release artifact as skill/accounting-mcp.md.
-To enable it in Claude Code or Codex, create a junction or copy that skill directory to:
+The MCP skill is bundled inside the release zip as skill/accounting-mcp.md alongside the installer.
+To enable it in Claude Code or Codex, extract the zip and create a junction or copy that skill directory to:
 
 - Claude Code: %USERPROFILE%\.claude\skills\accounting
 - Codex: %USERPROFILE%\.agents\skills\accounting

--- a/release.sh
+++ b/release.sh
@@ -75,8 +75,7 @@ if [ "$BUILD" = true ]; then
   # behind in extras/ so the root stays clean.
   shopt -s nullglob
   for f in "$DIST_DIR"/extras/*/alipsa-accounting-*.zip \
-           "$DIST_DIR"/extras/*/AlipsaAccounting-*.exe \
-           "$DIST_DIR"/extras/*/AlipsaAccounting-*.zip; do
+           "$DIST_DIR"/extras/*/app-*.zip; do
     mv "$f" "$DIST_DIR/"
   done
   shopt -u nullglob
@@ -141,9 +140,10 @@ ${notes}
     case "$file" in *.asc|*.sha256) continue ;; esac
     name=$(basename "$file")
     case "$name" in
-      *.exe)      platform="Windows" ;;
+      *windows*)  platform="Windows" ;;
       *linux*)    platform="Linux" ;;
       *macos*)    platform="macOS" ;;
+      app-*.zip)  platform="Auto-updater" ;;
       *)          platform="$name" ;;
     esac
     release_body="${release_body}

--- a/req/v1.1.0-SIE-skill.md
+++ b/req/v1.1.0-SIE-skill.md
@@ -206,7 +206,7 @@ Svar: `ok`, `duplicate`, `fiscal_year_id`, `fiscal_year_name`, `accounts_created
 | Parameter | Typ | Obligatorisk | Beskrivning |
 |---|---|---|---|
 | `fiscal_year_id` | integer | ja | Räkenskapsår att exportera |
-| `output_path` | string | nej | Absolut sökväg för SIE-filen; standard: `<sieExportsDir>/AlipsaAccounting-<namn>.sie` |
+| `output_path` | string | nej | Absolut sökväg för SIE-filen; standard: `<sieExportsDir>/AlipsaAccounting-<räkenskapsårsnamn>-<yyyyMMddHHmm>.sie` |
 | `overwrite` | boolean | nej (standard: false) | Tillåt överskrivning av befintlig fil |
 
 Svar: `ok`, `file_path`, `checksum_sha256`, `file_size_bytes`, `account_count`,

--- a/req/v1.1.0-SIE-skill.md
+++ b/req/v1.1.0-SIE-skill.md
@@ -15,11 +15,37 @@ operationer. Planen exponerar dem via fyra nya MCP-verktyg och uppdaterar skilld
 
 ### Tjänstelagret — utökning av `SieImportExportService`
 
-Lägg till en publik `previewSieImport`-metod som parsar SIE-filen utan att spara något:
+Lägg till en publik `previewSieImport`-metod som parsar SIE-filen och slår upp befintliga
+räkenskapsår i databasen — men gör inga skrivningar:
 
 ```
 SieImportPreview previewSieImport(long companyId, Path filePath, boolean replaceExisting)
 ```
+
+Metoden:
+1. Kör befintlig `validateImportPath`-kontroll.
+2. Beräknar SHA-256-checksum på filinnehållet.
+3. Kontrollerar `import_job`-tabellen för dubbletter (samma checksum + company_id, status SUCCESS).
+4. Anropar den privata `parseDocument(filePath)` för att läsa filinnehåll utan skrivning.
+5. Söker upp räkenskapsår i databasen baserat på filens `#RAR`-period.
+6. Om `replaceExisting=true` och räkenskapsåret existerar: beräknar rensningssumman med
+   befintlig logik ur `FiscalYearReplacementService` (enbart läsning — inga raderingar).
+7. Samlar spärrar baserat på räkenskapsårets faktiska tillstånd i databasen.
+
+   **Normal import (`replaceExisting=false`), om räkenskapsåret existerar:**
+   - Räkenskapsåret är stängt (`fiscal_year.closed = true`).
+   - Räkenskapsåret har befintliga verifikationer eller ingående balanser
+     (`voucher.count > 0 OR opening_balance.count > 0`).
+
+   **Ersättningsimport (`replaceExisting=true`), om räkenskapsåret existerar:**
+   - Räkenskapsåret är stängt.
+   - Räkenskapsåret har bokslutsposter (`closing_entry.count > 0`).
+
+   Om räkenskapsåret inte existerar finns inga spärrar från räkenskapsårets tillstånd.
+   Dessa kontroller speglar exakt vad `ensureFiscalYearImportable` (rad 361–379 i
+   `SieImportExportService`) och `ensureReplaceAllowed` (rad 70–83 i
+   `FiscalYearReplacementService`) kastar vid import — preview skall aldrig utfärda token
+   för ett anrop som förutsägbart skulle misslyckas.
 
 Returnerar en ny modellklass `SieImportPreview` (i `SieImportExportModels.groovy`):
 
@@ -34,10 +60,16 @@ Returnerar en ny modellklass `SieImportPreview` (i `SieImportExportModels.groovy
 | `warnings` | `List<String>` | Parsningsvarningar |
 | `checksumSha256` | `String` | SHA-256 av filinnehållet |
 | `replaceExisting` | `boolean` | Speglar inkommande parameter |
+| `fiscalYearExists` | `boolean` | Huruvida ett matchande räkenskapsår redan finns i databasen |
+| `targetFiscalYearId` | `Long` | Befintligt räkenskapsårets id, eller null om det saknas |
+| `targetFiscalYearName` | `String` | Befintligt räkenskapsårets namn, eller null om det saknas |
+| `purgeSummary` | `FiscalYearPurgeSummary` | Vad som tas bort vid ersättning; null om `replaceExisting=false` eller räkenskapsåret saknas |
+| `blockingIssues` | `List<String>` | Skäl till att import inte kan genomföras, t.ex. stängt räkenskapsår |
+| `isDuplicate` | `boolean` | Huruvida denna fil redan importerats (baserat på checksum + company_id) |
+| `duplicateJobId` | `Long` | Id för det tidigare importjobbet, eller null om inte duplikat |
 
-Metoden anropar den privata `parseDocument(filePath)` (görs tillgänglig paketintern eller via
-refaktorering), kör befintlig `validateImportPath`-kontroll och beräknar checksum — men gör
-inga databas­skrivningar.
+`blockingIssues` skall vara tom för att `import_token` skall genereras. Om det finns spärrar
+returneras `ok: false` utan token.
 
 ---
 
@@ -47,15 +79,15 @@ inga databas­skrivningar.
 
 | Verktyg | Delegerar till | Anmärkning |
 |---|---|---|
-| `preview_sie_import` | `SieImportExportService.previewSieImport` | Returnerar filsammanfattning och `import_token` |
-| `list_import_jobs` | `SieImportExportService.listImportJobs` | Max 50 jobb, standard 20 |
+| `preview_sie_import` | `SieImportExportService.previewSieImport` | Returnerar filsammanfattning, rensningssumma vid ersättning, och `import_token` |
+| `list_import_jobs` | `SieImportExportService.listImportJobs` | Gräns sätts i `AccountingMcpTools`: `Math.min(Math.max(1, limit), 50)` |
 
 #### Skrivande verktyg (tillägg till befintliga fyra)
 
 | Verktyg | Delegerar till | Kräver |
 |---|---|---|
 | `import_sie` | `SieImportExportService.importFile` eller `replaceFiscalYear` | `import_token` från `preview_sie_import` med identisk nyttolast |
-| `export_sie` | `SieImportExportService.exportFiscalYear` | Ingen token — icke-destruktiv mot bokföringsdata |
+| `export_sie` | `SieImportExportService.exportFiscalYear` | Ingen token; `overwrite: true` om målfilen redan finns |
 
 ---
 
@@ -63,35 +95,84 @@ inga databas­skrivningar.
 
 Samma SHA-256-mönster som `preview_voucher` → `post_voucher`.
 
-**Kanonisk nyttolast:**
+#### Normal import (`replace_existing: false`)
+
+Kanonisk nyttolast:
 
 ```json
 { "company_id": 1, "file_checksum": "<sha256>", "replace_existing": false }
 ```
 
-`replace_existing` ingår i hashen. En token framräknad för normal import kan inte återanvändas
-för en ersättningsimport och vice versa.
+#### Ersättningsimport (`replace_existing: true`)
 
-`import_sie` tar parametrarna `company_id`, `file_path` och `import_token`. Verktyget räknar om
-checksum från `file_path` och jämför med den inbäddade hashen i tokenen. Avvisas med
-`"import_token krävs — kör preview_sie_import med exakt samma fil och replace_existing-värde först."`
-om tokenkontrollen misslyckas.
+Kanonisk nyttolast inkluderar rensningssummans alla räknare så att tokenen ogiltigförklaras om
+räkenskapsårets innehåll förändras mellan preview och import:
 
-**Export (`export_sie`) kräver ingen token** — operationen är icke-destruktiv mot bokföringen och
-skriver bara en ny fil. Parametrarna är `fiscal_year_id` och valfri `output_path`. Om `output_path`
-utelämnas väljer verktyget ett standardnamn i hemkatalogen:
-`~/AlipsaAccounting-<räkenskapsårsnamn>.sie`.
+```json
+{
+  "company_id": 1,
+  "file_checksum": "<sha256>",
+  "replace_existing": true,
+  "target_fiscal_year_id": 42,
+  "purge_voucher_count": 15,
+  "purge_attachment_count": 3,
+  "purge_opening_balance_count": 10,
+  "purge_vat_period_count": 4,
+  "purge_report_archive_count": 0,
+  "purge_audit_log_count": 5
+}
+```
+
+`import_sie` med `replace_existing=true` räknar om den aktuella rensningssumman och avvisar om
+den skiljer sig från vad tokenen kodade. Felmeddelande:
+`"Räkenskapsårets innehåll har förändrats sedan förhandsgranskningen — kör preview_sie_import igen."`
+
+En token för normal import kan inte återanvändas för en ersättningsimport (och vice versa) eftersom
+`replace_existing` ingår i hashen.
+
+---
+
+### Export och överskrivningsskydd
+
+`export_sie` kräver ingen token. Operationen är icke-destruktiv mot bokföringsdata men kan
+skriva över befintliga lokala filer om `output_path` pekar på en befintlig fil.
+
+**Beteende:**
+- Om `output_path` anges och filen redan finns och `overwrite: false` (standard): returnera
+  `ok: false` med `file_exists: true` och sökvägen, utan att skriva något.
+- Om `overwrite: true`: skriv över (det befintliga beteendet hos `Files.write`).
+- Om `output_path` utelämnas: generera ett unikt filnamn med tidsstämpel i applikationens
+  exportkatalog (`AppPaths.sieExportsDirectory()`), se nedan. Format:
+  `AlipsaAccounting-<räkenskapsårsnamn>-<yyyyMMddHHmm>.sie`. Tidsstämpeln garanterar att
+  upprepade exporter av samma räkenskapsår inte krockar. Om standardsökvägen ändå mot
+  förmodan skulle krocka (klockan är densamma till minutnivå) gäller samma `file_exists`-beteende
+  som för en angiven sökväg: returnera `ok: false` med `file_exists: true`.
+
+**`AppPaths.sieExportsDirectory()`** — ny metod i `AppPaths` som följer samma mönster som
+`attachmentsDirectory()` och `reportsDirectory()`:
+
+```groovy
+static Path sieExportsDirectory() {
+    sieExportsDirectory(applicationHome())
+}
+static Path sieExportsDirectory(Path applicationHome) {
+    applicationHome.resolve('sie-exports')
+}
+```
+
+Standardnamn om `output_path` utelämnas: `<sieExportsDir>/AlipsaAccounting-<räkenskapsårsnamn>-<yyyyMMddHHmm>.sie`.
+
+Katalogen skapas med `Files.createDirectories` precis som `normalizeExportPath` redan gör för
+föräldern till en angiven sökväg.
 
 ---
 
 ### Sökvägssäkerhet
 
 `validateImportPath` (befintlig) kontrollerar att filen existerar och inte överstiger 50 MB.
-MCP-verktyget skickar sökvägssträngen från LLM-klienten via `Path.of(filePathArg)` —
-konverteringen sker i verktygslagret, inte i servicen.
-
-Inga ytterligare restriktioner (tillåtna kataloger etc.) läggs till i v1 — verktyget körs
-lokalt och användaren styr vilken fil som pekas ut.
+MCP-verktyget konverterar sökvägssträngen från LLM-klienten via `Path.of(filePathArg)` —
+konverteringen sker i verktygslagret, inte i servicen. Inga ytterligare katalogbegränsningar
+läggs till i v1.
 
 ---
 
@@ -105,7 +186,8 @@ lokalt och användaren styr vilken fil som pekas ut.
 | `file_path` | string | ja | Absolut sökväg till SIE-filen |
 | `replace_existing` | boolean | nej (standard: false) | Om befintligt räkenskapsår ska ersättas |
 
-Svar: alla fält ur `SieImportPreview` plus `import_token` (SHA-256-sträng) och `ok: true`.
+Svar: alla fält ur `SieImportPreview` plus `import_token` (null om `blockingIssues` ej är tom)
+och `ok` (false om det finns spärrar).
 
 #### `import_sie`
 
@@ -124,17 +206,19 @@ Svar: `ok`, `duplicate`, `fiscal_year_id`, `fiscal_year_name`, `accounts_created
 | Parameter | Typ | Obligatorisk | Beskrivning |
 |---|---|---|---|
 | `fiscal_year_id` | integer | ja | Räkenskapsår att exportera |
-| `output_path` | string | nej | Absolut sökväg för SIE-filen; standard: `~/AlipsaAccounting-<namn>.sie` |
+| `output_path` | string | nej | Absolut sökväg för SIE-filen; standard: `<sieExportsDir>/AlipsaAccounting-<namn>.sie` |
+| `overwrite` | boolean | nej (standard: false) | Tillåt överskrivning av befintlig fil |
 
 Svar: `ok`, `file_path`, `checksum_sha256`, `file_size_bytes`, `account_count`,
-`opening_balance_count`, `voucher_count`.
+`opening_balance_count`, `voucher_count`. Vid `ok: false` + `file_exists: true` returneras
+även `existing_file_path` som hjälp för LLM att ställa överskrivningsfrågan.
 
 #### `list_import_jobs`
 
 | Parameter | Typ | Obligatorisk | Beskrivning |
 |---|---|---|---|
 | `company_id` | integer | ja | Aktiv företagets id |
-| `limit` | integer | nej (standard: 20, max: 50) | Antal jobb att returnera |
+| `limit` | integer | nej (standard: 20, max: 50) | Gränsen sätts i `AccountingMcpTools` med `Math.min(Math.max(1, limit), 50)` |
 
 Svar: lista med `id`, `file_name`, `status`, `summary`, `fiscal_year_id`, `started_at`,
 `completed_at`.
@@ -144,47 +228,69 @@ Svar: lista med `id`, `file_name`, `status`, `summary`, `fiscal_year_id`, `start
 ### Uppdatering av `skill/accounting-mcp.md`
 
 1. **Läsande verktyg** — lägg till `preview_sie_import` och `list_import_jobs` i tabellen.
-2. **Skrivande verktyg** — lägg till `import_sie` och `export_sie` i tabellen med en not om
-   att `export_sie` inte kräver token.
+2. **Skrivande verktyg** — lägg till `import_sie` och `export_sie`; notera att `export_sie`
+   inte kräver token men kan returnera `file_exists: true`.
 3. **Arbetsflöde: SIE-import** (nytt avsnitt):
-   1. Anropa `preview_sie_import`. Visa `companyNameInFile`, räkenskapsårsperiod, antal konton
-      och verifikationer samt eventuella varningar.
-   2. Om `replace_existing` är aktuellt, visa `FiscalYearPurgeSummary`-liknande data och
-      påminn om att operationen är destruktiv — befintliga verifikationer, bilagor och
-      rapportarkiv tas bort.
-   3. Fråga användaren om importen ska genomföras.
-   4. Anropa `import_sie` med oförändrad `file_path`, `replace_existing` och `import_token`.
-   5. Visa `SieImportResult`-sammanfattning inklusive eventuella varningar.
+   1. Anropa `preview_sie_import`. Om `ok: false`, förklara spärrarna och avbryt.
+   2. Om `isDuplicate: true`: informera användaren om det tidigare importjobbet (visa
+      `duplicateJobId`) och avbryt. En normal import av en redan importerad fil fortsätter
+      inte — servicen returnerar direkt det befintliga jobbet utan att importera något.
+      Förklara att om användaren genuint vill ersätta befintlig data kan de anropa med
+      `replace_existing: true` (vilket kringgår dubblettkontrollen men triggar
+      ersättningsflödet med rensningssumma och separat tokenvalidering).
+   3. Visa `companyNameInFile`, räkenskapsårsperiod, antal konton och verifikationer, och
+      eventuella varningar.
+   4. Om `replace_existing: true` och `fiscalYearExists: true`, visa `purgeSummary` i klartext
+      (antal verifikationer, bilagor, rapporter som tas bort) och kräv explicit bekräftelse
+      innan `import_sie` anropas.
+   5. Anropa `import_sie` med oförändrad `file_path`, `replace_existing` och `import_token`.
+   6. Visa `SieImportResult`-sammanfattning inklusive eventuella varningar.
 4. **Arbetsflöde: SIE-export** (nytt avsnitt):
    1. Anropa `list_fiscal_years` om `fiscal_year_id` är okänt.
-   2. Bestäm `output_path` med användaren om det inte är uppenbart.
-   3. Fråga om exporten ska genomföras.
-   4. Anropa `export_sie`. Visa utmatad sökväg, filstorlek och checksum.
+   2. Anropa `export_sie` utan `output_path` för standardsökväg, eller med angiven sökväg.
+   3. Om svaret är `ok: false` och `file_exists: true`, berätta för användaren vilken fil som
+      redan finns och fråga om de vill skriva över. Anropa i så fall `export_sie` igen med
+      samma parametrar och `overwrite: true`.
+   4. Visa utmatad sökväg, filstorlek och checksum.
 5. **Begränsningar** — lägg till:
-   - Anropa aldrig `import_sie` med `replace_existing: true` utan att explicit ha bekräftat
-     med användaren att befintliga verifikationer och bilagor för räkenskapsåret tas bort.
-   - Vidarebefordra alltid varningar från `preview_sie_import` till användaren innan import.
+   - Anropa aldrig `import_sie` med `replace_existing: true` utan att ha visat `purgeSummary`
+     och fått explicit bekräftelse.
+   - Vidarebefordra alltid varningar och `isDuplicate`-status från `preview_sie_import` till
+     användaren innan import.
+   - Anropa aldrig `export_sie` med `overwrite: true` utan att först ha frågat användaren om
+     överskrivning.
 
 ---
 
 ### Testtäckning
 
-Integrationstester i `AccountingMcpToolsTest` (nytt testdata-SIE-fixtur i
+Integrationstester i `AccountingMcpToolsTest` (ny minimal SIE4-testfixtur i
 `app/src/test/resources/`):
 
 | Testfall | Förväntat resultat |
 |---|---|
-| `preview_sie_import` med giltig fil | `ok: true`, korrekt `companyNameInFile`, `import_token` ej null |
+| `preview_sie_import` med giltig fil, inget befintligt år | `ok: true`, `fiscalYearExists: false`, `import_token` ej null, `purgeSummary` null |
+| `preview_sie_import` med giltig fil, befintligt år finns | `ok: true`, `fiscalYearExists: true`, `targetFiscalYearId` ej null |
+| `preview_sie_import` med `replace_existing: true` och befintligt år | `purgeSummary` ej null med korrekta räknare |
+| `preview_sie_import` med fil för stängt räkenskapsår, normal import | `ok: false`, `blockingIssues` ej tom, `import_token` null |
+| `preview_sie_import` med fil för stängt räkenskapsår, `replace_existing: true` | `ok: false`, `blockingIssues` ej tom, `import_token` null |
+| `preview_sie_import` med fil för år som har befintliga verifikationer, normal import | `ok: false`, `blockingIssues` ej tom |
+| `preview_sie_import` med fil för år med bokslutsposter, `replace_existing: true` | `ok: false`, `blockingIssues` ej tom |
+| `preview_sie_import` efter tidigare lyckad import av samma fil | `isDuplicate: true`, `duplicateJobId` ej null |
 | `preview_sie_import` med saknad fil | `ok: false`, tydligt felmeddelande |
 | `preview_sie_import` med fil > 50 MB | `ok: false`, storleksfel |
 | `import_sie` utan token | Avvisas med instruktionsmeddelande |
 | `import_sie` med token för annan fil | Avvisas med tokenfel |
 | `import_sie` med token för `replace_existing: false` men anropar med `replace_existing: true` | Avvisas med tokenfel |
-| `import_sie` med korrekt token | `ok: true`, `fiscal_year_id` ej null |
+| `import_sie` med `replace_existing: true` men rensningssumman har förändrats | Avvisas med förändrat-innehåll-felmeddelande |
+| `import_sie` med korrekt token, normal import | `ok: true`, `fiscal_year_id` ej null |
 | `import_sie` duplicerat (samma fil igen) | `ok: true`, `duplicate: true` |
-| `export_sie` för öppet räkenskapsår | `ok: true`, fil skapas, `checksum_sha256` ej null |
-| `export_sie` med angiven `output_path` | Filen skrivs till angiven sökväg |
+| `export_sie` utan `output_path` | Fil skapas i `sieExportsDirectory()` med tidsstämpel i filnamn, `checksum_sha256` ej null |
+| `export_sie` med angiven `output_path`, filen finns inte | Filen skrivs till angiven sökväg |
+| `export_sie` med angiven `output_path`, filen finns redan, `overwrite: false` | `ok: false`, `file_exists: true` |
+| `export_sie` med angiven `output_path`, filen finns redan, `overwrite: true` | `ok: true`, filen skrivs över |
 | `list_import_jobs` | Returnerar lista med minst ett jobb efter genomförd import |
+| `list_import_jobs` med `limit: 100` | Returnerar högst 50 jobb |
 
 ---
 
@@ -194,9 +300,10 @@ Integrationstester i `AccountingMcpToolsTest` (nytt testdata-SIE-fixtur i
 
 | Fil | Förändring |
 |---|---|
-| `service/SieImportExportModels.groovy` | Ny `SieImportPreview`-klass |
-| `service/SieImportExportService.groovy` | Ny publik `previewSieImport`-metod |
-| `mcp/AccountingMcpTools.groovy` | Nya verktygsdefinitioner och implementationsmetoder för `preview_sie_import`, `import_sie`, `export_sie`, `list_import_jobs` |
+| `service/SieImportExportModels.groovy` | Ny `SieImportPreview`-klass med alla fält ovan |
+| `service/SieImportExportService.groovy` | Ny publik `previewSieImport`-metod (DB-läsning, ingen skrivning) |
+| `support/AppPaths.groovy` | Ny `sieExportsDirectory()` och `sieExportsDirectory(Path)` |
+| `mcp/AccountingMcpTools.groovy` | Verktygsdefinitioner och implementationsmetoder för `preview_sie_import`, `import_sie`, `export_sie`, `list_import_jobs` |
 
 #### Ändrad produktionskod
 
@@ -209,18 +316,20 @@ Integrationstester i `AccountingMcpToolsTest` (nytt testdata-SIE-fixtur i
 | Fil | Förändring |
 |---|---|
 | `test/groovy/integration/…/AccountingMcpToolsTest.groovy` | Testfall för de fyra nya verktygen |
-| `test/resources/` | Minsta möjliga giltig SIE4-testfixtur |
+| `test/resources/` | Minimal giltig SIE4-testfixtur |
 
 ---
 
 ### Leveransordning
 
-1. Lägg till `SieImportPreview` i `SieImportExportModels.groovy`.
-2. Implementera `previewSieImport` i `SieImportExportService`.
-3. Implementera `preview_sie_import` och `list_import_jobs` i `AccountingMcpTools` (läsande,
-   säker att testa utan destruktiv risk).
-4. Implementera `export_sie` i `AccountingMcpTools`.
-5. Implementera `import_sie` med tokenvalidering i `AccountingMcpTools`.
-6. Skriv integrationstester med SIE-fixtur.
-7. Uppdatera `skill/accounting-mcp.md`.
-8. Kör `./gradlew build`.
+1. Lägg till `sieExportsDirectory()` i `AppPaths`.
+2. Lägg till `SieImportPreview` i `SieImportExportModels.groovy`.
+3. Implementera `previewSieImport` i `SieImportExportService` (DB-läsning, inklusive
+   rensningssumma och dubblettdetektering).
+4. Implementera `preview_sie_import` och `list_import_jobs` i `AccountingMcpTools`.
+5. Implementera `export_sie` med överskrivningsskydd i `AccountingMcpTools`.
+6. Implementera `import_sie` med tokenvalidering (inklusive rensningssumma-fingeravtryck
+   för ersättningsimport) i `AccountingMcpTools`.
+7. Skriv integrationstester med SIE-fixtur.
+8. Uppdatera `skill/accounting-mcp.md`.
+9. Kör `./gradlew build`.

--- a/req/v1.1.0-SIE-skill.md
+++ b/req/v1.1.0-SIE-skill.md
@@ -1,0 +1,226 @@
+## Implementationsplan: SIE-filstöd i MCP-verktyg och skill (v1.1.0)
+
+Komplement till `req/v1.1.0-ai-impl-plan.md`. Lägger till SIE4-import, -export och jobbhistorik
+som MCP-verktyg och utökar `skill/accounting-mcp.md` med motsvarande arbetsflöden.
+
+---
+
+### Bakgrund
+
+`SieImportExportService` hanterar redan SIE4-import, ersättningsimport och export i GUI
+(`SieExchangeDialog`). MCP-lagret (`AccountingMcpTools`) saknar idag koppling till dessa
+operationer. Planen exponerar dem via fyra nya MCP-verktyg och uppdaterar skilldokumentet.
+
+---
+
+### Tjänstelagret — utökning av `SieImportExportService`
+
+Lägg till en publik `previewSieImport`-metod som parsar SIE-filen utan att spara något:
+
+```
+SieImportPreview previewSieImport(long companyId, Path filePath, boolean replaceExisting)
+```
+
+Returnerar en ny modellklass `SieImportPreview` (i `SieImportExportModels.groovy`):
+
+| Fält | Typ | Innehåll |
+|---|---|---|
+| `companyNameInFile` | `String` | `#FNAMN` ur SIE-filen |
+| `fiscalYearStart` | `LocalDate` | Räkenskapsårets startdatum (`#RAR`) |
+| `fiscalYearEnd` | `LocalDate` | Räkenskapsårets slutdatum |
+| `accountCount` | `int` | Antal konton i filen |
+| `voucherCount` | `int` | Antal verifikationer i filen |
+| `lineCount` | `int` | Antal verifikationsrader i filen |
+| `warnings` | `List<String>` | Parsningsvarningar |
+| `checksumSha256` | `String` | SHA-256 av filinnehållet |
+| `replaceExisting` | `boolean` | Speglar inkommande parameter |
+
+Metoden anropar den privata `parseDocument(filePath)` (görs tillgänglig paketintern eller via
+refaktorering), kör befintlig `validateImportPath`-kontroll och beräknar checksum — men gör
+inga databas­skrivningar.
+
+---
+
+### Nya MCP-verktyg
+
+#### Läsande verktyg (tillägg till befintliga tio)
+
+| Verktyg | Delegerar till | Anmärkning |
+|---|---|---|
+| `preview_sie_import` | `SieImportExportService.previewSieImport` | Returnerar filsammanfattning och `import_token` |
+| `list_import_jobs` | `SieImportExportService.listImportJobs` | Max 50 jobb, standard 20 |
+
+#### Skrivande verktyg (tillägg till befintliga fyra)
+
+| Verktyg | Delegerar till | Kräver |
+|---|---|---|
+| `import_sie` | `SieImportExportService.importFile` eller `replaceFiscalYear` | `import_token` från `preview_sie_import` med identisk nyttolast |
+| `export_sie` | `SieImportExportService.exportFiscalYear` | Ingen token — icke-destruktiv mot bokföringsdata |
+
+---
+
+### Token-mekanism för `import_sie`
+
+Samma SHA-256-mönster som `preview_voucher` → `post_voucher`.
+
+**Kanonisk nyttolast:**
+
+```json
+{ "company_id": 1, "file_checksum": "<sha256>", "replace_existing": false }
+```
+
+`replace_existing` ingår i hashen. En token framräknad för normal import kan inte återanvändas
+för en ersättningsimport och vice versa.
+
+`import_sie` tar parametrarna `company_id`, `file_path` och `import_token`. Verktyget räknar om
+checksum från `file_path` och jämför med den inbäddade hashen i tokenen. Avvisas med
+`"import_token krävs — kör preview_sie_import med exakt samma fil och replace_existing-värde först."`
+om tokenkontrollen misslyckas.
+
+**Export (`export_sie`) kräver ingen token** — operationen är icke-destruktiv mot bokföringen och
+skriver bara en ny fil. Parametrarna är `fiscal_year_id` och valfri `output_path`. Om `output_path`
+utelämnas väljer verktyget ett standardnamn i hemkatalogen:
+`~/AlipsaAccounting-<räkenskapsårsnamn>.sie`.
+
+---
+
+### Sökvägssäkerhet
+
+`validateImportPath` (befintlig) kontrollerar att filen existerar och inte överstiger 50 MB.
+MCP-verktyget skickar sökvägssträngen från LLM-klienten via `Path.of(filePathArg)` —
+konverteringen sker i verktygslagret, inte i servicen.
+
+Inga ytterligare restriktioner (tillåtna kataloger etc.) läggs till i v1 — verktyget körs
+lokalt och användaren styr vilken fil som pekas ut.
+
+---
+
+### Parameterspecifikationer
+
+#### `preview_sie_import`
+
+| Parameter | Typ | Obligatorisk | Beskrivning |
+|---|---|---|---|
+| `company_id` | integer | ja | Aktiv företagets id |
+| `file_path` | string | ja | Absolut sökväg till SIE-filen |
+| `replace_existing` | boolean | nej (standard: false) | Om befintligt räkenskapsår ska ersättas |
+
+Svar: alla fält ur `SieImportPreview` plus `import_token` (SHA-256-sträng) och `ok: true`.
+
+#### `import_sie`
+
+| Parameter | Typ | Obligatorisk | Beskrivning |
+|---|---|---|---|
+| `company_id` | integer | ja | Aktiv företagets id |
+| `file_path` | string | ja | Absolut sökväg till SIE-filen |
+| `import_token` | string | ja | Token från `preview_sie_import` |
+| `replace_existing` | boolean | nej (standard: false) | Måste matcha värdet som användes vid preview |
+
+Svar: `ok`, `duplicate`, `fiscal_year_id`, `fiscal_year_name`, `accounts_created`,
+`opening_balance_count`, `voucher_count`, `line_count`, `warnings`, `job_id`.
+
+#### `export_sie`
+
+| Parameter | Typ | Obligatorisk | Beskrivning |
+|---|---|---|---|
+| `fiscal_year_id` | integer | ja | Räkenskapsår att exportera |
+| `output_path` | string | nej | Absolut sökväg för SIE-filen; standard: `~/AlipsaAccounting-<namn>.sie` |
+
+Svar: `ok`, `file_path`, `checksum_sha256`, `file_size_bytes`, `account_count`,
+`opening_balance_count`, `voucher_count`.
+
+#### `list_import_jobs`
+
+| Parameter | Typ | Obligatorisk | Beskrivning |
+|---|---|---|---|
+| `company_id` | integer | ja | Aktiv företagets id |
+| `limit` | integer | nej (standard: 20, max: 50) | Antal jobb att returnera |
+
+Svar: lista med `id`, `file_name`, `status`, `summary`, `fiscal_year_id`, `started_at`,
+`completed_at`.
+
+---
+
+### Uppdatering av `skill/accounting-mcp.md`
+
+1. **Läsande verktyg** — lägg till `preview_sie_import` och `list_import_jobs` i tabellen.
+2. **Skrivande verktyg** — lägg till `import_sie` och `export_sie` i tabellen med en not om
+   att `export_sie` inte kräver token.
+3. **Arbetsflöde: SIE-import** (nytt avsnitt):
+   1. Anropa `preview_sie_import`. Visa `companyNameInFile`, räkenskapsårsperiod, antal konton
+      och verifikationer samt eventuella varningar.
+   2. Om `replace_existing` är aktuellt, visa `FiscalYearPurgeSummary`-liknande data och
+      påminn om att operationen är destruktiv — befintliga verifikationer, bilagor och
+      rapportarkiv tas bort.
+   3. Fråga användaren om importen ska genomföras.
+   4. Anropa `import_sie` med oförändrad `file_path`, `replace_existing` och `import_token`.
+   5. Visa `SieImportResult`-sammanfattning inklusive eventuella varningar.
+4. **Arbetsflöde: SIE-export** (nytt avsnitt):
+   1. Anropa `list_fiscal_years` om `fiscal_year_id` är okänt.
+   2. Bestäm `output_path` med användaren om det inte är uppenbart.
+   3. Fråga om exporten ska genomföras.
+   4. Anropa `export_sie`. Visa utmatad sökväg, filstorlek och checksum.
+5. **Begränsningar** — lägg till:
+   - Anropa aldrig `import_sie` med `replace_existing: true` utan att explicit ha bekräftat
+     med användaren att befintliga verifikationer och bilagor för räkenskapsåret tas bort.
+   - Vidarebefordra alltid varningar från `preview_sie_import` till användaren innan import.
+
+---
+
+### Testtäckning
+
+Integrationstester i `AccountingMcpToolsTest` (nytt testdata-SIE-fixtur i
+`app/src/test/resources/`):
+
+| Testfall | Förväntat resultat |
+|---|---|
+| `preview_sie_import` med giltig fil | `ok: true`, korrekt `companyNameInFile`, `import_token` ej null |
+| `preview_sie_import` med saknad fil | `ok: false`, tydligt felmeddelande |
+| `preview_sie_import` med fil > 50 MB | `ok: false`, storleksfel |
+| `import_sie` utan token | Avvisas med instruktionsmeddelande |
+| `import_sie` med token för annan fil | Avvisas med tokenfel |
+| `import_sie` med token för `replace_existing: false` men anropar med `replace_existing: true` | Avvisas med tokenfel |
+| `import_sie` med korrekt token | `ok: true`, `fiscal_year_id` ej null |
+| `import_sie` duplicerat (samma fil igen) | `ok: true`, `duplicate: true` |
+| `export_sie` för öppet räkenskapsår | `ok: true`, fil skapas, `checksum_sha256` ej null |
+| `export_sie` med angiven `output_path` | Filen skrivs till angiven sökväg |
+| `list_import_jobs` | Returnerar lista med minst ett jobb efter genomförd import |
+
+---
+
+### Berörda filer
+
+#### Ny produktionskod
+
+| Fil | Förändring |
+|---|---|
+| `service/SieImportExportModels.groovy` | Ny `SieImportPreview`-klass |
+| `service/SieImportExportService.groovy` | Ny publik `previewSieImport`-metod |
+| `mcp/AccountingMcpTools.groovy` | Nya verktygsdefinitioner och implementationsmetoder för `preview_sie_import`, `import_sie`, `export_sie`, `list_import_jobs` |
+
+#### Ändrad produktionskod
+
+| Fil | Förändring |
+|---|---|
+| `skill/accounting-mcp.md` | Verktygstabeller, tre nya arbetsflödesavsnitt, utökade begränsningar |
+
+#### Ny testkod
+
+| Fil | Förändring |
+|---|---|
+| `test/groovy/integration/…/AccountingMcpToolsTest.groovy` | Testfall för de fyra nya verktygen |
+| `test/resources/` | Minsta möjliga giltig SIE4-testfixtur |
+
+---
+
+### Leveransordning
+
+1. Lägg till `SieImportPreview` i `SieImportExportModels.groovy`.
+2. Implementera `previewSieImport` i `SieImportExportService`.
+3. Implementera `preview_sie_import` och `list_import_jobs` i `AccountingMcpTools` (läsande,
+   säker att testa utan destruktiv risk).
+4. Implementera `export_sie` i `AccountingMcpTools`.
+5. Implementera `import_sie` med tokenvalidering i `AccountingMcpTools`.
+6. Skriv integrationstester med SIE-fixtur.
+7. Uppdatera `skill/accounting-mcp.md`.
+8. Kör `./gradlew build`.

--- a/req/v1.1.0-ai-impl-plan.md
+++ b/req/v1.1.0-ai-impl-plan.md
@@ -121,27 +121,27 @@ app/src/test/groovy/acceptance/se/alipsa/accounting/
 
 #### Läsande verktyg
 
-| Verktyg | Delegerar till | Anmärkning |
-|---|---|---|
-| `get_company_info` | `CompanyService.findById` | |
-| `list_fiscal_years` | `FiscalYearService.listFiscalYears` | |
-| `list_accounts` | `AccountService.searchAccounts` | Valfri `query`-parameter |
-| `list_vouchers` | `VoucherService.listVouchers` | Max 200 rader |
-| `get_trial_balance` | `ReportDataService.generate(TRIAL_BALANCE)` | `fiscal_year_id` krävs; `accounting_period_id`, `start_date`, `end_date` valfria |
+| Verktyg              | Delegerar till                               | Anmärkning                                                                                                          |
+|----------------------|----------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| `get_company_info`   | `CompanyService.findById`                    |                                                                                                                     |
+| `list_fiscal_years`  | `FiscalYearService.listFiscalYears`          |                                                                                                                     |
+| `list_accounts`      | `AccountService.searchAccounts`              | Valfri `query`-parameter                                                                                            |
+| `list_vouchers`      | `VoucherService.listVouchers`                | Max 200 rader                                                                                                       |
+| `get_trial_balance`  | `ReportDataService.generate(TRIAL_BALANCE)`  | `fiscal_year_id` krävs; `accounting_period_id`, `start_date`, `end_date` valfria                                    |
 | `get_general_ledger` | `ReportDataService.generate(GENERAL_LEDGER)` | `fiscal_year_id` krävs; `accounting_period_id`, `start_date`, `end_date` valfria; `limit` (standard 1000, max 5000) |
-| `list_vat_periods` | `VatService.listPeriods` | |
-| `get_vat_report` | `VatService.calculateReport` | Returnerar `report_hash` som krävs av `book_vat_transfer` |
-| `preview_voucher` | Intern validering | Returnerar `preview_token`; avvisar om ogiltig |
-| `preview_year_end` | `ClosingService.previewClosing` | Returnerar `preview_token` |
+| `list_vat_periods`   | `VatService.listPeriods`                     |                                                                                                                     |
+| `get_vat_report`     | `VatService.calculateReport`                 | Returnerar `report_hash` som krävs av `book_vat_transfer`                                                           |
+| `preview_voucher`    | Intern validering                            | Returnerar `preview_token`; avvisar om ogiltig                                                                      |
+| `preview_year_end`   | `ClosingService.previewClosing`              | Returnerar `preview_token`                                                                                          |
 
 #### Skrivande verktyg (kräver token från föregående förhandsgranskning)
 
-| Verktyg | Delegerar till | Kräver |
-|---|---|---|
-| `post_voucher` | `VoucherService.createVoucher` | `preview_token` från `preview_voucher` med identisk nyttolast |
-| `create_correction_voucher` | `VoucherService.createCorrectionVoucher` | Ingen token — `original_voucher_id` identifierar entydigt |
-| `book_vat_transfer` | `VatService.bookTransfer` | `report_hash` från `get_vat_report` |
-| `close_fiscal_year` | `ClosingService.closeFiscalYear` | `preview_token` från `preview_year_end` |
+| Verktyg                     | Delegerar till                           | Kräver                                                        |
+|-----------------------------|------------------------------------------|---------------------------------------------------------------|
+| `post_voucher`              | `VoucherService.createVoucher`           | `preview_token` från `preview_voucher` med identisk nyttolast |
+| `create_correction_voucher` | `VoucherService.createCorrectionVoucher` | Ingen token — `original_voucher_id` identifierar entydigt     |
+| `book_vat_transfer`         | `VatService.bookTransfer`                | `report_hash` från `get_vat_report`                           |
+| `close_fiscal_year`         | `ClosingService.closeFiscalYear`         | `preview_token` från `preview_year_end`                       |
 
 Upplåsning av räkenskapsår (`reopenFiscalYear`) exponeras inte i första leveransen.
 

--- a/skill/accounting-mcp.md
+++ b/skill/accounting-mcp.md
@@ -1,0 +1,106 @@
+---
+name: accounting-mcp
+description: Guides an LLM assistant through bookkeeping workflows using the Alipsa Accounting MCP server. Covers context gathering, voucher entry, VAT reporting and year-end closing.
+---
+
+# Accounting MCP Skill
+
+## Overview
+
+This skill governs how you assist users with bookkeeping through the Alipsa Accounting MCP server. The server exposes the application's existing domain and service layer. The same business rules that apply in the GUI apply here. You cannot bypass them.
+
+Always read before you write. Gather context first, propose actions, then post only after the user confirms.
+
+## Available Tools
+
+### Read-only tools
+
+| Tool | Purpose |
+|------|---------|
+| `get_company_info` | Active company name, currency, VAT periodicity |
+| `list_fiscal_years` | All fiscal years with open/closed status |
+| `list_accounts` | Chart of accounts; supports optional query string filter |
+| `list_vouchers` | Recent vouchers for a fiscal year |
+| `get_trial_balance` | Opening balance, period debit/credit, closing balance per account |
+| `get_general_ledger` | Full posting history with running balance per account |
+| `list_vat_periods` | VAT periods with status (`OPEN`, `REPORTED`, `LOCKED`) |
+| `get_vat_report` | Calculated VAT report for a period; returns `report_hash` |
+| `preview_voucher` | Validate a proposed voucher without posting it; returns `preview_token` only when valid |
+| `preview_year_end` | Year-end pre-checks: blocking issues, warnings, net result; returns `preview_token` only when ready |
+
+### Write tools
+
+Only call write tools after the user explicitly confirms the proposed action.
+
+| Tool | Purpose |
+|------|---------|
+| `post_voucher` | Post a balanced voucher using a token from `preview_voucher` |
+| `create_correction_voucher` | Reverse a posted voucher; direct edit/delete is not exposed |
+| `book_vat_transfer` | Book the VAT settlement voucher using `report_hash` from `get_vat_report` |
+| `close_fiscal_year` | Close the fiscal year using a token from `preview_year_end` |
+
+## Workflow: Voucher Entry
+
+1. Gather context.
+   Call `get_company_info` and `list_fiscal_years`. Identify the open fiscal year and its `fiscal_year_id`.
+
+2. Look up accounts.
+   Call `list_accounts` with a query string when needed. Verify each account is active and has the expected `account_class`.
+
+3. Propose and validate.
+   Summarize the voucher to the user: date, description, and lines with account numbers and amounts. Call `preview_voucher` and show resolved account names plus any errors or warnings. Do not proceed if `ok` is false or `preview_token` is missing.
+
+4. Confirm and post.
+   Ask the user explicitly whether to post the voucher. Only call `post_voucher` after confirmation, passing the unchanged payload and the returned `preview_token`.
+
+5. Correct posted vouchers through corrections.
+   Direct edits and deletes are not exposed. If a posted voucher is wrong, explain that the permitted path is `create_correction_voucher`.
+
+## Workflow: VAT Reporting
+
+1. Call `list_vat_periods` for the relevant fiscal year.
+2. Identify the period the user wants to report.
+3. Call `get_vat_report` and show output VAT, input VAT, net VAT to pay, and any unusual rows.
+4. Ask whether to book the VAT transfer.
+5. Only call `book_vat_transfer` after confirmation, passing the exact `report_hash` returned by `get_vat_report`.
+
+## Workflow: Year-End Closing
+
+1. Call `list_fiscal_years` and confirm the year is open.
+2. Call `preview_year_end`.
+3. Show `blocking_issues`, `warnings`, `net_result`, and whether the next fiscal year will be created automatically.
+4. If `ready_to_close` is false or `preview_token` is missing, explain the blockers and do not call `close_fiscal_year`.
+5. If `ready_to_close` is true, ask the user to confirm closing the year.
+6. Only call `close_fiscal_year` after confirmation, passing the returned `preview_token`.
+
+## Domain Reference
+
+### Fiscal years
+
+Each fiscal year has `start_date`, `end_date`, and `closed`. Closed years block new ordinary vouchers. Reopening a year with existing closing entries is blocked by the service layer.
+
+### Vouchers
+
+Vouchers are append-only. A voucher must balance: total debit equals total credit. The only exposed correction path is a reversing correction voucher.
+
+### Account classes
+
+| Class | Meaning | Normal balance |
+|-------|---------|----------------|
+| `ASSET` | Asset | Debit |
+| `LIABILITY` | Liability | Credit |
+| `EQUITY` | Equity | Credit |
+| `INCOME` | Income | Credit |
+| `EXPENSE` | Expense | Debit |
+
+### VAT
+
+VAT periods are derived from accounting periods and the company's VAT periodicity. A VAT period moves from `OPEN` to `REPORTED` to `LOCKED` after the VAT transfer voucher is booked.
+
+## Constraints
+
+- Never call write tools speculatively.
+- Never proceed after `ok: false`; explain the returned `errors` in plain language.
+- Never suggest direct modification or deletion of posted vouchers.
+- Never make legal statements about tax liability. Describe bookkeeping consequences only.
+- Always use the company's `default_currency` when quoting amounts.

--- a/skill/accounting-mcp.md
+++ b/skill/accounting-mcp.md
@@ -1,6 +1,6 @@
 ---
 name: accounting-mcp
-description: Guides an LLM assistant through bookkeeping workflows using the Alipsa Accounting MCP server. Covers context gathering, voucher entry, VAT reporting and year-end closing.
+description: Bookkeeping workflows for the Alipsa Accounting MCP server.
 ---
 
 # Accounting MCP Skill
@@ -55,6 +55,17 @@ Only call write tools after the user explicitly confirms the proposed action.
 
 5. Correct posted vouchers through corrections.
    Direct edits and deletes are not exposed. If a posted voucher is wrong, explain that the permitted path is `create_correction_voucher`.
+
+## Workflow: Correction Voucher
+
+1. Gather and verify the original voucher.
+   Call `list_vouchers` and, if needed, `get_general_ledger` to identify the posted voucher that must be reversed. Confirm its date, description, voucher number, and lines with the user.
+
+2. Explain the correction.
+   State that posted vouchers are append-only and that `create_correction_voucher` creates a reversing voucher. Ask the user to confirm the original voucher ID and optional correction description.
+
+3. Create after confirmation.
+   Only call `create_correction_voucher` after explicit confirmation, passing `original_voucher_id` and the optional `description`. Show the created correction voucher number and lines.
 
 ## Workflow: VAT Reporting
 


### PR DESCRIPTION
## Summary

Implements Phase 5 of `req/v1.1.0-ai-impl-plan.md`.

- Adds `skill/accounting-mcp.md`, a packaged guide for LLM-assisted bookkeeping through the local MCP server.
- Includes `skill/` in Gradle `distZip`, `distTar`, and `installDist` distributions.
- Includes `skill/` in the Linux release zip.
- Adds Windows and macOS app-image copy tasks so platform app images get the same `skill/accounting-mcp.md` relative path.

## Validation

- `./gradlew spotlessApply`
- `./gradlew build`
- `./gradlew distZip` and verified `app-1.1.0-SNAPSHOT/skill/accounting-mcp.md`
- `./gradlew packageLinuxReleaseZip` and verified `skill/accounting-mcp.md`