### PR TITLE
 Add SIE export and import MCP tools

### DIFF
--- a/app/src/main/groovy/se/alipsa/accounting/mcp/AccountingMcpTools.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/mcp/AccountingMcpTools.groovy
@@ -818,7 +818,7 @@ class AccountingMcpTools {
             errors: [
                 replaceExisting
                     ? 'Räkenskapsårets innehåll har förändrats sedan förhandsgranskningen — kör preview_sie_import igen.'
-                    : 'import_token krävs — kör preview_sie_import med exakt samma fil och replace_existing-värde först.'
+                    : 'Ogiltig import_token — kör preview_sie_import med exakt samma fil och replace_existing-värde.'
             ]
         ]
       }
@@ -850,7 +850,7 @@ class AccountingMcpTools {
     try {
       Path outputPath = args.get('output_path') == null
           ? defaultSieExportPath(fiscalYearId)
-          : Path.of(requiredString(args, 'output_path')).toAbsolutePath().normalize()
+          : Path.of(args.get('output_path') as String).toAbsolutePath().normalize()
       if (Files.exists(outputPath) && !overwrite) {
         return [
             ok: false,
@@ -998,33 +998,33 @@ class AccountingMcpTools {
 
   private Map<String, Object> previewMap(SieImportPreview preview) {
     [
-        companyNameInFile: preview.companyNameInFile,
-        fiscalYearStart: preview.fiscalYearStart?.toString(),
-        fiscalYearEnd: preview.fiscalYearEnd?.toString(),
-        accountCount: preview.accountCount,
-        voucherCount: preview.voucherCount,
-        lineCount: preview.lineCount,
+        company_name_in_file: preview.companyNameInFile,
+        fiscal_year_start: preview.fiscalYearStart?.toString(),
+        fiscal_year_end: preview.fiscalYearEnd?.toString(),
+        account_count: preview.accountCount,
+        voucher_count: preview.voucherCount,
+        line_count: preview.lineCount,
         warnings: preview.warnings,
-        checksumSha256: preview.checksumSha256,
-        replaceExisting: preview.replaceExisting,
-        fiscalYearExists: preview.fiscalYearExists,
-        targetFiscalYearId: preview.targetFiscalYearId,
-        targetFiscalYearName: preview.targetFiscalYearName,
-        purgeSummary: preview.purgeSummary == null ? null : purgeSummaryMap(preview.purgeSummary),
-        blockingIssues: preview.blockingIssues,
-        isDuplicate: preview.duplicate,
-        duplicateJobId: preview.duplicateJobId
+        checksum_sha256: preview.checksumSha256,
+        replace_existing: preview.replaceExisting,
+        fiscal_year_exists: preview.fiscalYearExists,
+        target_fiscal_year_id: preview.targetFiscalYearId,
+        target_fiscal_year_name: preview.targetFiscalYearName,
+        purge_summary: preview.purgeSummary == null ? null : purgeSummaryMap(preview.purgeSummary),
+        blocking_issues: preview.blockingIssues,
+        is_duplicate: preview.duplicate,
+        duplicate_job_id: preview.duplicateJobId
     ]
   }
 
   private static Map<String, Object> purgeSummaryMap(FiscalYearPurgeSummary summary) {
     [
-        attachmentCount: summary.attachmentCount,
-        reportArchiveCount: summary.reportArchiveCount,
-        openingBalanceCount: summary.openingBalanceCount,
-        voucherCount: summary.voucherCount,
-        vatPeriodCount: summary.vatPeriodCount,
-        auditLogCount: summary.auditLogCount
+        attachment_count: summary.attachmentCount,
+        report_archive_count: summary.reportArchiveCount,
+        opening_balance_count: summary.openingBalanceCount,
+        voucher_count: summary.voucherCount,
+        vat_period_count: summary.vatPeriodCount,
+        audit_log_count: summary.auditLogCount
     ]
   }
 

--- a/app/src/main/groovy/se/alipsa/accounting/mcp/AccountingMcpTools.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/mcp/AccountingMcpTools.groovy
@@ -5,6 +5,7 @@ import groovy.json.JsonOutput
 import se.alipsa.accounting.domain.Account
 import se.alipsa.accounting.domain.Company
 import se.alipsa.accounting.domain.FiscalYear
+import se.alipsa.accounting.domain.ImportJob
 import se.alipsa.accounting.domain.VatPeriod
 import se.alipsa.accounting.domain.Voucher
 import se.alipsa.accounting.domain.VoucherLine
@@ -15,15 +16,24 @@ import se.alipsa.accounting.domain.report.TrialBalanceRow
 import se.alipsa.accounting.service.AccountService
 import se.alipsa.accounting.service.ClosingService
 import se.alipsa.accounting.service.CompanyService
+import se.alipsa.accounting.service.FiscalYearPurgeSummary
 import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.service.ReportDataService
+import se.alipsa.accounting.service.SieExportResult
+import se.alipsa.accounting.service.SieImportExportService
+import se.alipsa.accounting.service.SieImportPreview
 import se.alipsa.accounting.service.VatService
 import se.alipsa.accounting.service.VoucherService
 import se.alipsa.accounting.service.YearEndClosingPreview
 import se.alipsa.accounting.service.YearEndClosingResult
+import se.alipsa.accounting.support.AppPaths
 
+import java.nio.file.Files
+import java.nio.file.Path
 import java.security.MessageDigest
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 
 /**
@@ -40,6 +50,7 @@ class AccountingMcpTools {
   private final VatService vatService
   private final ClosingService closingService
   private final ReportDataService reportDataService
+  private final SieImportExportService sieImportExportService
 
   AccountingMcpTools() {
     this(
@@ -49,7 +60,8 @@ class AccountingMcpTools {
         new VoucherService(),
         new VatService(),
         new ClosingService(),
-        new ReportDataService()
+        new ReportDataService(),
+        new SieImportExportService()
     )
   }
 
@@ -62,6 +74,28 @@ class AccountingMcpTools {
       ClosingService closingService,
       ReportDataService reportDataService
   ) {
+    this(
+        companyService,
+        fiscalYearService,
+        accountService,
+        voucherService,
+        vatService,
+        closingService,
+        reportDataService,
+        new SieImportExportService()
+    )
+  }
+
+  AccountingMcpTools(
+      CompanyService companyService,
+      FiscalYearService fiscalYearService,
+      AccountService accountService,
+      VoucherService voucherService,
+      VatService vatService,
+      ClosingService closingService,
+      ReportDataService reportDataService,
+      SieImportExportService sieImportExportService
+  ) {
     this.companyService = companyService
     this.fiscalYearService = fiscalYearService
     this.accountService = accountService
@@ -69,10 +103,11 @@ class AccountingMcpTools {
     this.vatService = vatService
     this.closingService = closingService
     this.reportDataService = reportDataService
+    this.sieImportExportService = sieImportExportService
   }
 
   List<Map<String, Object>> listTools() {
-    readOnlyToolDefs() + voucherToolDefs() + vatWriteToolDefs() + yearEndToolDefs()
+    readOnlyToolDefs() + voucherToolDefs() + vatWriteToolDefs() + yearEndToolDefs() + sieToolDefs()
   }
 
   private static List<Map<String, Object>> readOnlyToolDefs() {
@@ -223,6 +258,47 @@ class AccountingMcpTools {
     ]
   }
 
+  private static List<Map<String, Object>> sieToolDefs() {
+    [
+        toolDef('preview_sie_import',
+            'Previews a SIE4 import without writing data. Returns file summary, duplicate status, replacement purge summary, blocking issues, and import_token when importable.',
+            ['company_id', 'file_path'],
+            [
+                company_id: intParam('Company ID'),
+                file_path: strParam('Absolute path to the SIE file.'),
+                replace_existing: optBoolParam('Whether to replace the existing matching fiscal year. Defaults to false.')
+            ]
+        ),
+        toolDef('import_sie',
+            'Imports a SIE4 file. Run preview_sie_import first and pass back its import_token for the same file and replace_existing value.',
+            ['company_id', 'file_path', 'import_token'],
+            [
+                company_id: intParam('Company ID'),
+                file_path: strParam('Absolute path to the SIE file.'),
+                import_token: strParam('Token returned by preview_sie_import.'),
+                replace_existing: optBoolParam('Whether to replace the existing matching fiscal year. Defaults to false.')
+            ]
+        ),
+        toolDef('export_sie',
+            'Exports a fiscal year as SIE4. Refuses to overwrite existing files unless overwrite is true.',
+            ['fiscal_year_id'],
+            [
+                fiscal_year_id: intParam('Fiscal year ID to export.'),
+                output_path: optStrParam('Optional absolute output path. Defaults to the application SIE export directory.'),
+                overwrite: optBoolParam('Allow overwriting an existing output file. Defaults to false.')
+            ]
+        ),
+        toolDef('list_import_jobs',
+            'Lists recent SIE import jobs for the given company. Limit defaults to 20 and is clamped to 1..50.',
+            ['company_id'],
+            [
+                company_id: intParam('Company ID'),
+                limit: optIntParam('Max rows returned. Default 20, max 50.')
+            ]
+        )
+    ]
+  }
+
   Map<String, Object> callTool(String name, Map<String, Object> arguments) {
     switch (name) {
       case 'get_company_info':
@@ -253,6 +329,14 @@ class AccountingMcpTools {
         return previewYearEnd(arguments)
       case 'close_fiscal_year':
         return closeFiscalYear(arguments)
+      case 'preview_sie_import':
+        return previewSieImport(arguments)
+      case 'import_sie':
+        return importSie(arguments)
+      case 'export_sie':
+        return exportSie(arguments)
+      case 'list_import_jobs':
+        return listImportJobs(arguments)
       default:
         throw new IllegalArgumentException("Unknown MCP tool: ${name}")
     }
@@ -698,6 +782,123 @@ class AccountingMcpTools {
     }
   }
 
+  private Map<String, Object> previewSieImport(Map<String, Object> args) {
+    long companyId = requiredLong(args, 'company_id')
+    Path filePath = Path.of(requiredString(args, 'file_path'))
+    boolean replaceExisting = optionalBoolean(args, 'replace_existing', false)
+    try {
+      SieImportPreview preview = sieImportExportService.previewSieImport(companyId, filePath, replaceExisting)
+      Map<String, Object> result = previewMap(preview)
+      result.import_token = preview.blockingIssues.isEmpty() ? sieImportToken(companyId, preview) : null
+      result.ok = preview.blockingIssues.isEmpty()
+      result
+    } catch (Exception exception) {
+      [ok: false, errors: [exception.message ?: exception.class.simpleName]]
+    }
+  }
+
+  private Map<String, Object> importSie(Map<String, Object> args) {
+    long companyId = requiredLong(args, 'company_id')
+    Path filePath = Path.of(requiredString(args, 'file_path'))
+    boolean replaceExisting = optionalBoolean(args, 'replace_existing', false)
+    String providedToken = args.get('import_token') as String
+    if (!providedToken) {
+      return [ok: false, errors: ['import_token krävs — kör preview_sie_import med exakt samma fil och replace_existing-värde först.']]
+    }
+
+    try {
+      SieImportPreview preview = sieImportExportService.previewSieImport(companyId, filePath, replaceExisting)
+      if (!preview.blockingIssues.isEmpty()) {
+        return [ok: false, errors: preview.blockingIssues]
+      }
+      String expectedToken = sieImportToken(companyId, preview)
+      if (providedToken != expectedToken) {
+        return [
+            ok: false,
+            errors: [
+                replaceExisting
+                    ? 'Räkenskapsårets innehåll har förändrats sedan förhandsgranskningen — kör preview_sie_import igen.'
+                    : 'import_token krävs — kör preview_sie_import med exakt samma fil och replace_existing-värde först.'
+            ]
+        ]
+      }
+      def result = replaceExisting
+          ? sieImportExportService.replaceFiscalYear(companyId, filePath)
+          : sieImportExportService.importFile(companyId, filePath)
+      [
+          ok: true,
+          duplicate: result.duplicate,
+          fiscal_year_id: result.fiscalYear?.id ?: result.job?.fiscalYearId,
+          fiscal_year_name: result.fiscalYear?.name,
+          accounts_created: result.accountsCreated,
+          opening_balance_count: result.openingBalanceCount,
+          voucher_count: result.voucherCount,
+          line_count: result.lineCount,
+          warnings: result.warnings,
+          job_id: result.job?.id,
+          job_status: result.job?.status?.name(),
+          summary: result.job?.summary
+      ]
+    } catch (Exception exception) {
+      [ok: false, errors: [exception.message ?: exception.class.simpleName]]
+    }
+  }
+
+  private Map<String, Object> exportSie(Map<String, Object> args) {
+    long fiscalYearId = requiredLong(args, 'fiscal_year_id')
+    boolean overwrite = optionalBoolean(args, 'overwrite', false)
+    try {
+      Path outputPath = args.get('output_path') == null
+          ? defaultSieExportPath(fiscalYearId)
+          : Path.of(requiredString(args, 'output_path')).toAbsolutePath().normalize()
+      if (Files.exists(outputPath) && !overwrite) {
+        return [
+            ok: false,
+            file_exists: true,
+            existing_file_path: outputPath.toString(),
+            errors: ['Målfilen finns redan. Bekräfta överskrivning och anropa export_sie med overwrite: true.']
+        ]
+      }
+      SieExportResult result = sieImportExportService.exportFiscalYear(fiscalYearId, outputPath)
+      [
+          ok: true,
+          file_path: result.filePath?.toString(),
+          checksum_sha256: result.checksumSha256,
+          file_size_bytes: result.fileSizeBytes,
+          account_count: result.accountCount,
+          opening_balance_count: result.openingBalanceCount,
+          voucher_count: result.voucherCount
+      ]
+    } catch (Exception exception) {
+      [ok: false, errors: [exception.message ?: exception.class.simpleName]]
+    }
+  }
+
+  private Map<String, Object> listImportJobs(Map<String, Object> args) {
+    long companyId = requiredLong(args, 'company_id')
+    int limit = args.get('limit') != null
+        ? Math.min(Math.max(((Number) args.get('limit')).intValue(), 1), 50)
+        : 20
+    try {
+      [
+          ok: true,
+          import_jobs: sieImportExportService.listImportJobs(companyId, limit).collect { ImportJob job ->
+            [
+                id: job.id,
+                file_name: job.fileName,
+                status: job.status?.name(),
+                summary: job.summary,
+                fiscal_year_id: job.fiscalYearId,
+                started_at: job.startedAt?.toString(),
+                completed_at: job.completedAt?.toString()
+            ]
+          }
+      ]
+    } catch (Exception exception) {
+      [ok: false, errors: [exception.message ?: exception.class.simpleName]]
+    }
+  }
+
   // ---- helpers ----
 
   private static long requiredLong(Map<String, Object> args, String key) {
@@ -719,6 +920,11 @@ class AccountingMcpTools {
   private static String optionalString(Map<String, Object> args, String key, String defaultValue) {
     String value = args.get(key) as String
     value?.trim() ?: defaultValue
+  }
+
+  private static boolean optionalBoolean(Map<String, Object> args, String key, boolean defaultValue) {
+    Object value = args.get(key)
+    value == null ? defaultValue : Boolean.valueOf(value.toString())
   }
 
   private static List<Map<String, Object>> linesArg(Map<String, Object> args) {
@@ -763,6 +969,78 @@ class AccountingMcpTools {
         fiscal_year_id: fiscalYearId,
         closing_account: closingAccount
     ])
+  }
+
+  private static String sieImportToken(long companyId, SieImportPreview preview) {
+    computePreviewToken(sieImportTokenPayload(companyId, preview))
+  }
+
+  private static Map<String, Object> sieImportTokenPayload(long companyId, SieImportPreview preview) {
+    Map<String, Object> payload = [
+        company_id: companyId,
+        file_checksum: preview.checksumSha256,
+        replace_existing: preview.replaceExisting
+    ]
+    if (preview.replaceExisting) {
+      FiscalYearPurgeSummary summary = preview.purgeSummary
+      payload.putAll([
+          target_fiscal_year_id: preview.targetFiscalYearId,
+          purge_voucher_count: summary?.voucherCount ?: 0,
+          purge_attachment_count: summary?.attachmentCount ?: 0,
+          purge_opening_balance_count: summary?.openingBalanceCount ?: 0,
+          purge_vat_period_count: summary?.vatPeriodCount ?: 0,
+          purge_report_archive_count: summary?.reportArchiveCount ?: 0,
+          purge_audit_log_count: summary?.auditLogCount ?: 0
+      ])
+    }
+    payload
+  }
+
+  private Map<String, Object> previewMap(SieImportPreview preview) {
+    [
+        companyNameInFile: preview.companyNameInFile,
+        fiscalYearStart: preview.fiscalYearStart?.toString(),
+        fiscalYearEnd: preview.fiscalYearEnd?.toString(),
+        accountCount: preview.accountCount,
+        voucherCount: preview.voucherCount,
+        lineCount: preview.lineCount,
+        warnings: preview.warnings,
+        checksumSha256: preview.checksumSha256,
+        replaceExisting: preview.replaceExisting,
+        fiscalYearExists: preview.fiscalYearExists,
+        targetFiscalYearId: preview.targetFiscalYearId,
+        targetFiscalYearName: preview.targetFiscalYearName,
+        purgeSummary: preview.purgeSummary == null ? null : purgeSummaryMap(preview.purgeSummary),
+        blockingIssues: preview.blockingIssues,
+        isDuplicate: preview.duplicate,
+        duplicateJobId: preview.duplicateJobId
+    ]
+  }
+
+  private static Map<String, Object> purgeSummaryMap(FiscalYearPurgeSummary summary) {
+    [
+        attachmentCount: summary.attachmentCount,
+        reportArchiveCount: summary.reportArchiveCount,
+        openingBalanceCount: summary.openingBalanceCount,
+        voucherCount: summary.voucherCount,
+        vatPeriodCount: summary.vatPeriodCount,
+        auditLogCount: summary.auditLogCount
+    ]
+  }
+
+  private Path defaultSieExportPath(long fiscalYearId) {
+    FiscalYear fiscalYear = fiscalYearService.findById(fiscalYearId)
+    if (fiscalYear == null) {
+      throw new IllegalArgumentException("Okänt räkenskapsår: ${fiscalYearId}")
+    }
+    String safeName = fiscalYear.name
+        .replaceAll(/[^A-Za-z0-9._-]+/, '-')
+        .replaceAll(/^-+|-+$/, '')
+    if (!safeName) {
+      safeName = fiscalYearId.toString()
+    }
+    String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern('yyyyMMddHHmm'))
+    AppPaths.sieExportsDirectory().resolve("AlipsaAccounting-${safeName}-${timestamp}.sie").toAbsolutePath().normalize()
   }
 
   private static List<Map<String, Object>> canonicalVoucherLines(List<Map<String, Object>> lines) {
@@ -863,6 +1141,10 @@ class AccountingMcpTools {
 
   private static Map<String, Object> optStrParam(String description) {
     [type: 'string', description: description]
+  }
+
+  private static Map<String, Object> optBoolParam(String description) {
+    [type: 'boolean', description: description]
   }
 
   private static Map<String, Object> strParam(String description) {

--- a/app/src/main/groovy/se/alipsa/accounting/service/FiscalYearReplacementService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/FiscalYearReplacementService.groovy
@@ -48,6 +48,15 @@ final class FiscalYearReplacementService {
     new FiscalYearReplacementPlan(summary, attachmentStoragePaths, reportArchiveStoragePaths)
   }
 
+  static FiscalYearReplacementPlan previewFiscalYearReplacement(Sql sql, long companyId, FiscalYear fiscalYear) {
+    ensureReplaceAllowed(sql, fiscalYear)
+    new FiscalYearReplacementPlan(
+        collectPurgeSummary(sql, companyId, fiscalYear.id),
+        loadAttachmentStoragePaths(sql, fiscalYear.id),
+        loadReportArchiveStoragePaths(sql, fiscalYear.id)
+    )
+  }
+
   static void deleteStoredFilesQuietly(Path rootDirectory, List<String> storagePaths) {
     Path root = rootDirectory.toAbsolutePath().normalize()
     List<String> validPaths = storagePaths.findAll { String path -> path != null && !path.isBlank() }

--- a/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportModels.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportModels.groovy
@@ -24,6 +24,27 @@ final class SieImportResult {
 }
 
 @Canonical
+final class SieImportPreview {
+
+  String companyNameInFile
+  LocalDate fiscalYearStart
+  LocalDate fiscalYearEnd
+  int accountCount
+  int voucherCount
+  int lineCount
+  List<String> warnings = []
+  String checksumSha256
+  boolean replaceExisting
+  boolean fiscalYearExists
+  Long targetFiscalYearId
+  String targetFiscalYearName
+  FiscalYearPurgeSummary purgeSummary
+  List<String> blockingIssues = []
+  boolean duplicate
+  Long duplicateJobId
+}
+
+@Canonical
 final class SieExportResult {
 
   Path filePath

--- a/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
@@ -2,6 +2,7 @@ package se.alipsa.accounting.service
 
 import groovy.sql.GroovyRowResult
 import groovy.sql.Sql
+import groovy.transform.PackageScope
 
 import alipsa.sieparser.SIE
 import alipsa.sieparser.SieAccount
@@ -90,6 +91,52 @@ final class SieImportExportService {
       throw new IllegalArgumentException((errors ?: ['SIE-filen kunde inte läsas.']).join('\n'))
     }
     document.getFNAMN()
+  }
+
+  SieImportPreview previewSieImport(long companyId, Path filePath, boolean replaceExisting) {
+    CompanyService.requireValidCompanyId(companyId)
+    Path safePath = validateImportPath(filePath)
+    byte[] content = Files.readAllBytes(safePath)
+    String checksum = sha256(content)
+    ParsedSie parsed = parseDocument(safePath)
+    SieDocument document = parsed.document
+    SieBookingYear bookingYear = selectPrimaryBookingYear(document)
+    int voucherCount = document.getVER()?.size() ?: 0
+    int lineCount = 0
+    (document.getVER() ?: []).each { SieVoucher voucher ->
+      lineCount += voucher.rows?.count { SieVoucherRow row -> scale(row.amount) != BigDecimal.ZERO } ?: 0
+    }
+
+    databaseService.withSql { Sql sql ->
+      FiscalYear existingYear = findFiscalYearByPeriod(sql, companyId, bookingYear.start, bookingYear.end)
+      ImportJob duplicate = findSuccessfulImportJobByChecksum(sql, companyId, checksum)
+      FiscalYearPurgeSummary purgeSummary = null
+      List<String> blockingIssues = []
+      if (existingYear != null && !(duplicate != null && !replaceExisting)) {
+        blockingIssues.addAll(importBlockingIssues(sql, existingYear, replaceExisting))
+        if (replaceExisting && blockingIssues.isEmpty()) {
+          purgeSummary = FiscalYearReplacementService.previewFiscalYearReplacement(sql, companyId, existingYear).summary
+        }
+      }
+      new SieImportPreview(
+          document.getFNAMN()?.name,
+          bookingYear.start,
+          bookingYear.end,
+          document.getKONTO()?.size() ?: 0,
+          voucherCount,
+          lineCount,
+          parsed.warnings,
+          checksum,
+          replaceExisting,
+          existingYear != null,
+          existingYear?.id,
+          existingYear?.name,
+          purgeSummary,
+          blockingIssues,
+          duplicate != null,
+          duplicate?.id
+      )
+    }
   }
 
   SieImportResult importFile(long companyId, Path filePath) {
@@ -281,6 +328,28 @@ final class SieImportExportService {
       completeImportJob(sql, jobId, null, ImportJobStatus.DUPLICATE, summary, [])
     }
   }
+
+  private static ImportJob findSuccessfulImportJobByChecksum(Sql sql, long companyId, String checksum) {
+    GroovyRowResult row = sql.firstRow('''
+        select id,
+               file_name as fileName,
+               checksum_sha256 as checksumSha256,
+               fiscal_year_id as fiscalYearId,
+               status,
+               summary,
+               error_log as errorLog,
+               started_at as startedAt,
+               completed_at as completedAt
+          from import_job
+         where checksum_sha256 = ?
+           and company_id = ?
+           and status = 'SUCCESS'
+         order by completed_at desc, id desc
+         limit 1
+    ''', [checksum, companyId]) as GroovyRowResult
+    row == null ? null : mapImportJob(row)
+  }
+
   private static ParsedSie parseDocument(Path filePath) {
     SieDocumentReader reader = new SieDocumentReader()
     reader.throwErrors = false
@@ -313,6 +382,13 @@ final class SieImportExportService {
 
   private FiscalYear resolveTargetFiscalYear(Sql sql, long companyId, SieDocument document, boolean replaceExistingFiscalYear) {
     SieBookingYear bookingYear = selectPrimaryBookingYear(document)
+    FiscalYear fiscalYear = findFiscalYearByPeriod(sql, companyId, bookingYear.start, bookingYear.end)
+        ?: createFiscalYear(sql, companyId, bookingYear.start, bookingYear.end)
+    ensureFiscalYearImportable(sql, fiscalYear, replaceExistingFiscalYear)
+    fiscalYear
+  }
+
+  private static FiscalYear findFiscalYearByPeriod(Sql sql, long companyId, LocalDate startDate, LocalDate endDate) {
     GroovyRowResult existing = sql.firstRow('''
         select id,
                name,
@@ -324,12 +400,8 @@ final class SieImportExportService {
          where company_id = ?
            and start_date = ?
            and end_date = ?
-    ''', [companyId, Date.valueOf(bookingYear.start), Date.valueOf(bookingYear.end)]) as GroovyRowResult
-    FiscalYear fiscalYear = existing == null
-        ? createFiscalYear(sql, companyId, bookingYear.start, bookingYear.end)
-        : mapFiscalYear(existing)
-    ensureFiscalYearImportable(sql, fiscalYear, replaceExistingFiscalYear)
-    fiscalYear
+    ''', [companyId, Date.valueOf(startDate), Date.valueOf(endDate)]) as GroovyRowResult
+    existing == null ? null : mapFiscalYear(existing)
   }
 
   private static SieBookingYear selectPrimaryBookingYear(SieDocument document) {
@@ -359,11 +431,26 @@ final class SieImportExportService {
   }
 
   private static void ensureFiscalYearImportable(Sql sql, FiscalYear fiscalYear, boolean replaceExistingFiscalYear) {
+    List<String> issues = importBlockingIssues(sql, fiscalYear, replaceExistingFiscalYear)
+    if (!issues.isEmpty()) {
+      throw new IllegalStateException(issues.first())
+    }
+  }
+
+  private static List<String> importBlockingIssues(Sql sql, FiscalYear fiscalYear, boolean replaceExistingFiscalYear) {
+    List<String> issues = []
     if (fiscalYear.closed) {
-      throw new IllegalStateException("Räkenskapsåret ${fiscalYear.name} är stängt och kan inte användas för import.")
+      issues << "Räkenskapsåret ${fiscalYear.name} är stängt och kan inte användas för import.".toString()
     }
     if (replaceExistingFiscalYear) {
-      return
+      GroovyRowResult closingRow = sql.firstRow(
+          'select count(*) as total from closing_entry where fiscal_year_id = ?',
+          [fiscalYear.id]
+      ) as GroovyRowResult
+      if (((Number) closingRow.get('total')).intValue() > 0) {
+        issues << "Räkenskapsåret ${fiscalYear.name} har bokslutsposter och kan inte ersättas från SIE.".toString()
+      }
+      return issues
     }
     GroovyRowResult voucherRow = sql.firstRow(
         'select count(*) as total from voucher where fiscal_year_id = ?',
@@ -374,8 +461,9 @@ final class SieImportExportService {
         [fiscalYear.id]
     ) as GroovyRowResult
     if (((Number) voucherRow.get('total')).intValue() > 0 || ((Number) openingRow.get('total')).intValue() > 0) {
-      throw new IllegalStateException("Räkenskapsåret ${fiscalYear.name} innehåller redan bokningar eller ingående balanser.")
+      issues << "Räkenskapsåret ${fiscalYear.name} innehåller redan bokningar eller ingående balanser.".toString()
     }
+    issues
   }
 
   private ImportCounts importDocument(Sql sql, long fiscalYearId, SieDocument document, List<String> warnings) {
@@ -960,7 +1048,8 @@ final class SieImportExportService {
     row == null ? null : mapImportJob(row)
   }
 
-  private static ImportJob mapImportJob(GroovyRowResult row) {
+  @PackageScope
+  static ImportJob mapImportJob(GroovyRowResult row) {
     new ImportJob(
         Long.valueOf(row.get('id').toString()),
         row.get('fileName') as String,

--- a/app/src/main/groovy/se/alipsa/accounting/support/AppPaths.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/support/AppPaths.groovy
@@ -54,6 +54,10 @@ final class AppPaths {
     reportsDirectory(applicationHome())
   }
 
+  static Path sieExportsDirectory() {
+    sieExportsDirectory(applicationHome())
+  }
+
   static Path backupsDirectory() {
     backupsDirectory(applicationHome())
   }
@@ -82,6 +86,10 @@ final class AppPaths {
     applicationHome.resolve('reports')
   }
 
+  static Path sieExportsDirectory(Path applicationHome) {
+    applicationHome.resolve('sie-exports')
+  }
+
   static Path backupsDirectory(Path applicationHome) {
     applicationHome.resolve('backups')
   }
@@ -105,6 +113,7 @@ final class AppPaths {
         logDirectory(applicationHome),
         attachmentsDirectory(applicationHome),
         reportsDirectory(applicationHome),
+        sieExportsDirectory(applicationHome),
         backupsDirectory(applicationHome),
         docsDirectory(applicationHome)
     ].each { Path path ->

--- a/app/src/test/groovy/integration/se/alipsa/accounting/mcp/AccountingMcpToolsTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/mcp/AccountingMcpToolsTest.groovy
@@ -15,10 +15,13 @@ import se.alipsa.accounting.service.CompanyService
 import se.alipsa.accounting.service.DatabaseService
 import se.alipsa.accounting.service.FiscalYearService
 import se.alipsa.accounting.service.ReportDataService
+import se.alipsa.accounting.service.ReportIntegrityService
+import se.alipsa.accounting.service.SieImportExportService
 import se.alipsa.accounting.service.VatService
 import se.alipsa.accounting.service.VoucherService
 import se.alipsa.accounting.support.AppPaths
 
+import java.nio.file.Files
 import java.nio.file.Path
 import java.time.LocalDate
 
@@ -45,6 +48,10 @@ class AccountingMcpToolsTest {
     AccountingPeriodService periodService = new AccountingPeriodService(databaseService, auditLogService)
     fiscalYearService = new FiscalYearService(databaseService, periodService, auditLogService)
     voucherService = new VoucherService(databaseService, auditLogService)
+    ReportIntegrityService reportIntegrityService = new ReportIntegrityService(
+        new se.alipsa.accounting.service.AttachmentService(databaseService, auditLogService),
+        auditLogService
+    )
 
     tools = new AccountingMcpTools(
         new CompanyService(databaseService),
@@ -57,9 +64,17 @@ class AccountingMcpToolsTest {
             periodService,
             fiscalYearService,
             voucherService,
-            new se.alipsa.accounting.service.ReportIntegrityService()
+            reportIntegrityService
         ),
-        new ReportDataService(databaseService)
+        new ReportDataService(databaseService),
+        new SieImportExportService(
+            databaseService,
+            periodService,
+            voucherService,
+            new CompanyService(databaseService),
+            reportIntegrityService,
+            auditLogService
+        )
     )
 
     databaseService.withTransaction { groovy.sql.Sql sql ->
@@ -638,6 +653,182 @@ class AccountingMcpToolsTest {
     assertNotEquals(originalId, ((Number) correction.get('voucher_id')).longValue())
   }
 
+  @Test
+  void previewSieImportReturnsTokenForImportableFile() {
+    Path sieFile = writeSimpleSie(tempDir.resolve('mcp-preview.sie'), 2027, '1510', 'Kundfordringar')
+
+    Map<String, Object> result = tools.callTool('preview_sie_import', [
+        company_id: (Object) 1L,
+        file_path: (Object) sieFile.toString()
+    ])
+
+    assertTrue((boolean) result.get('ok'), "Expected ok but got: ${result.get('errors') ?: result.get('blockingIssues')}")
+    assertEquals(false, result.get('fiscalYearExists'))
+    assertEquals('Testbolaget AB', result.get('companyNameInFile'))
+    assertEquals(1, result.get('accountCount'))
+    assertNotNull(result.get('import_token'))
+  }
+
+  @Test
+  void previewSieImportReportsBlockingIssuesForExistingBookedYear() {
+    previewAndPost(balancedVoucherArgs('Bokning före import', 100.00G))
+    Path sieFile = writeSimpleSie(tempDir.resolve('blocked-existing.sie'), 2026, '1510', 'Kundfordringar')
+
+    Map<String, Object> result = tools.callTool('preview_sie_import', [
+        company_id: (Object) 1L,
+        file_path: (Object) sieFile.toString()
+    ])
+
+    assertFalse((boolean) result.get('ok'))
+    assertNull(result.get('import_token'))
+    assertTrue(((List<String>) result.get('blockingIssues')).any { String issue -> issue.contains('innehåller redan') })
+  }
+
+  @Test
+  void previewSieImportReplacementReturnsPurgeSummary() {
+    previewAndPost(balancedVoucherArgs('Bokning att ersätta', 100.00G))
+    Path sieFile = writeSimpleSie(tempDir.resolve('replace-preview.sie'), 2026, '1510', 'Kundfordringar')
+
+    Map<String, Object> result = tools.callTool('preview_sie_import', [
+        company_id: (Object) 1L,
+        file_path: (Object) sieFile.toString(),
+        replace_existing: (Object) true
+    ])
+
+    assertTrue((boolean) result.get('ok'), "Expected ok but got: ${result.get('blockingIssues')}")
+    Map purgeSummary = (Map) result.get('purgeSummary')
+    assertNotNull(purgeSummary)
+    assertTrue(((Number) purgeSummary.get('voucherCount')).intValue() > 0)
+    assertNotNull(result.get('import_token'))
+  }
+
+  @Test
+  void importSieRejectsMissingAndTamperedTokens() {
+    Path sieFile = writeSimpleSie(tempDir.resolve('missing-token.sie'), 2027, '1510', 'Kundfordringar')
+
+    Map<String, Object> missing = tools.callTool('import_sie', [
+        company_id: (Object) 1L,
+        file_path: (Object) sieFile.toString()
+    ])
+    Map<String, Object> tampered = tools.callTool('import_sie', [
+        company_id: (Object) 1L,
+        file_path: (Object) sieFile.toString(),
+        import_token: (Object) 'wrong-token'
+    ])
+
+    assertFalse((boolean) missing.get('ok'))
+    assertTrue(((List<String>) missing.get('errors')).any { String error -> error.contains('import_token') })
+    assertFalse((boolean) tampered.get('ok'))
+  }
+
+  @Test
+  void importSieWithTokenImportsAndDuplicateSecondImportReturnsDuplicate() {
+    Path sieFile = writeSimpleSie(tempDir.resolve('mcp-import.sie'), 2027, '1510', 'Kundfordringar')
+    Map<String, Object> preview = tools.callTool('preview_sie_import', [
+        company_id: (Object) 1L,
+        file_path: (Object) sieFile.toString()
+    ])
+    assertTrue((boolean) preview.get('ok'), "Preview failed: ${preview}")
+
+    Map<String, Object> first = tools.callTool('import_sie', [
+        company_id: (Object) 1L,
+        file_path: (Object) sieFile.toString(),
+        import_token: (Object) preview.get('import_token')
+    ])
+    Map<String, Object> duplicatePreview = tools.callTool('preview_sie_import', [
+        company_id: (Object) 1L,
+        file_path: (Object) sieFile.toString()
+    ])
+    Map<String, Object> second = tools.callTool('import_sie', [
+        company_id: (Object) 1L,
+        file_path: (Object) sieFile.toString(),
+        import_token: (Object) duplicatePreview.get('import_token')
+    ])
+
+    assertTrue((boolean) first.get('ok'), "Expected ok but got: ${first.get('errors')}")
+    assertNotNull(first.get('fiscal_year_id'))
+    assertTrue((boolean) duplicatePreview.get('isDuplicate'))
+    assertTrue((boolean) second.get('ok'), "Expected duplicate ok but got: ${second.get('errors')}")
+    assertTrue((boolean) second.get('duplicate'))
+  }
+
+  @Test
+  void importSieReplacementRejectsWhenPurgeSummaryChangesAfterPreview() {
+    Path sieFile = writeSimpleSie(tempDir.resolve('replace-changed.sie'), 2026, '1510', 'Kundfordringar')
+    Map<String, Object> preview = tools.callTool('preview_sie_import', [
+        company_id: (Object) 1L,
+        file_path: (Object) sieFile.toString(),
+        replace_existing: (Object) true
+    ])
+    assertTrue((boolean) preview.get('ok'), "Preview failed: ${preview}")
+    previewAndPost(balancedVoucherArgs('Ny bokning efter preview', 25.00G))
+
+    Map<String, Object> result = tools.callTool('import_sie', [
+        company_id: (Object) 1L,
+        file_path: (Object) sieFile.toString(),
+        replace_existing: (Object) true,
+        import_token: (Object) preview.get('import_token')
+    ])
+
+    assertFalse((boolean) result.get('ok'))
+    assertTrue(((List<String>) result.get('errors')).any { String error -> error.contains('förändrats') })
+  }
+
+  @Test
+  void exportSieCreatesDefaultTimestampedFileAndProtectsExistingOutput() {
+    previewAndPost(balancedVoucherArgs('Exportunderlag', 100.00G))
+    Path explicitPath = tempDir.resolve('export.sie')
+
+    Map<String, Object> defaultExport = tools.callTool('export_sie', [
+        fiscal_year_id: (Object) fiscalYearId
+    ])
+    Map<String, Object> explicitExport = tools.callTool('export_sie', [
+        fiscal_year_id: (Object) fiscalYearId,
+        output_path: (Object) explicitPath.toString()
+    ])
+    Map<String, Object> blocked = tools.callTool('export_sie', [
+        fiscal_year_id: (Object) fiscalYearId,
+        output_path: (Object) explicitPath.toString()
+    ])
+    Map<String, Object> overwrite = tools.callTool('export_sie', [
+        fiscal_year_id: (Object) fiscalYearId,
+        output_path: (Object) explicitPath.toString(),
+        overwrite: (Object) true
+    ])
+
+    assertTrue((boolean) defaultExport.get('ok'), "Default export failed: ${defaultExport.get('errors')}")
+    Path defaultPath = Path.of((String) defaultExport.get('file_path'))
+    assertTrue(Files.exists(defaultPath))
+    assertTrue(defaultPath.fileName.toString() ==~ /AlipsaAccounting-2026-\d{12}\.sie/)
+    assertTrue((boolean) explicitExport.get('ok'), "Explicit export failed: ${explicitExport.get('errors')}")
+    assertFalse((boolean) blocked.get('ok'))
+    assertTrue((boolean) blocked.get('file_exists'))
+    assertTrue((boolean) overwrite.get('ok'), "Overwrite failed: ${overwrite.get('errors')}")
+  }
+
+  @Test
+  void listImportJobsClampsLimitToFifty() {
+    Path sieFile = writeSimpleSie(tempDir.resolve('job-list.sie'), 2027, '1510', 'Kundfordringar')
+    Map<String, Object> preview = tools.callTool('preview_sie_import', [
+        company_id: (Object) 1L,
+        file_path: (Object) sieFile.toString()
+    ])
+    tools.callTool('import_sie', [
+        company_id: (Object) 1L,
+        file_path: (Object) sieFile.toString(),
+        import_token: (Object) preview.get('import_token')
+    ])
+
+    Map<String, Object> result = tools.callTool('list_import_jobs', [
+        company_id: (Object) 1L,
+        limit: (Object) 100
+    ])
+
+    assertTrue((boolean) result.get('ok'))
+    assertTrue(((List) result.get('import_jobs')).size() <= 50)
+    assertFalse(((List) result.get('import_jobs')).isEmpty())
+  }
+
   private Map<String, Object> previewAndPost(Map<String, Object> postArgs) {
     Map<String, Object> previewResult = tools.callTool('preview_voucher', postArgs)
     assertTrue((boolean) previewResult.get('ok'), "Preview failed: ${previewResult.get('errors')}")
@@ -726,5 +917,20 @@ class AccountingMcpToolsTest {
             [account_number: '2440', debit: 0.00G, credit: amount]
         ]
     ]
+  }
+
+  private Path writeSimpleSie(Path filePath, int year, String accountNumber, String accountName) {
+    filePath.toFile().text = """#FLAGGA 0
+#PROGRAM "Test" "1.0"
+#FORMAT PC8
+#GEN ${year}0101 "tester"
+#SIETYP 4
+#FNAMN "Testbolaget AB"
+#ORGNR 556677-8899
+#RAR 0 ${year}0101 ${year}1231
+#KONTO ${accountNumber} "${accountName}"
+#IB 0 ${accountNumber} 100.00
+"""
+    filePath
   }
 }

--- a/app/src/test/groovy/integration/se/alipsa/accounting/mcp/AccountingMcpToolsTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/mcp/AccountingMcpToolsTest.groovy
@@ -662,10 +662,10 @@ class AccountingMcpToolsTest {
         file_path: (Object) sieFile.toString()
     ])
 
-    assertTrue((boolean) result.get('ok'), "Expected ok but got: ${result.get('errors') ?: result.get('blockingIssues')}")
-    assertEquals(false, result.get('fiscalYearExists'))
-    assertEquals('Testbolaget AB', result.get('companyNameInFile'))
-    assertEquals(1, result.get('accountCount'))
+    assertTrue((boolean) result.get('ok'), "Expected ok but got: ${result.get('errors') ?: result.get('blocking_issues')}")
+    assertEquals(false, result.get('fiscal_year_exists'))
+    assertEquals('Testbolaget AB', result.get('company_name_in_file'))
+    assertEquals(1, result.get('account_count'))
     assertNotNull(result.get('import_token'))
   }
 
@@ -681,7 +681,7 @@ class AccountingMcpToolsTest {
 
     assertFalse((boolean) result.get('ok'))
     assertNull(result.get('import_token'))
-    assertTrue(((List<String>) result.get('blockingIssues')).any { String issue -> issue.contains('innehåller redan') })
+    assertTrue(((List<String>) result.get('blocking_issues')).any { String issue -> issue.contains('innehåller redan') })
   }
 
   @Test
@@ -695,10 +695,10 @@ class AccountingMcpToolsTest {
         replace_existing: (Object) true
     ])
 
-    assertTrue((boolean) result.get('ok'), "Expected ok but got: ${result.get('blockingIssues')}")
-    Map purgeSummary = (Map) result.get('purgeSummary')
+    assertTrue((boolean) result.get('ok'), "Expected ok but got: ${result.get('blocking_issues')}")
+    Map purgeSummary = (Map) result.get('purge_summary')
     assertNotNull(purgeSummary)
-    assertTrue(((Number) purgeSummary.get('voucherCount')).intValue() > 0)
+    assertTrue(((Number) purgeSummary.get('voucher_count')).intValue() > 0)
     assertNotNull(result.get('import_token'))
   }
 
@@ -719,6 +719,7 @@ class AccountingMcpToolsTest {
     assertFalse((boolean) missing.get('ok'))
     assertTrue(((List<String>) missing.get('errors')).any { String error -> error.contains('import_token') })
     assertFalse((boolean) tampered.get('ok'))
+    assertTrue(((List<String>) tampered.get('errors')).any { String error -> error.contains('Ogiltig import_token') })
   }
 
   @Test
@@ -747,7 +748,7 @@ class AccountingMcpToolsTest {
 
     assertTrue((boolean) first.get('ok'), "Expected ok but got: ${first.get('errors')}")
     assertNotNull(first.get('fiscal_year_id'))
-    assertTrue((boolean) duplicatePreview.get('isDuplicate'))
+    assertTrue((boolean) duplicatePreview.get('is_duplicate'))
     assertTrue((boolean) second.get('ok'), "Expected duplicate ok but got: ${second.get('errors')}")
     assertTrue((boolean) second.get('duplicate'))
   }
@@ -799,7 +800,7 @@ class AccountingMcpToolsTest {
     assertTrue((boolean) defaultExport.get('ok'), "Default export failed: ${defaultExport.get('errors')}")
     Path defaultPath = Path.of((String) defaultExport.get('file_path'))
     assertTrue(Files.exists(defaultPath))
-    assertTrue(defaultPath.fileName.toString() ==~ /AlipsaAccounting-2026-\d{12}\.sie/)
+    assertTrue(defaultPath.fileName.toString() ==~ /AlipsaAccounting-.+-\d{12}\.sie/)
     assertTrue((boolean) explicitExport.get('ok'), "Explicit export failed: ${explicitExport.get('errors')}")
     assertFalse((boolean) blocked.get('ok'))
     assertTrue((boolean) blocked.get('file_exists'))

--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,6 +1,6 @@
 # Privacy Policy
 
-Effective date: 2026-04-19
+Effective date: 2026-04-26
 
 This privacy policy describes how Alipsa Accounting handles information when you use the desktop application and related project resources.
 
@@ -46,6 +46,16 @@ Users can disable automatic update checks in the application's Settings tab and 
 If the user chooses to download and install an update, the application downloads the release archive and checksum files from GitHub-hosted release assets.
 
 Only the files required for the selected update are downloaded.
+
+### MCP server mode
+
+The application can be started with `--mode=mcp` to function as a local Model Context Protocol (MCP) server. In this mode the application reads from and writes to its standard input and output streams; no network socket is opened by the application itself.
+
+When running as an MCP server, accounting data — including company information, fiscal years, accounts, vouchers, balances, VAT reports, and SIE file contents — is passed over the local stdio channel to the calling process (typically an LLM assistant tool such as Claude Code). That tool runs locally and may, as part of its normal operation, send the data to an external LLM provider API over the network.
+
+Alipsa Accounting does not control what the LLM client does with the data it receives. Users who enable MCP server mode should review the privacy policy of the LLM assistant tool they use.
+
+The automatic update check, update download, and browser actions described above are not triggered in MCP mode.
 
 ### User-initiated browser actions
 

--- a/skill/accounting-mcp.md
+++ b/skill/accounting-mcp.md
@@ -27,6 +27,8 @@ Always read before you write. Gather context first, propose actions, then post o
 | `get_vat_report` | Calculated VAT report for a period; returns `report_hash` |
 | `preview_voucher` | Validate a proposed voucher without posting it; returns `preview_token` only when valid |
 | `preview_year_end` | Year-end pre-checks: blocking issues, warnings, net result; returns `preview_token` only when ready |
+| `preview_sie_import` | Preview a SIE4 import; returns `import_token` only when importable |
+| `list_import_jobs` | Recent SIE import history |
 
 ### Write tools
 
@@ -38,6 +40,8 @@ Only call write tools after the user explicitly confirms the proposed action.
 | `create_correction_voucher` | Reverse a posted voucher; direct edit/delete is not exposed |
 | `book_vat_transfer` | Book the VAT settlement voucher using `report_hash` from `get_vat_report` |
 | `close_fiscal_year` | Close the fiscal year using a token from `preview_year_end` |
+| `import_sie` | Import a SIE4 file using a token from `preview_sie_import` |
+| `export_sie` | Export a fiscal year as SIE4; no token, but overwrite needs confirmation |
 
 ## Workflow: Voucher Entry
 
@@ -84,6 +88,37 @@ Only call write tools after the user explicitly confirms the proposed action.
 5. If `ready_to_close` is true, ask the user to confirm closing the year.
 6. Only call `close_fiscal_year` after confirmation, passing the returned `preview_token`.
 
+## Workflow: SIE Import
+
+1. Preview the file.
+   Call `preview_sie_import`. If `ok` is false, explain `blockingIssues` and do not call `import_sie`.
+
+2. Handle duplicates and warnings.
+   If `isDuplicate` is true, show `duplicateJobId` and stop ordinary import. Forward all `warnings` to the user before import.
+
+3. Summarize the import.
+   Show `companyNameInFile`, fiscal-year period, account count, voucher count, line count, and whether the fiscal year already exists.
+
+4. Confirm replacements explicitly.
+   If `replace_existing` is true and `fiscalYearExists` is true, show `purgeSummary` in plain language: vouchers, attachments, report archives, opening balances, VAT periods, and audit-log rows affected. Only proceed after explicit confirmation.
+
+5. Import after confirmation.
+   Call `import_sie` with unchanged `file_path`, `replace_existing`, and `import_token`. Show the resulting job id, fiscal year, counts, duplicate status, and warnings.
+
+## Workflow: SIE Export
+
+1. Identify the fiscal year.
+   Call `list_fiscal_years` if the `fiscal_year_id` is unknown.
+
+2. Export.
+   Call `export_sie` without `output_path` for the default timestamped export path, or with a user-specified path.
+
+3. Handle existing files.
+   If `export_sie` returns `ok: false` and `file_exists: true`, show `existing_file_path` and ask whether to overwrite. Only call `export_sie` again with `overwrite: true` after explicit confirmation.
+
+4. Show the result.
+   Show output path, file size, checksum, and exported counts.
+
 ## Domain Reference
 
 ### Fiscal years
@@ -115,3 +150,5 @@ VAT periods are derived from accounting periods and the company's VAT periodicit
 - Never suggest direct modification or deletion of posted vouchers.
 - Never make legal statements about tax liability. Describe bookkeeping consequences only.
 - Always use the company's `default_currency` when quoting amounts.
+- Never call `import_sie` with `replace_existing: true` before showing `purgeSummary` and receiving explicit confirmation.
+- Never call `export_sie` with `overwrite: true` before asking the user to confirm overwriting the existing file.

--- a/skill/accounting-mcp.md
+++ b/skill/accounting-mcp.md
@@ -91,16 +91,16 @@ Only call write tools after the user explicitly confirms the proposed action.
 ## Workflow: SIE Import
 
 1. Preview the file.
-   Call `preview_sie_import`. If `ok` is false, explain `blockingIssues` and do not call `import_sie`.
+   Call `preview_sie_import`. If `ok` is false, explain `blocking_issues` and do not call `import_sie`.
 
 2. Handle duplicates and warnings.
-   If `isDuplicate` is true, show `duplicateJobId` and stop ordinary import. Forward all `warnings` to the user before import.
+   If `is_duplicate` is true, show `duplicate_job_id` and stop ordinary import. Forward all `warnings` to the user before import.
 
 3. Summarize the import.
-   Show `companyNameInFile`, fiscal-year period, account count, voucher count, line count, and whether the fiscal year already exists.
+   Show `company_name_in_file`, fiscal-year period, `account_count`, `voucher_count`, `line_count`, and whether the fiscal year already exists.
 
 4. Confirm replacements explicitly.
-   If `replace_existing` is true and `fiscalYearExists` is true, show `purgeSummary` in plain language: vouchers, attachments, report archives, opening balances, VAT periods, and audit-log rows affected. Only proceed after explicit confirmation.
+   If `replace_existing` is true and `fiscal_year_exists` is true, show `purge_summary` in plain language: vouchers, attachments, report archives, opening balances, VAT periods, and audit-log rows affected. Only proceed after explicit confirmation.
 
 5. Import after confirmation.
    Call `import_sie` with unchanged `file_path`, `replace_existing`, and `import_token`. Show the resulting job id, fiscal year, counts, duplicate status, and warnings.
@@ -150,5 +150,5 @@ VAT periods are derived from accounting periods and the company's VAT periodicit
 - Never suggest direct modification or deletion of posted vouchers.
 - Never make legal statements about tax liability. Describe bookkeeping consequences only.
 - Always use the company's `default_currency` when quoting amounts.
-- Never call `import_sie` with `replace_existing: true` before showing `purgeSummary` and receiving explicit confirmation.
+- Never call `import_sie` with `replace_existing: true` before showing `purge_summary` and receiving explicit confirmation.
 - Never call `export_sie` with `overwrite: true` before asking the user to confirm overwriting the existing file.


### PR DESCRIPTION
 preview_sie_import, import_sie, export_sie, list_import_jobs.

  - Added SIE import preview model, token validation, duplicate detection, blocking issue reporting, replacement purge preview, and replacement drift protection.
  - Added default SIE export directory/path handling with timestamped filenames and overwrite protection.
  - Updated skill/accounting-mcp.md with SIE import/export workflows and the missing correction voucher workflow.
  - Added integration coverage for preview/import/export/job listing flows.
  - Fixed the mapper visibility issue using @PackageScope static, not public Groovy default visibility.
  - Update the privacy-policy to cover mcp mode.