### PR TITLE
flytta redigera-företagsuppgifter-knapp till översiktsfliken

### DIFF
--- a/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
@@ -579,7 +579,7 @@ final class MainFrame implements PropertyChangeListener {
         backupService,
         startupVerificationService,
         activeCompanyManager,
-        { showCompanySettingsDialog() } as Runnable
+        { showEditCompanyDialog() } as Runnable
     )
     overviewPanel
   }
@@ -651,6 +651,7 @@ final class MainFrame implements PropertyChangeListener {
     CompanyDialog.showDialog(frame, companyService, active, { Company saved ->
       reloadCompanyComboBox()
       refreshTitle()
+      overviewPanel.reload()
     } as java.util.function.Consumer<Company>)
   }
 

--- a/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
@@ -147,7 +147,6 @@ final class MainFrame implements PropertyChangeListener {
   private final ActiveCompanyManager activeCompanyManager = new ActiveCompanyManager(companyService, fiscalYearService)
 
   private JLabel statusLabel
-  private JLabel companySummaryLabel
   private OverviewPanel overviewPanel
   private JLabel companyLabel
   private JComboBox<Company> companyComboBox
@@ -164,7 +163,6 @@ final class MainFrame implements PropertyChangeListener {
   private JMenuItem updateMenuItem
   private JMenuItem reportIssueMenuItem
   private JMenuItem aboutMenuItem
-  private JButton editCompanySettingsButton
   private JButton updateNotificationButton
   private JButton englishButton
   private JButton swedishButton
@@ -184,7 +182,6 @@ final class MainFrame implements PropertyChangeListener {
     activeCompanyManager.addPropertyChangeListener(this)
     frame = buildFrame()
     applyIcons()
-    refreshCompanySettingsSummary()
     refreshTitle()
     setStatus(I18n.instance.getString('mainFrame.status.started'))
   }
@@ -218,7 +215,6 @@ final class MainFrame implements PropertyChangeListener {
 
   private void onCompanyChanged() {
     refreshTitle()
-    refreshCompanySettingsSummary()
     reloadFiscalYearComboBox()
     Company active = activeCompanyManager.activeCompany
     if (active != null) {
@@ -240,7 +236,6 @@ final class MainFrame implements PropertyChangeListener {
     statusLabel.text = I18n.instance.getString('mainFrame.status.ready')
     applyMenuLocale()
     applyTabLocale()
-    editCompanySettingsButton.text = I18n.instance.getString('mainFrame.button.editCompanySettings')
     companyLabel.text = I18n.instance.getString('mainFrame.label.activeCompany')
     fiscalYearLabel.text = I18n.instance.getString('mainFrame.label.fiscalYear')
     languageLabel.text = I18n.instance.getString('companySettingsDialog.label.language')
@@ -253,7 +248,6 @@ final class MainFrame implements PropertyChangeListener {
     if (pendingUpdate != null) {
       updateNotificationButton.text = I18n.instance.format('mainFrame.button.updateVersion', pendingUpdate.availableVersion)
     }
-    refreshCompanySettingsSummary()
   }
 
   private void applyMenuLocale() {
@@ -345,19 +339,9 @@ final class MainFrame implements PropertyChangeListener {
     settingsRows.add(buildThemeRow())
     settingsRows.add(buildUpdateRow())
 
-    JPanel companyRow = new JPanel(new FlowLayout(FlowLayout.LEFT, 8, 0))
-    editCompanySettingsButton = new JButton(I18n.instance.getString('mainFrame.button.editCompanySettings'))
-    editCompanySettingsButton.addActionListener { showCompanySettingsDialog() }
-    companyRow.add(editCompanySettingsButton)
-
     topPanel.add(settingsRows, BorderLayout.NORTH)
-    topPanel.add(companyRow, BorderLayout.SOUTH)
 
     panel.add(topPanel, BorderLayout.NORTH)
-
-    companySummaryLabel = new JLabel('')
-    companySummaryLabel.verticalAlignment = SwingConstants.TOP
-    panel.add(companySummaryLabel, BorderLayout.CENTER)
 
     panel
   }
@@ -594,7 +578,8 @@ final class MainFrame implements PropertyChangeListener {
         accountingPeriodService,
         backupService,
         startupVerificationService,
-        activeCompanyManager
+        activeCompanyManager,
+        { showCompanySettingsDialog() } as Runnable
     )
     overviewPanel
   }
@@ -645,7 +630,6 @@ final class MainFrame implements PropertyChangeListener {
 
   private void showCompanySettingsDialog() {
     CompanySettingsDialog.showDialog(frame, companySettingsService, {
-      refreshCompanySettingsSummary()
       reloadCompanyComboBox()
       setStatus(I18n.instance.getString('mainFrame.status.companySaved'))
     } as Runnable)
@@ -667,7 +651,6 @@ final class MainFrame implements PropertyChangeListener {
     CompanyDialog.showDialog(frame, companyService, active, { Company saved ->
       reloadCompanyComboBox()
       refreshTitle()
-      refreshCompanySettingsSummary()
     } as java.util.function.Consumer<Company>)
   }
 
@@ -721,25 +704,6 @@ final class MainFrame implements PropertyChangeListener {
     updateThread.daemon = true
     updateThread.priority = Thread.MIN_PRIORITY
     updateThread.start()
-  }
-
-  private void refreshCompanySettingsSummary() {
-    if (companySummaryLabel == null) {
-      return
-    }
-    Company active = activeCompanyManager.activeCompany
-    if (active == null) {
-      companySummaryLabel.text = I18n.instance.getString('mainFrame.companySettings.noProfile')
-      return
-    }
-    companySummaryLabel.text = I18n.instance.format(
-        'mainFrame.companySettings.summary',
-        escapeHtml(active.companyName),
-        I18n.instance.getString('mainFrame.companySettings.orgNumber'), escapeHtml(active.organizationNumber),
-        I18n.instance.getString('mainFrame.companySettings.currency'), escapeHtml(active.defaultCurrency),
-        escapeHtml(active.localeTag),
-        I18n.instance.getString('mainFrame.companySettings.vatPeriod'), escapeHtml(active.vatPeriodicity?.displayName ?: I18n.instance.getString('vatPeriodicity.MONTHLY'))
-    )
   }
 
   private void applyIcons() {
@@ -797,10 +761,4 @@ final class MainFrame implements PropertyChangeListener {
     ]
   }
 
-  private static String escapeHtml(String text) {
-    text
-        .replace('&', '&amp;')
-        .replace('<', '&lt;')
-        .replace('>', '&gt;')
-  }
 }

--- a/app/src/main/groovy/se/alipsa/accounting/ui/OverviewPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/OverviewPanel.groovy
@@ -12,6 +12,7 @@ import se.alipsa.accounting.support.I18n
 
 import java.awt.BorderLayout
 import java.awt.Color
+import java.awt.FlowLayout
 import java.awt.Font
 import java.awt.GridBagConstraints
 import java.awt.GridBagLayout
@@ -25,6 +26,7 @@ import java.time.temporal.ChronoUnit
 import java.util.concurrent.ExecutionException
 
 import javax.swing.BorderFactory
+import javax.swing.JButton
 import javax.swing.JLabel
 import javax.swing.JPanel
 import javax.swing.JSeparator
@@ -48,6 +50,7 @@ final class OverviewPanel extends JPanel implements PropertyChangeListener {
   private final BackupService backupService
   private final StartupVerificationService startupVerificationService
   private final ActiveCompanyManager activeCompanyManager
+  private final Runnable editCompanySettingsAction
 
   private boolean integrityChecked = false
   private boolean integrityCheckStarted = false
@@ -56,7 +59,8 @@ final class OverviewPanel extends JPanel implements PropertyChangeListener {
   private int reloadRequestId = 0
   private OverviewSnapshot currentSnapshot = OverviewSnapshot.empty()
 
-  // Header strip labels
+  // Header strip labels and actions
+  private final JButton editCompanySettingsButton = new JButton()
   private final JLabel companyTitleLabel = new JLabel()
   private final JLabel companyNameLabel = new JLabel()
   private final JLabel orgNumberLabel = new JLabel()
@@ -85,13 +89,15 @@ final class OverviewPanel extends JPanel implements PropertyChangeListener {
       AccountingPeriodService accountingPeriodService,
       BackupService backupService,
       StartupVerificationService startupVerificationService,
-      ActiveCompanyManager activeCompanyManager
+      ActiveCompanyManager activeCompanyManager,
+      Runnable editCompanySettingsAction
   ) {
     this.voucherService = voucherService
     this.accountingPeriodService = accountingPeriodService
     this.backupService = backupService
     this.startupVerificationService = startupVerificationService
     this.activeCompanyManager = activeCompanyManager
+    this.editCompanySettingsAction = editCompanySettingsAction
     registerListeners()
     buildUi()
     applyLocale()
@@ -305,6 +311,7 @@ final class OverviewPanel extends JPanel implements PropertyChangeListener {
 
   private void applyLocale() {
     Locale locale = I18n.instance.locale
+    editCompanySettingsButton.text = I18n.instance.getString('mainFrame.button.editCompanySettings')
     companyTitleLabel.text = I18n.instance.getString('overviewPanel.header.company').toUpperCase(locale)
     fiscalYearTitleLabel.text = I18n.instance.getString('overviewPanel.header.fiscalYear').toUpperCase(locale)
     voucherCardTitle.text = I18n.instance.getString('overviewPanel.card.vouchers').toUpperCase(locale)
@@ -343,8 +350,18 @@ final class OverviewPanel extends JPanel implements PropertyChangeListener {
   private void buildUi() {
     setLayout(new BorderLayout(0, 12))
     setBorder(BorderFactory.createEmptyBorder(16, 16, 16, 16))
-    add(buildHeaderStrip(), BorderLayout.NORTH)
+    JPanel northPanel = new JPanel(new BorderLayout(0, 8))
+    northPanel.add(buildHeaderStrip(), BorderLayout.CENTER)
+    northPanel.add(buildActionBar(), BorderLayout.SOUTH)
+    add(northPanel, BorderLayout.NORTH)
     add(buildStatGrid(), BorderLayout.CENTER)
+  }
+
+  private JPanel buildActionBar() {
+    JPanel bar = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0))
+    editCompanySettingsButton.addActionListener { editCompanySettingsAction.run() }
+    bar.add(editCompanySettingsButton)
+    bar
   }
 
   private void styleHeaderLabels() {


### PR DESCRIPTION
## Sammanfattning

- Tar bort `editCompanySettingsButton` och `companySummaryLabel` från inställningsfliken — dessa hör logiskt hemma nära företagsinformationen, inte bland globala inställningar
- Lägger till knappen "Redigera företagsuppgifter" i `OverviewPanel`, direkt under header-stripen som redan visar företagsnamn och organisationsnummer
- Knappen kopplas via en `Runnable`-callback som MainFrame skickar in i konstruktorn — OverviewPanel behöver inte känna till `CompanySettingsDialog` direkt
- Inställningsfliken innehåller nu enbart globala inställningar: språk, tema och automatisk uppdateringskontroll

Stänger #43.

## Testplan

- [ ] Starta appen, verifiera att "Redigera företagsuppgifter"-knappen syns i Översikt-fliken under header-stripen
- [ ] Klicka knappen — kontrollera att `CompanySettingsDialog` öppnas och att ändringarna sparas korrekt
- [ ] Verifiera att Inställningar-fliken inte längre visar knappen eller företagssammanfattningen
- [ ] Byt språk — verifiera att knaptexten uppdateras korrekt
- [ ] `./gradlew build` — alla tester gröna

🤖 Generated with [Claude Code](https://claude.com/claude-code)