### PR TITLE
Auto-rensa statusfältet efter 5 sekunder

### DIFF
--- a/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
@@ -151,6 +151,7 @@ final class MainFrame implements PropertyChangeListener {
   private final ActiveCompanyManager activeCompanyManager = new ActiveCompanyManager(companyService, fiscalYearService)
 
   private JLabel statusLabel
+  private Timer statusTimer
   private OverviewPanel overviewPanel
   private JLabel companyLabel
   private JComboBox<Company> companyComboBox
@@ -207,6 +208,14 @@ final class MainFrame implements PropertyChangeListener {
 
   void setStatus(String text) {
     statusLabel.text = text
+    if (statusTimer == null) {
+      statusTimer = new Timer(5000, {
+        statusLabel.text = I18n.instance.getString('mainFrame.status.ready')
+      })
+      statusTimer.repeats = false
+    }
+    statusTimer.stop()
+    statusTimer.start()
   }
 
   @Override


### PR DESCRIPTION
Fixar #56: lägger till en timer som återställer statusfältet till 'Redo' efter 5 sekunder, så att meddelanden som 'Bytte till {företag}' inte blir liggande på obestämd tid.