### PR TITLE
Fixa att kontodropdown försvinner vid sista siffran (#54)

### DIFF
--- a/app/src/main/groovy/se/alipsa/accounting/ui/AccountLookupPopup.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/AccountLookupPopup.groovy
@@ -132,15 +132,17 @@ final class AccountLookupPopup {
       hide()
       return
     }
-    if (query.matches('[0-9]{4,}')) {
-      hide()
-      return
-    }
     try {
       currentResults = accountService.searchAccounts(companyId, query, null, true, false)
     } catch (Exception ex) {
       log.warning("Kontosökning misslyckades: ${ex.message}")
       hide()
+      return
+    }
+    if (currentResults.size() == 1
+        && currentResults[0].accountNumber.toString() == query) {
+      hide()
+      onSelect.accept(currentResults[0])
       return
     }
     listModel.clear()

--- a/app/src/main/groovy/se/alipsa/accounting/ui/AccountLookupPopup.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/AccountLookupPopup.groovy
@@ -36,7 +36,7 @@ final class AccountLookupPopup {
   private static final int DEBOUNCE_MILLIS = 200
   private static final int MAX_VISIBLE_ROWS = 10
 
-  private final AccountService accountService
+  private final AccountSearcher accountSearcher
   private final long companyId
   private final Consumer<Account> onSelect
   private final DefaultListModel<String> listModel = new DefaultListModel<>()
@@ -47,7 +47,13 @@ final class AccountLookupPopup {
   private JWindow popupWindow
 
   AccountLookupPopup(AccountService accountService, long companyId, Consumer<Account> onSelect) {
-    this.accountService = accountService
+    this({ long lookupCompanyId, String query, String classFilter, boolean activeOnly, boolean manualReviewOnly ->
+      accountService.searchAccounts(lookupCompanyId, query, classFilter, activeOnly, manualReviewOnly)
+    } as AccountSearcher, companyId, onSelect)
+  }
+
+  AccountLookupPopup(AccountSearcher accountSearcher, long companyId, Consumer<Account> onSelect) {
+    this.accountSearcher = accountSearcher
     this.companyId = companyId
     this.onSelect = onSelect
     resultList.selectionMode = ListSelectionModel.SINGLE_SELECTION
@@ -133,7 +139,7 @@ final class AccountLookupPopup {
       return
     }
     try {
-      currentResults = accountService.searchAccounts(companyId, query, null, true, false)
+      currentResults = accountSearcher.searchAccounts(companyId, query, null, true, false)
     } catch (Exception ex) {
       log.warning("Kontosökning misslyckades: ${ex.message}")
       hide()
@@ -142,6 +148,7 @@ final class AccountLookupPopup {
     if (currentResults.size() == 1
         && currentResults[0].accountNumber.toString() == query) {
       hide()
+      listModel.clear()
       onSelect.accept(currentResults[0])
       return
     }
@@ -191,6 +198,10 @@ final class AccountLookupPopup {
       hide()
       onSelect.accept(selected)
     }
+  }
+
+  static interface AccountSearcher {
+    List<Account> searchAccounts(long companyId, String query, String classFilter, boolean activeOnly, boolean manualReviewOnly)
   }
 
 }

--- a/app/src/test/groovy/unit/se/alipsa/accounting/ui/AccountLookupPopupTest.groovy
+++ b/app/src/test/groovy/unit/se/alipsa/accounting/ui/AccountLookupPopupTest.groovy
@@ -19,26 +19,7 @@ final class AccountLookupPopupTest {
   void autoSelectsSingleExactAccountMatchAndClearsStaleResults() {
     Account account = new Account(null, 7L, '1510', 'Kassa', 'ASSET', 'DEBIT', null, true, false, null, null)
     List<Account> selectedAccounts = []
-    int callCount = 0
-    long capturedCompanyId = 0L
-    String capturedQuery = null
-    String capturedClassFilter = 'unused'
-    boolean capturedActiveOnly = false
-    boolean capturedManualReviewOnly = true
-    AccountLookupPopup popup = new AccountLookupPopup(
-        { long companyId, String query, String classFilter, boolean activeOnly, boolean manualReviewOnly ->
-          callCount++
-          capturedCompanyId = companyId
-          capturedQuery = query
-          capturedClassFilter = classFilter
-          capturedActiveOnly = activeOnly
-          capturedManualReviewOnly = manualReviewOnly
-          [account]
-        } as AccountLookupPopup.AccountSearcher,
-        7L,
-        { Account selected -> selectedAccounts << selected } as Consumer<Account>
-        )
-    popup.attachToEditor(new JTextField('1510'))
+    AccountLookupPopup popup = createPopup('1510', [account], selectedAccounts)
 
     DefaultListModel<String> listModel = fieldValue(popup, 'listModel') as DefaultListModel<String>
     listModel.addElement('stale result')
@@ -47,12 +28,33 @@ final class AccountLookupPopupTest {
 
     assertEquals([account], selectedAccounts)
     assertEquals(0, listModel.size())
-    assertEquals(1, callCount)
-    assertEquals(7L, capturedCompanyId)
-    assertEquals('1510', capturedQuery)
-    assertEquals(null, capturedClassFilter)
-    assertEquals(true, capturedActiveOnly)
-    assertEquals(false, capturedManualReviewOnly)
+  }
+
+  @Test
+  void keepsSinglePartialAccountMatchInResultList() {
+    Account account = new Account(null, 7L, '1510', 'Kassa', 'ASSET', 'DEBIT', null, true, false, null, null)
+    List<Account> selectedAccounts = []
+    AccountLookupPopup popup = createPopup('151', [account], selectedAccounts)
+
+    invokeSearch(popup)
+
+    DefaultListModel<String> listModel = fieldValue(popup, 'listModel') as DefaultListModel<String>
+    assertEquals([], selectedAccounts)
+    assertEquals(1, listModel.size())
+  }
+
+  @Test
+  void keepsMultipleAccountMatchesInResultList() {
+    Account account = new Account(null, 7L, '1510', 'Kassa', 'ASSET', 'DEBIT', null, true, false, null, null)
+    Account otherAccount = new Account(null, 7L, '1511', 'Bank', 'ASSET', 'DEBIT', null, true, false, null, null)
+    List<Account> selectedAccounts = []
+    AccountLookupPopup popup = createPopup('1510', [account, otherAccount], selectedAccounts)
+
+    invokeSearch(popup)
+
+    DefaultListModel<String> listModel = fieldValue(popup, 'listModel') as DefaultListModel<String>
+    assertEquals([], selectedAccounts)
+    assertEquals(2, listModel.size())
   }
 
   private static void invokeSearch(AccountLookupPopup popup) {
@@ -65,5 +67,16 @@ final class AccountLookupPopupTest {
     Field field = AccountLookupPopup.getDeclaredField(fieldName)
     field.accessible = true
     field.get(popup)
+  }
+
+  private static AccountLookupPopup createPopup(String query, List<Account> results, List<Account> selectedAccounts) {
+    AccountLookupPopup popup = new AccountLookupPopup(
+        { long companyId, String searchQuery, String classFilter, boolean activeOnly, boolean manualReviewOnly -> results }
+            as AccountLookupPopup.AccountSearcher,
+        7L,
+        { Account selected -> selectedAccounts << selected } as Consumer<Account>
+        )
+    popup.attachToEditor(new JTextField(query))
+    popup
   }
 }

--- a/app/src/test/groovy/unit/se/alipsa/accounting/ui/AccountLookupPopupTest.groovy
+++ b/app/src/test/groovy/unit/se/alipsa/accounting/ui/AccountLookupPopupTest.groovy
@@ -1,0 +1,69 @@
+package se.alipsa.accounting.ui
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+
+import org.junit.jupiter.api.Test
+
+import se.alipsa.accounting.domain.Account
+
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+import java.util.function.Consumer
+
+import javax.swing.DefaultListModel
+import javax.swing.JTextField
+
+final class AccountLookupPopupTest {
+
+  @Test
+  void autoSelectsSingleExactAccountMatchAndClearsStaleResults() {
+    Account account = new Account(null, 7L, '1510', 'Kassa', 'ASSET', 'DEBIT', null, true, false, null, null)
+    List<Account> selectedAccounts = []
+    int callCount = 0
+    long capturedCompanyId = 0L
+    String capturedQuery = null
+    String capturedClassFilter = 'unused'
+    boolean capturedActiveOnly = false
+    boolean capturedManualReviewOnly = true
+    AccountLookupPopup popup = new AccountLookupPopup(
+        { long companyId, String query, String classFilter, boolean activeOnly, boolean manualReviewOnly ->
+          callCount++
+          capturedCompanyId = companyId
+          capturedQuery = query
+          capturedClassFilter = classFilter
+          capturedActiveOnly = activeOnly
+          capturedManualReviewOnly = manualReviewOnly
+          [account]
+        } as AccountLookupPopup.AccountSearcher,
+        7L,
+        { Account selected -> selectedAccounts << selected } as Consumer<Account>
+        )
+    popup.attachToEditor(new JTextField('1510'))
+
+    DefaultListModel<String> listModel = fieldValue(popup, 'listModel') as DefaultListModel<String>
+    listModel.addElement('stale result')
+
+    invokeSearch(popup)
+
+    assertEquals([account], selectedAccounts)
+    assertEquals(0, listModel.size())
+    assertEquals(1, callCount)
+    assertEquals(7L, capturedCompanyId)
+    assertEquals('1510', capturedQuery)
+    assertEquals(null, capturedClassFilter)
+    assertEquals(true, capturedActiveOnly)
+    assertEquals(false, capturedManualReviewOnly)
+  }
+
+  private static void invokeSearch(AccountLookupPopup popup) {
+    Method searchMethod = AccountLookupPopup.getDeclaredMethod('search')
+    searchMethod.accessible = true
+    searchMethod.invoke(popup)
+  }
+
+  private static Object fieldValue(AccountLookupPopup popup, String fieldName) {
+    Field field = AccountLookupPopup.getDeclaredField(fieldName)
+    field.accessible = true
+    field.get(popup)
+  }
+}


### PR DESCRIPTION
## Summary
- Tar bort den tidiga stängningen av kontodropdown vid 4+ siffror som orsakade att listan försvann innan användaren hann välja konto
- Lägger till auto-val: om exakt ett sökresultat matchar frågan, väljs det automatiskt och listan stängs

Fixes #54

## Test plan
- [x] `./gradlew build` passerar
- [x] Unit test: `AccountLookupPopupTest` täcker auto-val vid exakt matchning och rensar stale listdata
- [ ] Manuell verifiering: skriv kontonummer i verifikateditor, bekräfta att dropdown stannar kvar och auto-väljer vid exakt matchning