### PR TITLE
fixa SIE4-import: hantera #BTRANS och #RTRANS-rader (#60)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'se.alipsa'
-version = '1.2.1'
+version = '1.3.0-SNAPSHOT'
 
 repositories {
   mavenLocal()

--- a/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
@@ -768,6 +768,7 @@ final class SieImportExportService {
       )
     }
     if (lines.isEmpty()) {
+      // No valid #TRANS rows — signal caller to skip this voucher (distinct from the < 2 check below which is an error).
       return []
     }
     if (lines.size() < 2) {

--- a/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
@@ -89,6 +89,8 @@ final class SieImportExportService {
     Path safePath = validateImportPath(filePath)
     SieDocumentReader reader = new SieDocumentReader()
     reader.throwErrors = false
+    reader.ignoreBTRANS = true
+    reader.ignoreRTRANS = true
     SieDocument document = reader.readDocument(safePath.toString())
     List<String> errors = reader.validationExceptions*.message.findAll() as List<String>
     if (document == null) {
@@ -105,11 +107,9 @@ final class SieImportExportService {
     ParsedSie parsed = parseDocument(safePath)
     SieDocument document = parsed.document
     SieBookingYear bookingYear = selectPrimaryBookingYear(document)
-    int voucherCount = document.getVER()?.size() ?: 0
-    int lineCount = 0
-    (document.getVER() ?: []).each { SieVoucher voucher ->
-      lineCount += voucher.rows?.count { SieVoucherRow row -> scale(row.amount) != BigDecimal.ZERO } ?: 0
-    }
+    int[] counts = countImportableVouchers(document)
+    int voucherCount = counts[0]
+    int lineCount = counts[1]
 
     databaseService.withSql { Sql sql ->
       FiscalYear existingYear = findFiscalYearByPeriod(sql, companyId, bookingYear.start, bookingYear.end)
@@ -141,6 +141,22 @@ final class SieImportExportService {
           duplicate?.id
       )
     }
+  }
+
+  private static int[] countImportableVouchers(SieDocument document) {
+    List<SieVoucher> vouchers = document.getVER() ?: []
+    int voucherCount = 0
+    int lineCount = 0
+    for (SieVoucher voucher : vouchers) {
+      int rows = (voucher.rows?.count { SieVoucherRow row ->
+        row.token == SIE.TRANS && scale(row.amount) != BigDecimal.ZERO
+      } ?: 0) as int
+      if (rows > 0) {
+        voucherCount++
+        lineCount += rows
+      }
+    }
+    [voucherCount, lineCount] as int[]
   }
 
   SieImportResult importFile(long companyId, Path filePath) {
@@ -374,6 +390,8 @@ final class SieImportExportService {
     SieDocumentReader reader = new SieDocumentReader()
     reader.throwErrors = false
     reader.acceptSIETypes = EnumSet.of(SieType.TYPE_4)
+    reader.ignoreBTRANS = true
+    reader.ignoreRTRANS = true
     SieDocument document = reader.readDocument(filePath.toString())
 
     List<String> errors = []
@@ -684,6 +702,11 @@ final class SieImportExportService {
     int lineCount = 0
     for (SieVoucher voucher : sortedVouchers) {
       List<VoucherLine> lines = buildVoucherLines(voucher)
+      if (lines.isEmpty()) {
+        // Voucher has no valid #TRANS rows (e.g. fully deleted via #BTRANS).
+        // Per SIE 4B spec these represent deleted vouchers and are skipped.
+        continue
+      }
       voucherService.createVoucher(
           sql,
           fiscalYearId,
@@ -743,6 +766,9 @@ final class SieImportExportService {
           debitAmount,
           creditAmount
       )
+    }
+    if (lines.isEmpty()) {
+      return []
     }
     if (lines.size() < 2) {
       throw new IllegalArgumentException("Verifikationen ${voucher.series ?: 'A'}-${voucher.number ?: '?'} saknar tillräckliga transaktionsrader.")

--- a/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/SieImportExportService.groovy
@@ -724,7 +724,7 @@ final class SieImportExportService {
     }
     List<VoucherLine> lines = []
     int lineIndex = 1
-    voucher.rows.each { SieVoucherRow row ->
+    voucher.rows.findAll { it.token == SIE.TRANS }.each { SieVoucherRow row ->
       BigDecimal amount = scale(row.amount)
       if (amount == BigDecimal.ZERO) {
         return

--- a/app/src/test/groovy/integration/se/alipsa/accounting/service/SieImportExportServiceTest.groovy
+++ b/app/src/test/groovy/integration/se/alipsa/accounting/service/SieImportExportServiceTest.groovy
@@ -858,6 +858,62 @@ class SieImportExportServiceTest {
     ]
   }
 
+  @Test
+  void importSkipsVouchersWithOnlyBtransOrRtransRows() {
+    switchHome(tempDir.resolve('btrans-rtrans-db'))
+    DatabaseService databaseService = DatabaseService.newForTesting()
+    databaseService.initialize()
+    CompanyService companyService = new CompanyService(databaseService)
+    companyService.save(new Company(
+        CompanyService.LEGACY_COMPANY_ID, 'Testbolaget AB', '556677-8899', 'SEK', 'sv-SE',
+        VatPeriodicity.MONTHLY, true, null, null
+    ))
+    SieImportExportService service = createSieService(databaseService)
+
+    Path sieFile = tempDir.resolve('btrans-rtrans.sie')
+    sieFile.toFile().text = """\
+#FLAGGA 0
+#PROGRAM "Test" "1.0"
+#FORMAT PC8
+#GEN 20260101 "tester"
+#SIETYP 4
+#FNAMN "Testbolaget AB"
+#ORGNR 556677-8899
+#RAR 0 20260101 20261231
+#KONTO 1510 "Kundfordringar"
+#KONTO 1930 "Bank"
+#KONTO 3010 "Intakt"
+#VER A 1 20260115 "Normal"
+{
+  #TRANS 1510 {} 1000.00
+  #TRANS 3010 {} -1000.00
+}
+#VER A 2 20260120 "Borttagen"
+{
+  #BTRANS 1930 {} 500.00
+  #BTRANS 3010 {} -500.00
+}
+#VER A 3 20260125 "Struken"
+{
+  #RTRANS 1510 {} 200.00
+  #RTRANS 3010 {} -200.00
+}
+#VER A 4 20260130 "Blandad"
+{
+  #TRANS 1930 {} 750.00
+  #BTRANS 1930 {} -100.00
+  #RTRANS 1930 {} -50.00
+  #TRANS 3010 {} -750.00
+}
+"""
+
+    SieImportResult result = service.importFile(CompanyService.LEGACY_COMPANY_ID, sieFile)
+
+    assertEquals(ImportJobStatus.SUCCESS, result.job.status)
+    assertEquals(2, result.voucherCount)
+    assertEquals(4, result.lineCount)
+  }
+
   private Path writeSimpleSie(Path filePath, String accountNumber, String accountName) {
     filePath.toFile().text = """#FLAGGA 0
 #PROGRAM "Test" "1.0"

--- a/app/src/test/groovy/unit/se/alipsa/accounting/service/SieVoucherImportTest.groovy
+++ b/app/src/test/groovy/unit/se/alipsa/accounting/service/SieVoucherImportTest.groovy
@@ -1,7 +1,6 @@
 package unit.se.alipsa.accounting.service
 
 import static org.junit.jupiter.api.Assertions.assertEquals
-import static org.junit.jupiter.api.Assertions.assertThrows
 
 import alipsa.sieparser.SIE
 import alipsa.sieparser.SieAccount
@@ -49,7 +48,7 @@ final class SieVoucherImportTest {
   }
 
   @Test
-  void buildVoucherLinesRejectsVoucherWithOnlyBtransRows() {
+  void buildVoucherLinesReturnsNullForVoucherWithOnlyBtransRows() {
     SieVoucher voucher = new SieVoucher()
     voucher.series = 'A'
     voucher.number = '2'
@@ -61,10 +60,23 @@ final class SieVoucherImportTest {
         btransRow('3010', 1000.00)
     ]
 
-    IllegalArgumentException ex = assertThrows(IllegalArgumentException) {
-      buildVoucherLines(voucher)
-    }
-    assertEquals('Verifikationen A-2 saknar tillräckliga transaktionsrader.', ex.message)
+    assertEquals([], buildVoucherLines(voucher))
+  }
+
+  @Test
+  void buildVoucherLinesReturnsNullForVoucherWithOnlyRtransRows() {
+    SieVoucher voucher = new SieVoucher()
+    voucher.series = 'A'
+    voucher.number = '3'
+    voucher.voucherDate = java.time.LocalDate.of(2026, 1, 15)
+    voucher.text = 'Rättat'
+
+    voucher.rows = [
+        rtransRow('1930', -1000.00),
+        rtransRow('3010', 1000.00)
+    ]
+
+    assertEquals([], buildVoucherLines(voucher))
   }
 
   private static SieVoucherRow transRow(String accountNumber, BigDecimal amount) {

--- a/app/src/test/groovy/unit/se/alipsa/accounting/service/SieVoucherImportTest.groovy
+++ b/app/src/test/groovy/unit/se/alipsa/accounting/service/SieVoucherImportTest.groovy
@@ -48,7 +48,7 @@ final class SieVoucherImportTest {
   }
 
   @Test
-  void buildVoucherLinesReturnsNullForVoucherWithOnlyBtransRows() {
+  void buildVoucherLinesReturnsEmptyListForVoucherWithOnlyBtransRows() {
     SieVoucher voucher = new SieVoucher()
     voucher.series = 'A'
     voucher.number = '2'
@@ -64,7 +64,7 @@ final class SieVoucherImportTest {
   }
 
   @Test
-  void buildVoucherLinesReturnsNullForVoucherWithOnlyRtransRows() {
+  void buildVoucherLinesReturnsEmptyListForVoucherWithOnlyRtransRows() {
     SieVoucher voucher = new SieVoucher()
     voucher.series = 'A'
     voucher.number = '3'

--- a/app/src/test/groovy/unit/se/alipsa/accounting/service/SieVoucherImportTest.groovy
+++ b/app/src/test/groovy/unit/se/alipsa/accounting/service/SieVoucherImportTest.groovy
@@ -1,0 +1,99 @@
+package unit.se.alipsa.accounting.service
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertThrows
+
+import alipsa.sieparser.SIE
+import alipsa.sieparser.SieAccount
+import alipsa.sieparser.SieVoucher
+import alipsa.sieparser.SieVoucherRow
+import org.junit.jupiter.api.Test
+
+import se.alipsa.accounting.domain.VoucherLine
+import se.alipsa.accounting.service.SieImportExportService
+
+final class SieVoucherImportTest {
+
+  private static List<VoucherLine> buildVoucherLines(SieVoucher voucher) {
+    SieImportExportService.metaClass.invokeStaticMethod(
+        SieImportExportService,
+        'buildVoucherLines',
+        [voucher] as Object[]
+    ) as List<VoucherLine>
+  }
+
+  @Test
+  void buildVoucherLinesIgnoresBtransAndRtransRows() {
+    SieVoucher voucher = new SieVoucher()
+    voucher.series = 'A'
+    voucher.number = '1'
+    voucher.voucherDate = java.time.LocalDate.of(2026, 1, 15)
+    voucher.text = 'Testverifikat'
+
+    voucher.rows = [
+        transRow('1930', -1000.00),
+        btransRow('1930', -500.00),
+        rtransRow('1930', -200.00),
+        transRow('3010', 1000.00)
+    ]
+
+    List<VoucherLine> lines = buildVoucherLines(voucher)
+
+    assertEquals(2, lines.size())
+    assertEquals('1930', lines[0].accountNumber)
+    assertEquals(0.00G, lines[0].debitAmount)
+    assertEquals(1000.00G, lines[0].creditAmount)
+    assertEquals('3010', lines[1].accountNumber)
+    assertEquals(1000.00G, lines[1].debitAmount)
+    assertEquals(0.00G, lines[1].creditAmount)
+  }
+
+  @Test
+  void buildVoucherLinesRejectsVoucherWithOnlyBtransRows() {
+    SieVoucher voucher = new SieVoucher()
+    voucher.series = 'A'
+    voucher.number = '2'
+    voucher.voucherDate = java.time.LocalDate.of(2026, 1, 15)
+    voucher.text = 'Borttaget'
+
+    voucher.rows = [
+        btransRow('1930', -1000.00),
+        btransRow('3010', 1000.00)
+    ]
+
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException) {
+      buildVoucherLines(voucher)
+    }
+    assertEquals('Verifikationen A-2 saknar tillräckliga transaktionsrader.', ex.message)
+  }
+
+  private static SieVoucherRow transRow(String accountNumber, BigDecimal amount) {
+    SieVoucherRow row = new SieVoucherRow()
+    row.account = account(accountNumber)
+    row.amount = amount
+    row.token = SIE.TRANS
+    row
+  }
+
+  private static SieVoucherRow btransRow(String accountNumber, BigDecimal amount) {
+    SieVoucherRow row = new SieVoucherRow()
+    row.account = account(accountNumber)
+    row.amount = amount
+    row.token = SIE.BTRANS
+    row
+  }
+
+  private static SieVoucherRow rtransRow(String accountNumber, BigDecimal amount) {
+    SieVoucherRow row = new SieVoucherRow()
+    row.account = account(accountNumber)
+    row.amount = amount
+    row.token = SIE.RTRANS
+    row
+  }
+
+  private static SieAccount account(String number) {
+    SieAccount acc = new SieAccount()
+    acc.number = number
+    acc
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-groovy = "5.0.5"
+groovy = "5.0.6"
 h2 = "2.4.240"
 sie-parser = "2.1.0"
 poi = "5.5.1"
@@ -7,7 +7,7 @@ journo = "0.7.3"
 flatlaf = "3.7.1"
 swing-widgets = "1.1.0"
 junit = "6.0.3"
-groovier-junit = "0.3.1"
+groovier-junit = "0.3.2"
 
 [libraries]
 groovy-core = { module = "org.apache.groovy:groovy", version.ref = "groovy" }

--- a/release.md
+++ b/release.md
@@ -1,5 +1,7 @@
 # Alipsa Accounting, Release History
 
+## v1.3.0, In progress
+
 ## v1.2.1, 2026-05-03
 ### Patch Release
 


### PR DESCRIPTION
Filtrerar bort #BTRANS och #RTRANS-rader vid SIE4-import enligt SIE 4B-specifikationen.

- Sätter <code>SieDocumentReader.ignoreBTRANS</code> och <code>ignoreRTRANS</code> för att låta parsern hantera filtreringen nativt.
- Hoppar över verifikat som enbart innehåller #BTRANS/#RTRANS-rader (borttagna verifikat).
- Lade till enhetstester som verifierar filtreringen.

Fixes #60