### PR TITLE
[codex] Fixa uppdateraren för jpackage-installationer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ build
 /dist/
 .DS_Store
 /.gradle-user/
+/releases/
+/issues/

--- a/app/src/main/groovy/se/alipsa/accounting/service/UpdateService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/UpdateService.groovy
@@ -308,12 +308,13 @@ rm -f "\$0"
   private static String unixConfigUpdateCommand(Path installDir, String newMainJar, String newVersion) {
     String versionCommand = newVersion.isEmpty()
         ? ''
-        : "  sed -i \"s#^java-options=-Djpackage.app-version=.*#java-options=-Djpackage.app-version=${newVersion}#\" \"\$cfg\"\n"
+        : "  sed -i.bak \"s#^java-options=-Djpackage.app-version=.*#java-options=-Djpackage.app-version=${newVersion}#\" \"\$cfg\"\n"
     """\
 for cfg in "${installDir}/"*.cfg; do
   [ -f "\$cfg" ] || continue
-  sed -i "s#^app.classpath=\\\$APPDIR/app-.*\\.jar#app.classpath=\\\$APPDIR/${newMainJar}#" "\$cfg"
-${versionCommand}done
+  sed -i.bak "s#^app.classpath=\\\$APPDIR/app-.*\\.jar#app.classpath=\\\$APPDIR/${newMainJar}#" "\$cfg"
+${versionCommand}  rm -f "\$cfg.bak"
+done
 """.stripIndent()
   }
 
@@ -323,7 +324,7 @@ ${versionCommand}done
         ? ''
         : "  (Get-Content -LiteralPath \$cfg.FullName) -replace '^java-options=-Djpackage.app-version=.*', 'java-options=-Djpackage.app-version=${newVersion}' | Set-Content -LiteralPath \$cfg.FullName\n"
     """\
-powershell -NoProfile -ExecutionPolicy Bypass -Command "Get-ChildItem -LiteralPath '${escapedInstallDir}' -Filter '*.cfg' | ForEach-Object { \$cfg = \$_; (Get-Content -LiteralPath \$cfg.FullName) -replace '^app.classpath=\\\$APPDIR/app-.*\\.jar', 'app.classpath=\\\$APPDIR/${newMainJar}' | Set-Content -LiteralPath \$cfg.FullName; ${versionCommand.trim()} }"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "Get-ChildItem -LiteralPath '${escapedInstallDir}' -Filter '*.cfg' | ForEach-Object { \$cfg = \$_; (Get-Content -LiteralPath \$cfg.FullName) -replace '^app.classpath=\\\$APPDIR[/\\\\]app-.*\\.jar', 'app.classpath=\\\$APPDIR/${newMainJar}' | Set-Content -LiteralPath \$cfg.FullName; ${versionCommand.trim()} }"
 """.stripIndent()
   }
 

