### PR TITLE
fix: göm AccountLookupPopup när editor tappar fokus (#62)

### DIFF
--- a/app/src/main/groovy/se/alipsa/accounting/ui/AccountLookupPopup.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/AccountLookupPopup.groovy
@@ -7,6 +7,8 @@ import se.alipsa.accounting.support.I18n
 import java.awt.BorderLayout
 import java.awt.IllegalComponentStateException
 import java.awt.Point
+import java.awt.event.FocusAdapter
+import java.awt.event.FocusEvent
 import java.awt.event.KeyAdapter
 import java.awt.event.KeyEvent
 import java.awt.event.MouseAdapter
@@ -84,6 +86,12 @@ final class AccountLookupPopup {
       void removeUpdate(DocumentEvent event) { scheduleSearch() }
       @Override
       void changedUpdate(DocumentEvent event) { scheduleSearch() }
+    })
+    editor.addFocusListener(new FocusAdapter() {
+      @Override
+      void focusLost(FocusEvent event) {
+        hide()
+      }
     })
     editor.addKeyListener(new KeyAdapter() {
       @Override


### PR DESCRIPTION
**Problem**
När man tabbar sig vidare från en cell med kontosökningsdropdown (konto-nummer eller konto-beskrivning) så försvinner inte popup-fönstret, utan ligger kvar och hovrar över tabellen.

**Lösning**
Lade till en `FocusListener` i `AccountLookupPopup.attachToEditor()` som anropar `hide()` vid `focusLost`. Eftersom popup-fönstret (`JWindow`) är icke-fokuserbart och listkomponenten också har `focusable = false`, så triggar inte klick inuti popupen focusLost — endast när användaren tabbar vidare eller klickar utanför editorn.

**Validering**
- `./gradlew build` passerar.

Fixes #62