### PR TITLE
Aktivera tangentbordsinmatning i DatePicker och uppdatera swing-widgets

### DIFF
--- a/app/src/main/groovy/se/alipsa/accounting/ui/FiscalYearPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/FiscalYearPanel.groovy
@@ -349,7 +349,6 @@ final class FiscalYearPanel extends JPanel implements PropertyChangeListener {
   private static DatePicker createDatePicker() {
     DatePicker picker = new DatePicker(null, null, null, I18n.instance.locale, 'yyyy-MM-dd')
     picker.textFieldPosition = TextFieldPosition.RIGHT
-    picker.textField.editable = false
     picker
   }
 

--- a/app/src/main/groovy/se/alipsa/accounting/ui/ReportPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/ReportPanel.groovy
@@ -654,7 +654,6 @@ final class ReportPanel extends JPanel implements PropertyChangeListener {
   private static DatePicker createDatePicker() {
     DatePicker picker = new DatePicker(null, null, null, I18n.instance.locale, 'yyyy-MM-dd')
     picker.textFieldPosition = TextFieldPosition.RIGHT
-    picker.textField.editable = false
     picker
   }
 

--- a/app/src/main/groovy/se/alipsa/accounting/ui/VoucherPanel.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/VoucherPanel.groovy
@@ -16,6 +16,7 @@ import se.alipsa.accounting.service.VoucherService
 import se.alipsa.accounting.support.AmountFormatter
 import se.alipsa.accounting.support.I18n
 import se.alipsa.datepicker.DatePicker
+import se.alipsa.datepicker.TextFieldPosition
 
 import java.awt.BorderLayout
 import java.awt.Color
@@ -904,7 +905,7 @@ final class VoucherPanel extends JPanel implements PropertyChangeListener {
 
   private static DatePicker createDatePicker() {
     DatePicker picker = new DatePicker(null, null, null, I18n.instance.locale)
-    picker.textField.editable = false
+    picker.textFieldPosition = TextFieldPosition.RIGHT
     picker
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ sie-parser = "2.1.0"
 poi = "5.5.1"
 journo = "0.7.3"
 flatlaf = "3.7.1"
-swing-widgets = "1.1.0"
+swing-widgets = "1.1.1"
 junit = "6.0.3"
 groovier-junit = "0.3.2"
 


### PR DESCRIPTION
Fixar #57

- Uppdaterar swing-widgets från 1.1.0 till 1.1.1 (innehåller fix för editable-buggen i MaskedDateField)
- Tar bort explicit editable = false på DatePicker i ReportPanel, VoucherPanel och FiscalYearPanel
- Detta gör att användaren kan mata in datum direkt med tangentbordet (intuitivt skriva, markera, sudda, etc.) istället för att enbart kunna använda kalendern