### PR TITLE
[codex] kom ihåg senaste företaget

### DIFF
--- a/app/src/main/groovy/se/alipsa/accounting/service/UserPreferencesService.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/service/UserPreferencesService.groovy
@@ -12,6 +12,7 @@ final class UserPreferencesService {
   private static final String LANGUAGE_KEY = 'ui.language'
   private static final String THEME_KEY = 'ui.theme'
   private static final String UPDATE_CHECK_ENABLED_KEY = 'update.autoCheckEnabled'
+  private static final String LAST_ACTIVE_COMPANY_ID_KEY = 'company.lastActiveId'
 
   private final Preferences preferences = Preferences.userNodeForPackage(UserPreferencesService)
 
@@ -47,5 +48,18 @@ final class UserPreferencesService {
     } else {
       preferences.putBoolean(UPDATE_CHECK_ENABLED_KEY, false)
     }
+  }
+
+  Long getLastActiveCompanyId() {
+    long companyId = preferences.getLong(LAST_ACTIVE_COMPANY_ID_KEY, 0L)
+    companyId > 0L ? companyId : null
+  }
+
+  void setLastActiveCompanyId(Long companyId) {
+    if (companyId == null || companyId <= 0L) {
+      preferences.remove(LAST_ACTIVE_COMPANY_ID_KEY)
+      return
+    }
+    preferences.putLong(LAST_ACTIVE_COMPANY_ID_KEY, companyId)
   }
 }

