### PR TITLE
[codex] Fixa menyåtgärder i 1.4.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'se.alipsa'
-version = '1.4.1'
+version = '1.4.2'
 
 repositories {
   mavenLocal()

--- a/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
+++ b/app/src/main/groovy/se/alipsa/accounting/ui/MainFrame.groovy
@@ -352,16 +352,16 @@ final class MainFrame implements PropertyChangeListener {
   private void buildFileMenu(Object builder) {
     builder.with {
       fileMenu = menu(text: I18n.instance.getString('mainFrame.menu.file')) {
-        newCompanyMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.file.newCompany'), actionPerformed: this.&showNewCompanyDialog)
-        editCompanyMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.file.editCompany'), actionPerformed: this.&showEditCompanyDialog)
+        newCompanyMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.file.newCompany'), actionPerformed: { showNewCompanyDialog() })
+        editCompanyMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.file.editCompany'), actionPerformed: { showEditCompanyDialog() })
         separator()
-        sieExchangeMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.file.sieExchange'), actionPerformed: this.&showSieExchangeDialog)
+        sieExchangeMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.file.sieExchange'), actionPerformed: { showSieExchangeDialog() })
         separator()
-        archiveCompanyMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.file.archiveCompany'), actionPerformed: this.&archiveCompanyRequested)
-        unarchiveCompanyMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.file.unarchiveCompany'), actionPerformed: this.&showUnarchiveCompanyDialog)
-        deleteCompanyMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.file.deleteCompany'), actionPerformed: this.&deleteCompanyRequested)
+        archiveCompanyMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.file.archiveCompany'), actionPerformed: { archiveCompanyRequested() })
+        unarchiveCompanyMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.file.unarchiveCompany'), actionPerformed: { showUnarchiveCompanyDialog() })
+        deleteCompanyMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.file.deleteCompany'), actionPerformed: { deleteCompanyRequested() })
         separator()
-        exitMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.file.exit'), actionPerformed: this.&exitRequested)
+        exitMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.file.exit'), actionPerformed: { exitRequested() })
       }
     }
   }
@@ -369,11 +369,11 @@ final class MainFrame implements PropertyChangeListener {
   private void buildHelpMenu(Object builder) {
     builder.with {
       helpMenu = menu(text: I18n.instance.getString('mainFrame.menu.help')) {
-        manualMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.help.manual'), actionPerformed: this.&showUserManualDialog)
-        updateMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.help.checkForUpdates'), actionPerformed: this.&showUpdateDialog)
-        reportIssueMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.help.reportIssue'), actionPerformed: this.&openIssueTracker)
+        manualMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.help.manual'), actionPerformed: { showUserManualDialog() })
+        updateMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.help.checkForUpdates'), actionPerformed: { showUpdateDialog() })
+        reportIssueMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.help.reportIssue'), actionPerformed: { openIssueTracker() })
         separator()
-        aboutMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.help.about'), actionPerformed: this.&showAboutDialog)
+        aboutMenuItem = menuItem(text: I18n.instance.getString('mainFrame.menu.help.about'), actionPerformed: { showAboutDialog() })
       }
     }
   }

--- a/release.md
+++ b/release.md
@@ -1,5 +1,30 @@
 # Alipsa Accounting, Release History
 
+## v1.4.2, 2026-06-21
+### Patch Release
+
+This patch release fixes File and Help menu actions that could fail silently instead of opening their dialogs.
+
+### Highlights
+
+- **Menu actions fixed** — File and Help menu actions now open their dialogs again, including File → New company and Help → About. Menu callbacks now ignore Swing's action event argument before calling no-argument dialog methods.
+
+### Downloads
+
+| Platform                  | File                                  |
+|---------------------------|---------------------------------------|
+| Linux                     | `alipsa-accounting-1.4.2-linux.zip`   |
+| Windows                   | `alipsa-accounting-1.4.2-windows.zip` |
+| macOS                     | `alipsa-accounting-1.4.2-macos.zip`   |
+| Universal updater archive | `app-1.4.2.zip`                       |
+
+All artifacts are accompanied by SHA-256 checksum files and GPG signatures. Verify with:
+```
+gpg --verify <file>.asc <file>
+```
+
+Windows and macOS releases are not currently platform-code-signed/notarized, so those operating systems may still show their usual unsigned-application warnings.
+
 ## v1.4.1, 2026-06-21
 ### Patch Release
 


### PR DESCRIPTION
## What changed

- Fixes File and Help menu actions by replacing no-arg method references with closures that ignore Swing's `ActionEvent` before calling the dialog/action methods.
- Bumps `app/build.gradle` to `1.4.2` for this patch release.
- Corrects `release.md` so:
  - `v1.4.0` remains the feature/minor release for voucher duplication, settings reorganization, Swing locale sync, and build tooling.
  - `v1.4.1` remains the updater diagnostics/reliability patch release.
  - `v1.4.2` is the menu-action patch release.

## Why

Menu items such as File -> New company and Help -> About were wired as method closures like `this.&showAboutDialog`. Swing supplies an `ActionEvent` to `actionPerformed`, but these target methods take no arguments, causing the action callback to fail instead of opening the dialog.

## Release notes and version files

- `app/build.gradle` is now `1.4.2`.
- This checkout does not contain `matrix-bom/bom.xml` or `matrix-json/release.md`; the accounting repo uses root `release.md`.

## Validation

- `./gradlew spotlessApply`
- `./gradlew :app:compileGroovy codenarcMain`
- `./gradlew build`
- `git diff --check`