### PR TITLE
[codex] fixa v1.4.0 cleanup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -542,7 +542,7 @@ tasks.register('releaseCheck') {
 }
 
 signing {
-  if (project.properties['signing.keyId'] != null) {
+  if (providers.gradleProperty('signing.keyId').isPresent()) {
     sign distZip, distTar, tasks.named('packageLinuxReleaseZip').get()
   } else {
     project.logger.debug("signing.keyId is not defined, skipping signing of artifacts...")

--- a/app/src/main/groovy/se/alipsa/accounting/ui/SieExchangeDialog.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/SieExchangeDialog.groovy
@@ -359,10 +359,10 @@ final class SieExchangeDialog extends JDialog {
     if (companiesMatch(currentCompany, sieCompany)) {
       return companyId
     }
-    String sieName = sieCompany.name ?: '-'
-    String sieOrg = sieCompany.orgIdentifier ?: '-'
-    String dbName = currentCompany?.companyName ?: '-'
-    String dbOrg = currentCompany?.organizationNumber ?: '-'
+    String sieName = escapeHtml(sieCompany.name ?: '-')
+    String sieOrg = escapeHtml(sieCompany.orgIdentifier ?: '-')
+    String dbName = escapeHtml(currentCompany?.companyName ?: '-')
+    String dbOrg = escapeHtml(currentCompany?.organizationNumber ?: '-')
     boolean canCreateNew = sieCompany.name?.trim() && sieCompany.orgIdentifier?.trim()
     String message = "<html>" +
         I18n.instance.format('sieExchangeDialog.company.mismatchSieLine', sieName, sieOrg) + "<br>" +
@@ -392,6 +392,16 @@ final class SieExchangeDialog extends JDialog {
       return createCompanyFromSie(sieCompany)
     }
     CANCELLED
+  }
+
+  private static String escapeHtml(String text) {
+    if (text == null) {
+      return ''
+    }
+    text
+        .replace('&', '&amp;')
+        .replace('<', '&lt;')
+        .replace('>', '&gt;')
   }
 
   private long createCompanyFromSie(SieCompany sieCompany) {

--- a/req/roadmap.md
+++ b/req/roadmap.md
@@ -7,9 +7,12 @@ Detta dokument samlar upp förbättringar som ännu inte fått någon version ti
 - Utred om applikationen ska kompletteras med ett enkelt anläggningsregister för företag som behöver hålla ordning på materiella och immateriella anläggningstillgångar.
 - Funktionen är uttryckligen uppskjuten från `v1.0.0` och ska inte blockera första releasen av kärnbokföringen.
 
+### Kodhälsa
+
+- Utred uppdelning av stora klasser som ligger nära eller över CodeNarc:s `ClassSize`-gräns: `VoucherPanel.groovy` (1250 rader), `SieImportExportService.groovy` (1275), `ReportDataService.groovy` (1206) och `AccountingMcpTools.groovy` (1203). Faktisk refaktorering ska planeras separat.
+
 ### Förslag på angreppssätt
 
 - Börja med dokumentation av vad som menas med `anläggningsregister` i svensk bokföringskontext och vilka företagstyper som faktiskt behöver det i praktiken.
 - Om funktionen bedöms motiverad: inför en enkel registervy med anskaffningsdatum, anskaffningsvärde, konto, beskrivning och avyttring/utrangering.
 - Håll lösningen frikopplad från huvudboksflödet i första steget så att v1.1.0 kan införa stöd utan att skriva om verifikationsmotorn.
-

--- a/req/v1.4.0-cleanup.md
+++ b/req/v1.4.0-cleanup.md
@@ -1,0 +1,92 @@
+# v1.4.0 — Cleanup: Gradle-deprecation, HTML-escaping i SIE-dialog, kodhälsa
+
+## Context
+
+En projektgenomgång (2026-06-20) av hela repot — byggstatus, öppna issues/PRs, TODO-markörer, klassgrupper nära CodeNarc:s storleksgräns, samt en sökning efter andra ställen som bygger rå `<html>`-text till Swing-komponenter (samma mönster som orsakade HTML-injektion-fixen i `MainFrame.groovy`, commit `a098aba`) — hittade fyra konkreta saker värda att åtgärda innan nästa release. Inget av detta är akut (build är grön, inga öppna issues), men de är låg-risk, väldefinierade fixar som bör göras innan de orsakar problem (Gradle 10-uppgradering, eller ett SIE-importfil med konstiga tecken i bolagsnamnet).
+
+Detta dokument är avsett att fungera som körbar checklista för arbetet.
+
+## Fynd och åtgärder
+
+### 1. Gradle-deprecation: `project.properties` i signeringsblocket (måste fixas innan Gradle 10)
+**Fil:** `app/build.gradle:544-550`
+
+```groovy
+signing {
+  if (project.properties['signing.keyId'] != null) {
+    sign distZip, distTar, tasks.named('packageLinuxReleaseZip').get()
+  } else {
+    project.logger.debug("signing.keyId is not defined, skipping signing of artifacts...")
+  }
+}
+```
+
+`Project.getProperties()` är deprecated i Gradle 9.6 och kommer att **kasta fel i Gradle 10** (bekräftat via `./gradlew build --rerun-tasks --no-configuration-cache --warning-mode all`, som visar varningen explicit pekande på rad 545). Ersätt med Provider-API:t:
+
+```groovy
+signing {
+  if (providers.gradleProperty('signing.keyId').isPresent()) {
+    sign distZip, distTar, tasks.named('packageLinuxReleaseZip').get()
+  } else {
+    project.logger.debug("signing.keyId is not defined, skipping signing of artifacts...")
+  }
+}
+```
+
+`providers.gradleProperty(...)` täcker samma källor (`gradle.properties`, `-P`-flaggor, `ORG_GRADLE_PROJECT_*`-miljövariabler) som `project.properties` gjorde för detta specifika nyckelnamn, så beteendet är oförändrat.
+
+### 2. Säkerhet: oescapad HTML i `SieExchangeDialog` från importerad SIE-fil
+**Fil:** `app/src/main/groovy/se/alipsa/accounting/ui/SieExchangeDialog.groovy:357-371` (metod `resolveImportTarget`)
+
+```groovy
+String sieName = sieCompany.name ?: '-'
+String sieOrg = sieCompany.orgIdentifier ?: '-'
+String dbName = currentCompany?.companyName ?: '-'
+String dbOrg = currentCompany?.organizationNumber ?: '-'
+...
+String message = "<html>" +
+    I18n.instance.format('sieExchangeDialog.company.mismatchSieLine', sieName, sieOrg) + "<br>" +
+    I18n.instance.format('sieExchangeDialog.company.mismatchCurrentLine', dbName, dbOrg) + "<br><br>" +
+    I18n.instance.getString('sieExchangeDialog.company.mismatchQuestion') +
+    "</html>"
+```
+
+`sieName`/`sieOrg` kommer direkt från en **importerad, potentiellt extern SIE-fil** (`#FNAMN`/org-fält), och interpoleras orescapade i en `<html>`-sträng som visas i `JOptionPane.showOptionDialog`. Samma sårbarhetsklass som redan åtgärdats i `MainFrame.groovy` (escapeHtml för företagsprofilen) och som redan hanteras i `ChartOfAccountsPanel.groovy:418-426` och `PeriodLockDialog.groovy:113` — men var och en av dessa klasser har sin egen privata `escapeHtml`-kopia; `SieExchangeDialog.groovy` saknar en helt.
+
+**Åtgärd:** Lägg till samma privata `escapeHtml(String)`-helper (identisk implementation som i `MainFrame.groovy:440` / `ChartOfAccountsPanel.groovy:418`) i `SieExchangeDialog.groovy`, och wrap `sieName`, `sieOrg`, `dbName`, `dbOrg` med den innan de interpoleras i `message`. (`dbName`/`dbOrg` är mindre känsliga eftersom de redan validerats vid företagsregistrering, men escapas av konsekvens och defensivt, precis som i `MainFrame`.)
+
+Ingen ny abstraktion ska införas (t.ex. en delad `HtmlUtil`-klass) — följ det redan etablerade mönstret med en privat helper per UI-klass, eftersom det är så de tre andra klasserna redan gör det.
+
+### 3. Reporegister-städning: redan mergade lokala grenar
+15 av 16 lokala grenar är redan mergade till `main` och kan tas bort:
+`gui-consolidation-settings-menu`, `issue-75`, `codex/fix-swing-locale`, `review-pr-73`, `codex-review-pr-73`, `codex/fix-voucher-cell-editing`, `codex/remember-last-company`, `codex/voucher-tab-navigation`, `fix/54-dropdown-disappears-on-last-digit`, `fix/55-locale-aware-amount-formatting`, `fix/60-sie-btrans-rtrans-import`, `fix/62-dropdown-focus`, `fix/63-vat-periods-and-vat-codes`, `1.3.0-issue56`, `1.3.0-issue57`.
+
+`codex/fix-jpackage-updater` är **inte** mergad men innehåller bara förlegat releaseförberedande arbete för v1.2.1 (`app/build.gradle`-versionssträng, `release.md`, dokumentation) som redan vida överspelats av `main` (nu v1.4.0). Rekommendation: ta bort grenen utan att merga den.
+
+Listan ovan är ett ögonblicksfoto (2026-06-21); kör om `git merge-base --is-ancestor <gren> main` för varje lokal gren innan städning genomförs, eftersom listan annars riskerar bli inaktuell igen.
+
+**Åtgärd (lokalt, ofarligt):** `git branch -d <gren>` för de 15 mergade grenarna.
+**Åtgärd (fjärr, kräver uttrycklig bekräftelse innan körning eftersom det påverkar delad state):** motsvarande `git push origin --delete <gren>` för de fjärrgrenar som redan är mergade (samma lista minus de som bara finns lokalt), samt ta bort `codex/fix-jpackage-updater` både lokalt och på fjärren efter bekräftelse att den ska överges.
+
+### 4. Uppmärksamhetspunkt: klasser nära CodeNarc:s `ClassSize`-gräns
+`VoucherPanel.groovy` låg exakt på gränsen (1250 rader) under arbetet med PR #78 och fick trimmas några rader för att klara bygget. Tre andra klasser ligger i samma härad: `SieImportExportService.groovy` (1275 rader totalt), `ReportDataService.groovy` (1206), `AccountingMcpTools.groovy` (1203). Att extrahera ut sammanhängande delar (t.ex. SIE-import/export-delsteg, verifikationskorrigering/dubblering) är en designfråga som kräver egen analys och är **explicit utanför scope** för denna cleanup.
+
+**Åtgärd (litet, i scope för denna cleanup):** lägg till en kort post om detta i `req/roadmap.md` ("Förbättringar som ännu inte fått någon version tilldelad") som nämner de fyra klasserna och deras radantal, så att uppmärksamhetspunkten inte tappas bort. **Den faktiska refaktoreringen/uppdelningen är inte i scope** — bara dokumentationsposten är det.
+
+## Kritiska filer
+- `app/build.gradle` (rad 544-550) — signeringsblocket.
+- `app/src/main/groovy/se/alipsa/accounting/ui/SieExchangeDialog.groovy` (rad 357-371, samt ny privat `escapeHtml`-metod, placerad i stil med `ChartOfAccountsPanel.groovy:418-426`).
+- `app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy:440` och `ChartOfAccountsPanel.groovy:418` — referensimplementation av `escapeHtml` att kopiera.
+- `req/roadmap.md` — punkt 4 (klasststorlek) ska läggas till här som en kort, framtida post (se Åtgärd ovan); detta är den enda delen av punkt 4 som är i scope.
+
+## Verifiering
+- Efter Gradle-fixen: `./gradlew build --rerun-tasks --no-configuration-cache --warning-mode all` ska inte längre visa `Project.getProperties`-varningen. `./gradlew build` (normal, cachad) ska fortsatt vara grön.
+- Efter HTML-escape-fixen: `escapeHtml` förblir `private static`, i linje med `MainFrame.groovy:440` och `ChartOfAccountsPanel.groovy:418` — ändra inte synlighet bara för att underlätta testning. Ingen av dessa två befintliga helpers har ett dedikerat unit-test (`grep -rln "escapeHtml" app/src/test/groovy` ger inga träffar idag), så följ samma etablerade mönster: verifiera genom manuell kodgranskning att `sieName`, `sieOrg`, `dbName` och `dbOrg` är wrappade vid alla fyra interpoleringsställen i `message`, snarare än att lägga till ett isolerat enhetstest.
+- `./gradlew spotlessApply` följt av en manuell diff-granskning innan commit (CodeNarc/Spotless gate, samma som alltid).
+- Grenstädning: `git branch -a` ska visa endast `main` plus eventuellt kvarvarande aktiva arbetsgrenar efter lokal och (efter bekräftelse) fjärrstädning.
+- Inga schema-/migrationsförändringar i denna cleanup.
+
+## Explicit utanför scope
+- Refaktorering/uppdelning av de fyra stora klasserna i punkt 4 — endast dokumentationsposten i `req/roadmap.md` är i scope för denna cleanup, inte den faktiska extraktionen.
+- Borttagning av `company_settings`-tabellen (redan tidigare beslutat som separat uppgift, ej kopplad till denna cleanup).
+- Att ta bort fjärrgrenar utan uttrycklig bekräftelse i stunden, enligt agentens säkerhetsregler för delad state.


### PR DESCRIPTION
## Summary

- Replace the deprecated Gradle signing property lookup with `providers.gradleProperty`.
- Escape SIE/current-company values before rendering the SIE import mismatch dialog as Swing HTML.
- Add the v1.4.0 cleanup request document and carry the class-size follow-up into the roadmap.
- Clean up merged local branches; remote branch deletion remains separate because it changes shared refs.

## Validation

- `./gradlew spotlessApply`
- `./gradlew build --rerun-tasks --no-configuration-cache --warning-mode all`
- `./gradlew build`
- `git diff --check`

No schema or migration changes.