### PR TITLE
uppdatera företagslistan efter SIE-import till nytt företag

### DIFF
--- a/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
@@ -656,10 +656,16 @@ final class MainFrame implements PropertyChangeListener {
   }
 
   private void showSieExchangeDialog() {
-    SieExchangeDialog.showDialog(frame, sieImportExportService, fiscalYearService, companyService, activeCompanyManager.companyId, {
-      reloadFiscalYearComboBox()
-      activeCompanyManager.refreshFiscalYear()
-    } as Runnable)
+    long openedForCompanyId = activeCompanyManager.companyId
+    SieExchangeDialog.showDialog(frame, sieImportExportService, fiscalYearService, companyService, openedForCompanyId, { Long targetCompanyId ->
+      if (targetCompanyId != openedForCompanyId) {
+        reloadCompanyComboBox()
+        selectCompanyInComboBox(targetCompanyId)
+      } else {
+        reloadFiscalYearComboBox()
+        activeCompanyManager.refreshFiscalYear()
+      }
+    } as java.util.function.Consumer<Long>)
     setStatus(I18n.instance.getString('mainFrame.status.sieExchangeClosed'))
   }
 

--- a/app/src/main/groovy/se/alipsa/accounting/ui/SieExchangeDialog.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/SieExchangeDialog.groovy
@@ -23,6 +23,7 @@ import java.awt.Insets
 import java.nio.file.Path
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.ExecutionException
+import java.util.function.Consumer
 import java.util.logging.Logger
 
 import javax.swing.BorderFactory
@@ -56,7 +57,7 @@ final class SieExchangeDialog extends JDialog {
   private final FiscalYearService fiscalYearService
   private final CompanyService companyService
   private final long companyId
-  private final Runnable onImportSuccess
+  private final Consumer<Long> onImportSuccess
 
   private final JComboBox<FiscalYear> fiscalYearComboBox = new JComboBox<>()
   private final JTextArea summaryArea = new JTextArea(5, 50)
@@ -68,7 +69,7 @@ final class SieExchangeDialog extends JDialog {
   private final JButton exportButton = new JButton(I18n.instance.getString('sieExchangeDialog.button.export'))
   private boolean workInProgress
 
-  SieExchangeDialog(Frame owner, SieImportExportService sieImportExportService, FiscalYearService fiscalYearService, CompanyService companyService, long companyId, Runnable onImportSuccess = null) {
+  SieExchangeDialog(Frame owner, SieImportExportService sieImportExportService, FiscalYearService fiscalYearService, CompanyService companyService, long companyId, Consumer<Long> onImportSuccess = null) {
     super(owner, I18n.instance.getString('sieExchangeDialog.title'), true)
     this.sieImportExportService = sieImportExportService
     this.fiscalYearService = fiscalYearService
@@ -81,7 +82,7 @@ final class SieExchangeDialog extends JDialog {
     showInfo(I18n.instance.getString('sieExchangeDialog.status.initial'))
   }
 
-  static void showDialog(Frame owner, SieImportExportService sieImportExportService, FiscalYearService fiscalYearService, CompanyService companyService, long companyId, Runnable onImportSuccess = null) {
+  static void showDialog(Frame owner, SieImportExportService sieImportExportService, FiscalYearService fiscalYearService, CompanyService companyService, long companyId, Consumer<Long> onImportSuccess = null) {
     SieExchangeDialog dialog = new SieExchangeDialog(owner, sieImportExportService, fiscalYearService, companyService, companyId, onImportSuccess)
     dialog.visible = true
   }
@@ -332,11 +333,11 @@ final class SieExchangeDialog extends JDialog {
             reloadFiscalYears()
             reloadJobs()
             renderImportResult(result)
-            try {
-              onImportSuccess?.run()
-            } catch (Exception callbackEx) {
-              showError(I18n.instance.getString('sieExchangeDialog.status.refreshFailed'), callbackEx.message)
-            }
+          }
+          try {
+            onImportSuccess?.accept(targetCompanyId)
+          } catch (Exception callbackEx) {
+            showError(I18n.instance.getString('sieExchangeDialog.status.refreshFailed'), callbackEx.message)
           }
         } catch (InterruptedException exception) {
           Thread.currentThread().interrupt()


### PR DESCRIPTION
## Sammanfattning

Rapporterat i #41: efter SIE-import som skapar ett nytt företag syntes det nya företaget inte i dropdown-listan — appen behövde startas om.

Roten till felet var dubbel:

1. `onImportSuccess`-callbacken anropades aldrig när importen skapade ett nytt företag (`importingToNewCompany == true`). Callbacken låg enbart i `else`-grenen, dvs. den kördes bara vid import till *befintligt* företag.

2. Callbacken anropade ändå inte `reloadCompanyComboBox()`, så dropdown-listan uppdaterades aldrig.

### Ändringar

- `SieExchangeDialog`: `Runnable onImportSuccess` → `Consumer<Long>` — callbacken får nu ID:t för det importerade företaget. Callbacken anropas ovillkorligt efter lyckad import (både nytt och befintligt företag).
- `MainFrame.showSieExchangeDialog()`: vid nytt företag körs `reloadCompanyComboBox()` + `selectCompanyInComboBox(targetId)` — dropdown-listan uppdateras och det importerade företaget väljs automatiskt. Vid import till befintligt företag behålls existerande beteende (`reloadFiscalYearComboBox()` + `refreshFiscalYear()`).

Stänger #41.

## Testplan

- [ ] Importera en SIE-fil för ett företag som inte finns — välj "Skapa nytt företag" i mismatch-dialogen — verifiera att det nya företaget omedelbart visas och väljs i company-dropdown utan omstart
- [ ] Importera en SIE-fil för det aktiva företaget — verifiera att räkenskapsårslistan uppdateras som tidigare
- [ ] `./gradlew build` — alla tester gröna

🤖 Generated with [Claude Code](https://claude.com/claude-code)