--- a/app/src/main/groovy/se/alipsa/accounting/service/UpdateService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/UpdateService.groovy
@@ -13,6 +13,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.security.MessageDigest
+import java.util.regex.Matcher
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 
@@ -186,14 +187,24 @@ final class UpdateService {
     if (jarDir == null) {
       return null
     }
-    String osName = System.getProperty('os.name', '').toLowerCase(Locale.ROOT)
+    launcherPath(jarDir, System.getProperty('os.name', '').toLowerCase(Locale.ROOT))
+  }
+
+  static Path launcherPath(Path jarDir, String osName) {
     if (osName.contains('win')) {
-      return jarDir.parent.resolve('AlipsaAccounting.exe')
+      return appImageRoot(jarDir).resolve('AlipsaAccounting.exe')
     }
     if (osName.contains('mac')) {
-      return jarDir.parent.resolve('MacOS').resolve('AlipsaAccounting')
+      return appImageRoot(jarDir).resolve('MacOS').resolve('AlipsaAccounting')
     }
-    jarDir.parent.resolve('bin').resolve('AlipsaAccounting')
+    appImageRoot(jarDir).resolve('bin').resolve('AlipsaAccounting')
+  }
+
+  static Path appImageRoot(Path jarDir) {
+    if (jarDir?.fileName?.toString() == 'app' && jarDir.parent?.fileName?.toString() == 'lib') {
+      return jarDir.parent.parent
+    }
+    jarDir.parent
   }
 
   private static Path stagingDirectory() {
@@ -220,6 +231,8 @@ final class UpdateService {
     Path launcher = launcherPath()
     String launcherCommand = launcher != null ? "\"${launcher}\"" : ''
     Path backupDir = installDir.resolve('.update-backup')
+    String newMainJar = mainJarFileName(extractedDir) ?: ''
+    String newVersion = versionFromMainJar(newMainJar) ?: ''
 
     Path script
     if (isWindows) {
@@ -239,6 +252,7 @@ if errorlevel 1 (
   pause
   exit /b 1
 )
+${newMainJar.isEmpty() ? '' : windowsConfigUpdateCommand(installDir, newMainJar, newVersion)}
 rd /s /q "${backupDir}"
 rd /s /q "${extractedDir}"
 del "${stagingDir}\\*.zip"
@@ -260,6 +274,7 @@ if ! cp "${extractedDir}/"*.jar "${installDir}/"; then
   echo "Update failed. Please try again."
   exit 1
 fi
+${newMainJar.isEmpty() ? '' : unixConfigUpdateCommand(installDir, newMainJar, newVersion)}
 rm -rf "${backupDir}"
 rm -rf "${extractedDir}"
 rm -f "${stagingDir}/"*.zip
@@ -269,6 +284,47 @@ rm -f "\$0"
       script.toFile().setExecutable(true)
     }
     script
+  }
+
+  private static String mainJarFileName(Path directory) {
+    if (!Files.isDirectory(directory)) {
+      return null
+    }
+    Files.list(directory).withCloseable { stream ->
+      stream
+          .map { Path path -> path.fileName.toString() }
+          .filter { String fileName -> fileName ==~ /app-\d+(\.\d+)*\.jar/ }
+          .sorted()
+          .findFirst()
+          .orElse(null)
+    }
+  }
+
+  private static String versionFromMainJar(String fileName) {
+    Matcher matcher = fileName =~ /^app-(.+)\.jar$/
+    matcher.matches() ? matcher.group(1) : null
+  }
+
+  private static String unixConfigUpdateCommand(Path installDir, String newMainJar, String newVersion) {
+    String versionCommand = newVersion.isEmpty()
+        ? ''
+        : "  sed -i \"s#^java-options=-Djpackage.app-version=.*#java-options=-Djpackage.app-version=${newVersion}#\" \"\$cfg\"\n"
+    """\
+for cfg in "${installDir}/"*.cfg; do
+  [ -f "\$cfg" ] || continue
+  sed -i "s#^app.classpath=\\\$APPDIR/app-.*\\.jar#app.classpath=\\\$APPDIR/${newMainJar}#" "\$cfg"
+${versionCommand}done
+""".stripIndent()
+  }
+
+  private static String windowsConfigUpdateCommand(Path installDir, String newMainJar, String newVersion) {
+    String escapedInstallDir = installDir.toString().replace('\\', '\\\\')
+    String versionCommand = newVersion.isEmpty()
+        ? ''
+        : "  (Get-Content -LiteralPath \$cfg.FullName) -replace '^java-options=-Djpackage.app-version=.*', 'java-options=-Djpackage.app-version=${newVersion}' | Set-Content -LiteralPath \$cfg.FullName\n"
+    """\
+powershell -NoProfile -ExecutionPolicy Bypass -Command "Get-ChildItem -LiteralPath '${escapedInstallDir}' -Filter '*.cfg' | ForEach-Object { \$cfg = \$_; (Get-Content -LiteralPath \$cfg.FullName) -replace '^app.classpath=\\\$APPDIR/app-.*\\.jar', 'app.classpath=\\\$APPDIR/${newMainJar}' | Set-Content -LiteralPath \$cfg.FullName; ${versionCommand.trim()} }"
+""".stripIndent()
   }
 
   private static void launchUpdaterAndExit(Path updaterScript) {

--- a/app/src/main/groovy/se/alipsa/accounting/ui/UpdateDialog.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/UpdateDialog.groovy
@@ -175,7 +175,7 @@ final class UpdateDialog extends JDialog {
         } catch (Exception exception) {
           log.log(Level.WARNING, 'Update apply failed.', exception)
           resetAfterError()
-          showError(I18n.instance.format('updateDialog.error.downloadFailed',
+          showError(I18n.instance.format('updateDialog.error.applyFailed',
               exception.message ?: exception.class.simpleName))
         }
       }

--- a/app/src/main/groovy/se/alipsa/accounting/ui/UpdateDialog.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/UpdateDialog.groovy
@@ -172,6 +172,11 @@ final class UpdateDialog extends JDialog {
           resetAfterError()
           showError(I18n.instance.format('updateDialog.error.downloadFailed',
               cause.message ?: cause.class.simpleName))
+        } catch (Exception exception) {
+          log.log(Level.WARNING, 'Update apply failed.', exception)
+          resetAfterError()
+          showError(I18n.instance.format('updateDialog.error.downloadFailed',
+              exception.message ?: exception.class.simpleName))
         }
       }
     }.execute()

--- a/app/src/main/resources/i18n/messages.properties
+++ b/app/src/main/resources/i18n/messages.properties
@@ -698,6 +698,7 @@ updateDialog.confirm.message=Version {0} will be downloaded and installed.\nThe 
 updateDialog.error.interrupted=Update check was interrupted.
 updateDialog.error.checkFailed=Could not check for updates: {0}
 updateDialog.error.downloadFailed=Download failed: {0}
+updateDialog.error.applyFailed=Could not install the update: {0}
 updateDialog.error.cannotDetectInstall=Cannot detect the installation directory. Please update manually.
 
 # VoucherPanel

--- a/app/src/main/resources/i18n/messages_sv.properties
+++ b/app/src/main/resources/i18n/messages_sv.properties
@@ -698,6 +698,7 @@ updateDialog.confirm.message=Version {0} kommer att laddas ner och installeras.\
 updateDialog.error.interrupted=Uppdateringskontrollen avbröts.
 updateDialog.error.checkFailed=Kunde inte söka efter uppdateringar: {0}
 updateDialog.error.downloadFailed=Nedladdningen misslyckades: {0}
+updateDialog.error.applyFailed=Kunde inte installera uppdateringen: {0}
 updateDialog.error.cannotDetectInstall=Kan inte avgöra installationskatalogen. Uppdatera manuellt.
 
 # VoucherPanel

--- a/app/src/test/groovy/unit/se/alipsa/accounting/service/UpdateServiceTest.groovy
+++ b/app/src/test/groovy/unit/se/alipsa/accounting/service/UpdateServiceTest.groovy
@@ -82,7 +82,7 @@ final class UpdateServiceTest {
   }
 
   @Test
-  void launcherPathUsesJpackageAppImageRootOnMacos() {
+  void launcherPathUsesMacosAppBundleContentsRoot() {
     assertEquals(
         Path.of('/Applications/AlipsaAccounting.app/Contents/MacOS/AlipsaAccounting'),
         UpdateService.launcherPath(Path.of('/Applications/AlipsaAccounting.app/Contents/app'), 'mac os x')

--- a/app/src/test/groovy/unit/se/alipsa/accounting/service/UpdateServiceTest.groovy
+++ b/app/src/test/groovy/unit/se/alipsa/accounting/service/UpdateServiceTest.groovy
@@ -8,6 +8,8 @@ import org.junit.jupiter.params.provider.CsvSource
 
 import se.alipsa.accounting.service.UpdateService
 
+import java.nio.file.Path
+
 final class UpdateServiceTest {
 
   @ParameterizedTest
@@ -61,5 +63,29 @@ final class UpdateServiceTest {
   @Test
   void parseVersionTreatsNonNumericAsZero() {
     assertArrayEquals([1, 0, 0] as int[], UpdateService.parseVersion('1.beta.0'))
+  }
+
+  @Test
+  void launcherPathUsesJpackageAppImageRootOnLinux() {
+    assertEquals(
+        Path.of('/opt/AlipsaAccounting/bin/AlipsaAccounting'),
+        UpdateService.launcherPath(Path.of('/opt/AlipsaAccounting/lib/app'), 'linux')
+    )
+  }
+
+  @Test
+  void launcherPathUsesJpackageAppImageRootOnWindows() {
+    assertEquals(
+        Path.of('C:/Programs/AlipsaAccounting/AlipsaAccounting.exe'),
+        UpdateService.launcherPath(Path.of('C:/Programs/AlipsaAccounting/lib/app'), 'windows')
+    )
+  }
+
+  @Test
+  void launcherPathUsesJpackageAppImageRootOnMacos() {
+    assertEquals(
+        Path.of('/Applications/AlipsaAccounting.app/Contents/MacOS/AlipsaAccounting'),
+        UpdateService.launcherPath(Path.of('/Applications/AlipsaAccounting.app/Contents/app'), 'mac os x')
+    )
   }
 }


### PR DESCRIPTION
## Sammanfattning

- Rättar sökvägsberäkningen för launchern i jpackage app-images så Linux/Windows/macOS utgår från app-image-roten i stället för `lib/app`.
- Uppdaterar genererade updater-skript så `AlipsaAccounting.cfg` pekar på den nya `app-<version>.jar` och uppdaterar `java-options=-Djpackage.app-version=...`.
- Gör Unix-konfiguppdateringen kompatibel med både GNU sed och BSD sed via `sed -i.bak`, och tar bort backupfilen direkt efteråt.
- Gör Windows `.cfg`-regexen tolerant för både `/` och `\` efter `$APPDIR`.
- Gör uppdateringsdialogen återhämtningsbar om appliceringssteget kastar fel, med separat feltext för installationsfel.
- Lägger till enhetstester för launcher-sökvägar i jpackage-layouten.
- Ignorerar lokala `releases/` och `issues/`-kataloger.

## Bakgrund

Vid test av uppdatering från 1.1.0 till 1.2.0 laddades och extraherades uppdateringen, men installationen fastnade. Rotorsaken var att updater-skriptet startade om från `.../lib/bin/AlipsaAccounting` i stället för `.../bin/AlipsaAccounting`, och att jpackage-konfigurationen fortfarande pekade på `app-1.1.0.jar` efter att `app-1.2.0.jar` kopierats in.

## Validering

- `./gradlew spotlessApply test --tests 'unit.se.alipsa.accounting.service.UpdateServiceTest'`
- `./gradlew build`