### PR TITLE
Synka Swing-lokal med språkval

### DIFF
--- a/app/src/main/groovy/se/alipsa/accounting/support/I18n.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/support/I18n.groovy
@@ -5,6 +5,8 @@ import java.beans.PropertyChangeSupport
 import java.text.MessageFormat
 import java.util.logging.Logger
 
+import javax.swing.JComponent
+
 /**
  * Manages locale and translatable string lookups with runtime switching support.
  */
@@ -54,8 +56,10 @@ final class I18n {
 
   void setLocale(Locale locale) {
     Locale oldLocale = currentLocale
+    ResourceBundle newBundle = loadBundle(locale)
+    JComponent.setDefaultLocale(locale)
     currentLocale = locale
-    bundle = loadBundle(locale)
+    bundle = newBundle
     changeSupport.firePropertyChange('locale', oldLocale, locale)
   }
 

--- a/app/src/test/groovy/unit/se/alipsa/accounting/domain/EnumDisplayNameTest.groovy
+++ b/app/src/test/groovy/unit/se/alipsa/accounting/domain/EnumDisplayNameTest.groovy
@@ -2,6 +2,7 @@ package unit.se.alipsa.accounting.domain
 
 import static org.junit.jupiter.api.Assertions.*
 
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -10,11 +11,21 @@ import se.alipsa.accounting.domain.VatPeriodicity
 import se.alipsa.accounting.domain.report.ReportType
 import se.alipsa.accounting.support.I18n
 
+import javax.swing.JComponent
+
 final class EnumDisplayNameTest {
+
+  private Locale previousComponentLocale
 
   @BeforeEach
   void setUp() {
+    previousComponentLocale = JComponent.defaultLocale
     I18n.instance.setLocale(Locale.ENGLISH)
+  }
+
+  @AfterEach
+  void tearDown() {
+    JComponent.setDefaultLocale(previousComponentLocale)
   }
 
   @Test

--- a/app/src/test/groovy/unit/se/alipsa/accounting/support/I18nTest.groovy
+++ b/app/src/test/groovy/unit/se/alipsa/accounting/support/I18nTest.groovy
@@ -2,6 +2,7 @@ package unit.se.alipsa.accounting.support
 
 import static org.junit.jupiter.api.Assertions.*
 
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -10,14 +11,25 @@ import se.alipsa.accounting.support.I18n
 import java.beans.PropertyChangeEvent
 import java.beans.PropertyChangeListener
 
+import javax.swing.JComponent
+
 final class I18nTest {
 
   private I18n i18n
+  private Locale previousDefaultLocale
+  private Locale previousComponentLocale
 
   @BeforeEach
   void setUp() {
+    previousDefaultLocale = Locale.default
+    previousComponentLocale = JComponent.defaultLocale
     i18n = new I18n()
     i18n.setLocale(Locale.ENGLISH)
+  }
+
+  @AfterEach
+  void tearDown() {
+    JComponent.setDefaultLocale(previousComponentLocale)
   }
 
   @Test
@@ -65,6 +77,16 @@ final class I18nTest {
     assertTrue(fired)
     assertEquals(Locale.ENGLISH, receivedLocales[0])
     assertEquals(Locale.forLanguageTag('sv'), receivedLocales[1])
+  }
+
+  @Test
+  void setLocaleUpdatesSwingDefaultWithoutChangingJvmDefault() {
+    Locale swedish = Locale.forLanguageTag('sv')
+
+    i18n.setLocale(swedish)
+
+    assertEquals(previousDefaultLocale, Locale.default)
+    assertEquals(swedish, JComponent.defaultLocale)
   }
 
   @Test


### PR DESCRIPTION
## Summary
Fixes #74 by making the application's language switch update Swing's component locale defaults as well as the app resource bundle, without mutating the JVM default locale.

## Root Cause
`I18n.setLocale()` only swapped `i18n.messages`, while built-in Swing chrome such as `JOptionPane` buttons and `JFileChooser` labels read locale defaults from Swing component locale state.

## Changes
- Update `JComponent.defaultLocale` in `I18n.setLocale()`.
- Leave `Locale.default` unchanged so Java `ResourceBundle` fallback behavior and app i18n remain stable.
- Add unit coverage that verifies Swing's component default follows the selected app locale while the JVM default locale is not changed.
- Restore Swing component locale state in test cleanup to avoid test leakage.

## Validation
- `./gradlew spotlessApply`
- `./gradlew test --tests 'unit.se.alipsa.accounting.support.I18nTest'`
- `git diff --check`
- `./gradlew build`