### PR TITLE
Uppdatera kontolistan vid filterändring i kontoplan

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Följande funktioner ingår inte i v1.1.x:
 - Fakturering och lön
 - Bankintegration
 - Årsredovisningsflöden
-- Anläggningsregister (planerat till v1.2.0)
-- Förbättrad kraschsäker bilagehantering (planerat till v1.2.0)
+- Anläggningsregister (planerat till v1.3.0)
+- Förbättrad kraschsäker bilagehantering (planerat till v1.3.0)
 
 ## Förutsättningar
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'se.alipsa'
-version = '1.1.0'
+version = '1.1.1-SNAPSHOT'
 
 repositories {
   mavenLocal()

--- a/app/src/main/groovy/se/alipsa/accounting/ui/ChartOfAccountsPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/ChartOfAccountsPanel.groovy
@@ -163,12 +163,14 @@ final class ChartOfAccountsPanel extends JPanel implements PropertyChangeListene
     fieldConstraints.gridx = 3
     classLabel = new JLabel(I18n.instance.getString('chartOfAccountsPanel.label.class'))
     filterPanel.add(classLabel, labelConstraints)
+    classFilter.addActionListener { reloadAccounts() }
     filterPanel.add(classFilter, fieldConstraints)
 
     labelConstraints.gridx = 4
     fieldConstraints.gridx = 5
     filterLabel = new JLabel(I18n.instance.getString('chartOfAccountsPanel.label.filter'))
     filterPanel.add(filterLabel, labelConstraints)
+    activeOnlyCheckBox.addItemListener { reloadAccounts() }
     filterPanel.add(activeOnlyCheckBox, fieldConstraints)
 
     filterPanel

--- a/release.md
+++ b/release.md
@@ -1,5 +1,7 @@
 # Alipsa Accounting, Release History
 
+## v1.2.0, In progress
+
 ## v1.1.0, 2026-04-26
 ### Minor Release
 

--- a/req/roadmap.md
+++ b/req/roadmap.md
@@ -17,6 +17,34 @@ Följande punkter är medvetet uppskjutna från `v1.0.0` för att hålla första
 - Alternativt: skriv metadata först som `PENDING`, färdigställ filflytt atomiskt och markera sedan raden som aktiv i samma arbetsflöde.
 - Lägg till en reparations- eller städscan som kan hitta filer i bilagearkivet utan motsvarande rad i databasen.
 
+### Arkivering och radering av företag och räkenskapsår
+
+Svensk bokföringslag förbjuder radering av bokföringsdata under sju år. Efter sju år ställer
+GDPR:s lagringsminimeringsprincip krav på att data faktiskt kan raderas.
+
+Kravet kan sammanfattas i tre steg:
+
+1. **Arkivering** — ett företag kan arkiveras oavsett ålder. Arkiverade företag visas inte i
+   normala vyer men all data behålls intakt. Arkiveringen är reversibel.
+2. **Radering av räkenskapsår** — ett enskilt räkenskapsår (med alla dess verifikationer,
+   bilagor, balanser, momsperioder, rapportarkiv och revisionsloggar) kan raderas permanent
+   när räkenskapsårets slutdatum är äldre än sju år. `RetentionPolicyService` kontrollerar
+   villkoret innan radering tillåts.
+3. **Radering av företag** — ett företag kan raderas permanent när alla dess räkenskapsår
+   har raderats. Företag med kvarvarande räkenskapsår kan inte raderas.
+
+### Förslag på angreppssätt
+
+- Börja med arkiveringsflaggan (`archived boolean not null default false`) på `company`-tabellen
+  och filtrera bort arkiverade företag i `CompanyService.listCompanies()`.
+- Implementera radering av räkenskapsår som en separat operation med en explicit
+  sju-års-kontroll och en bekräftelsedialog som listar vad som kommer att tas bort
+  (antal verifikationer, bilagor, osv.) innan data rörs.
+- Radering av räkenskapsår kräver hantering av `audit_log`-rader med FK till `attachment`
+  och `voucher` (båda `ON DELETE RESTRICT`). Överväg att nolla ut dessa FK-kolumner
+  (`ON DELETE SET NULL` i en migration) eller att radera i rätt ordning: audit-loggar →
+  bilagor → verifikationsrader → verifikationer → räkenskapsår.
+
 ### Anläggningsregister
 
 - Utred om applikationen ska kompletteras med ett enkelt anläggningsregister för företag som behöver hålla ordning på materiella och immateriella anläggningstillgångar.

--- a/req/v1.2.0-attachment-management.md
+++ b/req/v1.2.0-attachment-management.md
@@ -1,0 +1,288 @@
+# v1.2.0 — Förbättrad kraschsäker bilagehantering
+
+## Bakgrund och problem
+
+`AttachmentService.addAttachment()` kopierar filen till disk **innan** databastransaktionen öppnas.
+Om JVM eller OS kraschar i fönstret mellan filkopiering (rad 56) och att transaktionen committats (rad 64–94)
+hamnar en fil i bilagearkivet utan någon motsvarande rad i databasen — en s.k. orphan-fil.
+Denna fil hittas inte av integritetschecken (som jämför checksummor mot DB-rader) och kan aldrig rensas bort automatiskt.
+
+Det omvända problemet finns i `deleteAttachment()`: databastransaktionen körs (rad 177) **innan** filen tas
+bort från disk (rad 182). Om JVM kraschar mellan dessa steg försvinner DB-raden men filen finns kvar —
+återigen en orphan.
+
+Dessutom är befintlig `deleteAttachment()` redan bruten för vanliga bilagor med revisionshistorik:
+`audit_log.attachment_id` har `ON DELETE RESTRICT` (V5__audit_and_attachments.sql), vilket innebär att H2
+blockerar DELETE av en `attachment`-rad som refereras av en audit-logg-rad. Eftersom `addAttachment()`
+alltid skriver en `ATTACHMENT_ADDED`-loggpost för varje bilaga kommer ett DELETE-försök att kasta ett
+FK-constraint-fel för alla bilagor med revisionshistorik.
+
+---
+
+## Mål
+
+1. `addAttachment()` kan inte lämna kvar oåtkomliga filer på disk vid JVM- eller OS-krasch.
+2. `deleteAttachment()` bryter inte mot FK-begränsningen och kan inte lämna kvar orphan-filer vid krasch.
+3. En startup-scan identifierar och reparerar avbrutna operationer automatiskt i alla startlägen (GUI, MCP).
+4. En städscan rapporterar filer i bilagearkivet utan motsvarande DB-rad som förväntas ha fil.
+5. Befintlig funktionalitet (lista, läsa, verifiera) förblir opåverkad för externa anropare.
+
+---
+
+## Lösningsdesign
+
+### Ny statuskolumn i `attachment`
+
+```
+status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE'
+```
+
+Tillåtna värden:
+
+| Status           | Betydelse                                                |
+|------------------|----------------------------------------------------------|
+| `PENDING`        | DB-rad insertad, filen håller på att kopieras            |
+| `ACTIVE`         | Filen finns på disk och stämmer — normal aktiv bilaga    |
+| `PENDING_DELETE` | Markerats för borttagning, filen håller på att raderas   |
+| `DELETED`        | Filen borttagen; raden behålls för att bevara FK till audit_log |
+| `FAILED`         | Avbruten operation som inte gick att återställa          |
+
+**`DELETED` i stället för DELETE:** Eftersom `audit_log.attachment_id` har `ON DELETE RESTRICT`
+kan `attachment`-rader med revisionshistorik aldrig tas bort. `deleteAttachment()` sätter därför
+slutstatus `DELETED` och lämnar raden kvar. Audit-loggens referens behåller sin integritet.
+
+### Nytt flöde för `addAttachment`
+
+```
+1. Validera källfil
+2. Beräkna checksum från källfilen
+3. Bygg storage_path och resolva målsökväg
+4. Skapa målkatalog
+5. Transaktions-INSERT: status = PENDING (ny)
+6. try {
+     Files.copy källfil → målsökväg
+     Verifiera checksum på kopierad fil
+     if (checksummen stämmer inte) {
+       tryDeleteQuietly(målsökväg)            // best-effort; kastar inte
+       Transaktions-UPDATE: status = FAILED
+       kasta IllegalStateException
+     }
+   } catch (IOException) {
+     tryDeleteQuietly(målsökväg)             // best-effort städning av partiell kopia
+     Transaktions-UPDATE: status = FAILED    // körs oavsett om städningen lyckades
+     kasta exception
+   }
+7. Transaktions-UPDATE: status = ACTIVE, skriv audit-logg i samma transaktion
+```
+
+Jämfört med nuläget kopieras filen aldrig till disk innan PENDING-raden har committats.
+Det befintliga catch-blocket som raderar filen vid transaktionsfel tas bort.
+
+**IO-fel och checksummafel — best-effort cleanup:** `tryDeleteQuietly` sväljer undantag från
+`Files.deleteIfExists` (t.ex. om OS håller filen låst) och sätter alltid status till FAILED
+oavsett om filrensningen lyckades. En FAILED-rad vars fil inte gick att ta bort syns i
+orphan-detektionen som en känd DB-sökväg (inte en orphan) och rapporteras som integritetsfel
+via `findIntegrityFailures`. Startup-scanen vid nästa start försöker då verifiera eller radera filen.
+
+### Nytt flöde för `deleteAttachment`
+
+```
+1. Hämta attachment — kräver status = ACTIVE (se nedan)
+2. Kontrollera retentionsregel
+3. Transaktions-UPDATE: status = PENDING_DELETE
+4. Files.deleteIfExists(målsökväg)
+5. Transaktions-UPDATE: status = DELETED
+```
+
+Ingen DELETE av DB-raden. FK-konflikten med `audit_log` uppstår aldrig.
+Om JVM kraschar mellan steg 3 och 5 finns en `PENDING_DELETE`-rad kvar.
+Startup-scanen avslutar operationen.
+
+### Beteende för publika read/find-metoder
+
+| Metod | Beteende för icke-ACTIVE status |
+|---|---|
+| `findAttachment(long)` | Returnerar raden oavsett status (behövs internt av startup-scan och verifyAttachment) |
+| `readAttachment(long)` | Anropar `requireActiveAttachment` — kastar `IllegalArgumentException` om status ≠ ACTIVE |
+| `deleteAttachment(long)` | Anropar `requireActiveAttachment` — kastar `IllegalArgumentException` om status ≠ ACTIVE |
+| `verifyAttachment(long)` | Anropar `requireAttachment` (status-neutral) — fungerar på ACTIVE och FAILED |
+| `resolveStoredPath(AttachmentMetadata)` | Oförändrad, tar redan hämtad metadata |
+
+Implementeras med två separata hjälpmetoder:
+- `requireAttachment(long)` — hämtar via `findAttachment`, kastar om raden saknas, inget statuskrav; används av `verifyAttachment`.
+- `requireActiveAttachment(long)` — hämtar via `findAttachment`, kastar om raden saknas **eller** om `status ≠ 'ACTIVE'`; används av `readAttachment` och `deleteAttachment`.
+
+Interna hjälpmetoder (t.ex. den statiska `findAttachment(Sql, long)`) och recovery-koden har inget statuskrav.
+
+### Startup-scan: `AttachmentService.recoverOnStartup()`
+
+Returnerar `AttachmentRecoveryReport`:
+
+```groovy
+@Canonical
+final class AttachmentRecoveryReport {
+  int activated      // PENDING → ACTIVE
+  int failed         // PENDING → FAILED (checksum-fel eller saknad fil)
+  int deletionsDone  // PENDING_DELETE → DELETED
+  List<Path> orphanFiles
+}
+```
+
+**Återskapa PENDING-rader (avbruten addAttachment):**
+- Filen finns och checksumman stämmer → UPDATE status = ACTIVE, skriv audit-logg med eventtyp `ATTACHMENT_RECOVERED` (ny eventtyp i `AuditLogService`), logga info
+- Filen finns men checksumman stämmer inte → tryDeleteQuietly(fil), UPDATE status = FAILED, logga varning
+- Filen saknas → UPDATE status = FAILED, logga varning
+
+`ATTACHMENT_RECOVERED`-audit-händelsen ersätter den `ATTACHMENT_ADDED`-post som inte hann skrivas vid kraschen. Utan den här händelsen skulle en återställd bilaga sakna all revisionshistorik, vilket är oacceptabelt. Eventtypen ska inkluderas i `AuditLogService`-konstanterna och läggas till i audit-logg-valideringen.
+
+**Avsluta PENDING_DELETE-rader (avbruten deleteAttachment):**
+- Filen finns → tryDeleteQuietly(fil), kontrollera om filen är borta; om borta UPDATE status = DELETED, annars behåll PENDING_DELETE och logga/rapportera varning
+- Filen saknas → UPDATE status = DELETED
+
+**Hitta orphan-filer:**
+Traversera `AppPaths.attachmentsDirectory()` rekursivt.
+Bygg upp mängden kända `storage_path`-värden från `attachment`-tabellen (alla status utom DELETED —
+DELETED-raders filer är avsiktligt borttagna och räknas inte som orphaner).
+Normalisera sökvägar för jämförelse: konvertera relativa `Path`-objekt till strängar med `/` som
+separator (`path.toString().replace('\\', '/')`) på både filsystemssidan och DB-sidan, för att
+undvika falska orphan-träffar på Windows. Returnera sökvägar utan att auto-radera.
+
+### Integration: var recovery anropas
+
+`recoverOnStartup()` anropas i `StartupVerificationService.verify()`, direkt i början av metoden,
+**innan** integritetskontroller körs. `StartupVerificationService` utökas med en `AttachmentService`-
+instans (redan implicit tillgänglig via `ReportIntegrityService`, men behöver en direkt referens).
+
+Recovery körs därmed i alla startlägen:
+- **MCP-läge:** `AlipsaAccounting.main()` → `new StartupVerificationService().verify()`
+- **GUI-läge:** `AlipsaAccounting.main()` → `new StartupVerificationService().verify()`
+- **`--verify-launch`:** `AlipsaAccounting.main()` → `new StartupVerificationService().verify()`
+
+Recovery-rapportens innehåll hanteras i `StartupVerificationService.verify()`:
+- `failed > 0` eller `deletionsDone > 0` läggs till som varningar i `StartupVerificationReport`
+  (format: `"Bilageåterställning: ${activated} aktiverade, ${failed} misslyckade, ${deletionsDone} borttagningar slutförda."`)
+- `orphanFiles` (om icke-tom) läggs till som en varning per fil eller sammanfattning i `warnings`
+- FAILED-rader rapporteras också av den befintliga `findAllIntegrityFailures()`-slingan, som nu
+  inkluderar `status IN ('ACTIVE', 'FAILED')`
+
+**Varningsloggning per startläge:**
+- **`--verify-launch`:** Befintlig kod loggar redan `startupReport.warnings` (rad 72–74 i `AlipsaAccounting`). Inga ändringar behövs.
+- **MCP-läge:** `failOnStartupErrors(startupReport)` kastar bara vid fel och loggar ingenting för varningar. Lägg till explicit varningsloggning i MCP-grenen i `AlipsaAccounting.main()` direkt efter `failOnStartupErrors(startupReport)`:
+  ```groovy
+  if (!startupReport.warnings.isEmpty()) {
+    log.warning("Startup warnings: ${startupReport.warnings.join(' | ')}")
+  }
+  ```
+- **GUI-läge:** `showStartupVerificationWarning(startupReport)` visar varningarna för användaren. Inga ändringar behövs.
+
+---
+
+## Implementationsuppgifter
+
+### Uppgift 1 — Migrationsskript och registrering
+
+Skapa `app/src/main/resources/db/migrations/V22__attachment_status.sql`:
+
+```sql
+alter table attachment
+    add column if not exists status varchar(20) not null default 'ACTIVE'
+        constraint ck_attachment_status
+            check (status in ('PENDING', 'ACTIVE', 'PENDING_DELETE', 'DELETED', 'FAILED'));
+
+create index if not exists idx_attachment_status on attachment(status);
+```
+
+Lägg till en ny rad i `DatabaseService.MIGRATIONS`-listan (ej Flyway; projektet kör egna migrationer):
+
+```groovy
+new MigrationDefinition(22, 'V22__attachment_status.sql', '/db/migrations/V22__attachment_status.sql'),
+```
+
+`expectedSchemaVersion()` returnerar `MIGRATIONS.last().version` och uppdateras automatiskt.
+
+### Uppgift 2 — `AttachmentMetadata`
+
+Lägg till fältet `String status` i `AttachmentMetadata`.
+Uppdatera alla `mapAttachment()`-anrop att läsa ut `status`-kolumnen.
+
+### Uppgift 3 — `addAttachment` omskrivning
+
+Implementera det nya PENDING-flödet. Ta bort det befintliga catch-blocket som raderar filen.
+Lägg till try/catch runt `Files.copy` och checksum-verifieringen som sätter FAILED och kastar vidare.
+
+### Uppgift 4 — `deleteAttachment` omskrivning
+
+Implementera PENDING_DELETE → DELETED-flödet. Ta bort `executeUpdate('delete from attachment ...')`.
+Lägg till `requireActiveAttachment(long)` som hämtar via `findAttachment`, kastar `IllegalArgumentException`
+om raden saknas eller om `status ≠ 'ACTIVE'`. Befintliga `requireAttachment(long)` förblir status-neutral
+och används av `verifyAttachment(long)` och recovery-koden.
+
+### Uppgift 5 — Filtrera list- och read-metoder
+
+Lägg till `and status = 'ACTIVE'` i SQL för:
+- `listAttachments(long voucherId)`
+- `listAllAttachments(long companyId)`
+- `listAllAttachments()`
+
+`readAttachment(long)` kastar `IllegalArgumentException` om det hämtade objektets status ≠ ACTIVE.
+
+### Uppgift 6 — `AttachmentRecoveryReport` och `recoverOnStartup()`
+
+Skapa `AttachmentRecoveryReport` (`@Canonical`, service-paketet).
+Implementera `recoverOnStartup()` i `AttachmentService` med logiken beskriven ovan.
+Path-normalisering för orphan-jämförelse: `storagePath.toString().replace('\\', '/')`.
+
+### Uppgift 7 — `findIntegrityFailures` inkluderar FAILED
+
+Uppdatera `findIntegrityFailures(long companyId)` och `findAllIntegrityFailures()` med två ändringar:
+
+1. **FAILED-rader rapporteras alltid**, oavsett om en överblivna fil råkar finnas kvar på disk med
+   matchande checksumma. Rapportera alla rader med `status = 'FAILED'` utan att kontrollera disken —
+   en FAILED-rad är per definition ett integritetsfel.
+2. **ACTIVE-rader** granskas som tidigare mot disk (checksumma och filstorlek).
+
+Implementering: kör två separata frågor och slå ihop resultaten, eller använd en enda fråga med
+`CASE`-logik. Enklast är:
+```groovy
+// Alla FAILED-rader direkt
+List<AttachmentMetadata> failed = sql.rows("... where status = 'FAILED' ...")
+// ACTIVE-rader som inte klarar diskverifiering
+List<AttachmentMetadata> brokenActive = activeRows.findAll { !verifyAttachment(it) }
+failed + brokenActive
+```
+
+### Uppgift 8 — `StartupVerificationService` anropar recovery
+
+Lägg till `AttachmentService`-beroende i `StartupVerificationService`.
+Anropa `attachmentService.recoverOnStartup()` i `verify()` innan befintliga kontroller.
+Bygg varningsmeddelanden från rapporten och inkludera orphan-filernas sökvägar i `warnings`.
+
+---
+
+## Tester
+
+Alla tester i `AttachmentServiceTest` (integrationstester).
+
+| Testfall | Vad som verifieras |
+|---|---|
+| Normalt flöde (anpassat) | PENDING-rad skapas, fil kopieras, rad aktiveras till ACTIVE, audit-logg skrivs |
+| IO-fel under kopiering | FAILED-status sätts omedelbart; inga PENDING-rader kvar; exception propageras |
+| Simulerad krasch vid add (PENDING-rad, fil OK) | `recoverOnStartup()` aktiverar → `activated = 1`; integritet OK |
+| Simulerad krasch vid add (PENDING-rad, fil saknas) | `recoverOnStartup()` sätter FAILED → `failed = 1`; `findIntegrityFailures` returnerar raden |
+| Simulerad krasch vid add (PENDING-rad, fil med fel checksum) | `recoverOnStartup()` raderar fil, sätter FAILED; `findIntegrityFailures` returnerar raden |
+| Normal borttagning | PENDING_DELETE → fil raderas → DELETED; `listAttachments` returnerar inte raden; audit-logg-FK intakt |
+| Simulerad krasch vid delete (PENDING_DELETE, fil finns) | `recoverOnStartup()` raderar fil, sätter DELETED → `deletionsDone = 1` |
+| Simulerad krasch vid delete (PENDING_DELETE, fil saknas) | `recoverOnStartup()` sätter DELETED → `deletionsDone = 1` |
+| Simulerad krasch vid delete (PENDING_DELETE, fil låst/kan inte raderas) | `recoverOnStartup()` behåller PENDING_DELETE, rapporterar varning och kastar inte |
+| Orphan-fil utan DB-rad | `recoverOnStartup()` returnerar den i `orphanFiles`; `findIntegrityFailures` opåverkad |
+| Windows-sökvägar (simulerat) | Orphan-jämförelse med `\`-separator ger inga falska träffar |
+| `readAttachment` på DELETED-rad | `IllegalArgumentException` kastas |
+| `deleteAttachment` på DELETED-rad | `IllegalArgumentException` kastas |
+
+---
+
+## Vad som inte ingår
+
+- Auto-radering av orphan-filer (kräver manuell åtgärd från användaren).
+- MCP-exponering av bilageoperationer (befintlig MCP-server exponerar inga bilageverktyg).
+- Fysisk rensning av DELETED-rader (kan läggas till som ett separat underhållskommando vid behov).

--- a/req/v1.3.0-attachment-management.md
+++ b/req/v1.3.0-attachment-management.md
@@ -1,4 +1,4 @@
-# v1.2.0 — Förbättrad kraschsäker bilagehantering
+# v1.3.0 — Förbättrad kraschsäker bilagehantering
 
 ## Bakgrund och problem
 


### PR DESCRIPTION
## Summary

- `activeOnlyCheckBox` had no listener — ticking it changed the checkbox state but did not reload the account list.
- `classFilter` had the same problem — selecting a class did not reload.

Fixed by adding `addItemListener { reloadAccounts() }` on the checkbox and `addActionListener { reloadAccounts() }` on the class combo box, matching how `searchField` already works.

Closes #44

## Test plan

- [ ] Tick/untick "Active Only" — list updates immediately
- [ ] Change class filter selection — list updates immediately
- [ ] Search field (Enter) still works
- [ ] Reset button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)