--- a/app/src/main/groovy/se/alipsa/accounting/ui/ActiveCompanyManager.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/ActiveCompanyManager.groovy
@@ -27,11 +27,15 @@ final class ActiveCompanyManager {
   private FiscalYear fiscalYear
 
   ActiveCompanyManager(CompanyService companyService, FiscalYearService fiscalYearService) {
+    this(companyService, fiscalYearService, null)
+  }
+
+  ActiveCompanyManager(CompanyService companyService, FiscalYearService fiscalYearService, Long preferredCompanyId) {
     this.companyService = companyService
     this.fiscalYearService = fiscalYearService
     try {
       List<Company> companies = companyService.listCompanies(true) ?: []
-      this.companyId = companies.isEmpty() ? 0L : companies.first().id
+      this.companyId = resolveInitialCompanyId(companies, preferredCompanyId)
       if (this.companyId > 0) {
         List<FiscalYear> years = fiscalYearService.listFiscalYears(this.companyId)
         this.fiscalYear = years.isEmpty() ? null : years.first()
@@ -39,6 +43,14 @@ final class ActiveCompanyManager {
     } catch (Exception ignored) {
       this.companyId = 0L
     }
+  }
+
+  private static long resolveInitialCompanyId(List<Company> companies, Long preferredCompanyId) {
+    if (companies.isEmpty()) {
+      return 0L
+    }
+    Company preferred = companies.find { Company company -> company.id == preferredCompanyId }
+    preferred?.id ?: companies.first().id
   }
 
   long getCompanyId() {

--- a/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
@@ -148,7 +148,11 @@ final class MainFrame implements PropertyChangeListener {
       DatabaseService.instance
   )
   private final FiscalYearDeletionService fiscalYearDeletionService = new FiscalYearDeletionService(DatabaseService.instance)
-  private final ActiveCompanyManager activeCompanyManager = new ActiveCompanyManager(companyService, fiscalYearService)
+  private final ActiveCompanyManager activeCompanyManager = new ActiveCompanyManager(
+      companyService,
+      fiscalYearService,
+      userPreferencesService.lastActiveCompanyId
+  )
 
   private JLabel statusLabel
   private Timer statusTimer
@@ -234,6 +238,7 @@ final class MainFrame implements PropertyChangeListener {
     reloadFiscalYearComboBox()
     Company active = activeCompanyManager.activeCompany
     if (active != null) {
+      userPreferencesService.setLastActiveCompanyId(active.id)
       setStatus(I18n.instance.format('mainFrame.status.companySwitched', active.companyName))
     }
   }
@@ -510,11 +515,10 @@ final class MainFrame implements PropertyChangeListener {
     try {
       companyComboBox.removeAllItems()
       companies.each { Company c -> companyComboBox.addItem(c) }
-      if (selected != null) {
-        Company match = companies.find { Company c -> c.id == selected.id }
-        if (match != null) {
-          companyComboBox.selectedItem = match
-        }
+      Long selectedCompanyId = selected?.id ?: activeCompanyManager.companyId
+      Company match = companies.find { Company c -> c.id == selectedCompanyId }
+      if (match != null) {
+        companyComboBox.selectedItem = match
       } else if (!companies.isEmpty()) {
         companyComboBox.selectedIndex = 0
       }

--- a/app/src/test/groovy/unit/se/alipsa/accounting/service/UserPreferencesThemeTest.groovy
+++ b/app/src/test/groovy/unit/se/alipsa/accounting/service/UserPreferencesThemeTest.groovy
@@ -16,6 +16,7 @@ class UserPreferencesThemeTest {
   void cleanup() {
     service.setTheme(null)
     service.setAutomaticUpdateCheckEnabled(true)
+    service.setLastActiveCompanyId(null)
   }
 
   @Test
@@ -53,5 +54,14 @@ class UserPreferencesThemeTest {
 
     service.setAutomaticUpdateCheckEnabled(true)
     assertEquals(true, service.isAutomaticUpdateCheckEnabled())
+  }
+
+  @Test
+  void roundTripsLastActiveCompanyPreference() {
+    service.setLastActiveCompanyId(17L)
+    assertEquals(17L, service.getLastActiveCompanyId())
+
+    service.setLastActiveCompanyId(null)
+    assertEquals(null, service.getLastActiveCompanyId())
   }
 }

--- a/app/src/test/groovy/unit/se/alipsa/accounting/ui/ActiveCompanyManagerTest.groovy
+++ b/app/src/test/groovy/unit/se/alipsa/accounting/ui/ActiveCompanyManagerTest.groovy
@@ -60,6 +60,24 @@ class ActiveCompanyManagerTest {
   }
 
   @Test
+  void initializesToPreferredCompanyWhenItExists() {
+    Company second = companyService.save(new Company(
+        null, 'Zetterberg AB', '556000-0002', 'SEK', 'sv-SE', VatPeriodicity.MONTHLY, true, null, null
+    ))
+
+    ActiveCompanyManager manager = new ActiveCompanyManager(companyService, fiscalYearService, second.id)
+
+    assertEquals(second.id, manager.companyId)
+  }
+
+  @Test
+  void fallsBackToFirstCompanyWhenPreferredCompanyDoesNotExist() {
+    ActiveCompanyManager manager = new ActiveCompanyManager(companyService, fiscalYearService, 999_999L)
+
+    assertEquals(CompanyService.LEGACY_COMPANY_ID, manager.companyId)
+  }
+
+  @Test
   void firesPropertyChangeEventOnCompanySwitch() {
     Company second = companyService.save(new Company(
         null, 'Zetterberg AB', '556000-0002', 'SEK', 'sv-SE', VatPeriodicity.MONTHLY, true, null, null


### PR DESCRIPTION
## Summary

- Stores the last active company id in user preferences when the user switches company.
- Initializes the active company manager with the stored company id on startup.
- Keeps the status-bar company selector aligned with the active company and falls back to the first active company when the saved company is unavailable.
- Adds focused tests for preference round-tripping and startup selection fallback.

Fixes #59.

## Validation

- `./gradlew test --tests 'se.alipsa.accounting.ui.ActiveCompanyManagerTest' --tests 'unit.se.alipsa.accounting.service.UserPreferencesThemeTest'`
- `./gradlew spotlessApply`
- `./gradlew build`